### PR TITLE
[Feat] data.sql 기반 DB 초기화 환경 구축 및 빌드 환경 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,3 +44,7 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+tasks.withType(JavaCompile) {
+    options.compilerArgs << '-parameters'
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,9 +5,14 @@ spring:
     password: ${DB_PASSWORD:}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+  sql:
+    init:
+      mode: always  # 항상 data.sql을 실행하도록 설정
+
   jpa:
+    defer-datasource-initialization: true  # 하이버네이트가 테이블을 만든 후 data.sql 실행
     hibernate:
-      ddl-auto: ${DDL_AUTO:update}
+      ddl-auto: ${DDL_AUTO:create}
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,6 +1,6 @@
--- recruitment 임시 데이터
-INSERT INTO recruitment (term, start_date, end_date, brochure_url, created_at, updated_at)
-VALUES (26, '2026-03-01 00:00:00', '2026-03-11 23:59:59', 'https://example.com/brochure.pdf', NOW(), NOW());
+-- (예시) recruitment 임시 데이터
+-- INSERT INTO recruitment (term, start_date, end_date, brochure_url, created_at, updated_at)
+-- VALUES (26, '2026-03-01 00:00:00', '2026-03-11 23:59:59', 'https://example.com/brochure.pdf', NOW(), NOW());
 
-INSERT INTO recruitment (term, start_date, end_date, brochure_url, created_at, updated_at)
-VALUES (27, '2026-07-01 00:00:00', '2026-07-31 23:59:59', 'https://example.com/brochure.pdf', NOW(), NOW());
+-- INSERT INTO recruitment (term, start_date, end_date, brochure_url, created_at, updated_at)
+-- VALUES (27, '2026-07-01 00:00:00', '2026-07-31 23:59:59', 'https://example.com/brochure.pdf', NOW(), NOW());

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,6 @@
+-- recruitment 임시 데이터
+INSERT INTO recruitment (term, start_date, end_date, brochure_url, created_at, updated_at)
+VALUES (26, '2026-03-01 00:00:00', '2026-03-11 23:59:59', 'https://example.com/brochure.pdf', NOW(), NOW());
+
+INSERT INTO recruitment (term, start_date, end_date, brochure_url, created_at, updated_at)
+VALUES (27, '2026-07-01 00:00:00', '2026-07-31 23:59:59', 'https://example.com/brochure.pdf', NOW(), NOW());


### PR DESCRIPTION
## 💡 개요
data.sql을 사용해 데이터를 초기화할 수 있도록 하고, build.gradle에 설정을 추가해 InvalidDataAccessApiUsageException 방지하도록 함
* Issue Number: #1 

## 🪐 주요 변경 사항
- DB 초기화 전략 변경: ddl-auto: update 방식에서 data.sql 스크립트 실행 방식으로 전환
- 컴파일 옵션 추가: Java 21 및 Spring Boot 3.4 환경에서의 파라미터 인식 오류 해결을 위해 -parameters 옵션 적용

## ✅ 상세 내용
- data.sql 도입 및 실행 시점 제어
    - JPA가 테이블 생성을 완료한 후 데이터를 삽입할 수 있도록 spring.jpa.defer-datasource-initialization: true 설정 추가
    - spring.sql.init.mode: always 설정을 통해 애플리케이션 시작 시마다 초기 데이터 정합성 유지
    - 앞으로 기능 개발 후 테스트할 때, data.sql로 임시 데이터 넣어서 테스트하면 됩니다 (RDS 마이그레이션 하기 전까지 data.sql 사용)
- 컴파일러 매개변수 보존 설정
    - build.gradle에 tasks.withType(JavaCompile) 설정을 추가하여 리플렉션 사용 시 파라미터 이름이 누락되는 InvalidDataAccessApiUsageException 방지


## 🔔 참고 사항
- X