### PR TITLE
[Feat] Recruitment Entity, 모집 중 여부 및 모집 공고 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/boaz/backend/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/controller/RecruitmentController.java
@@ -1,5 +1,32 @@
 package com.boaz.backend.domain.recruitment.controller;
 
+import com.boaz.backend.domain.recruitment.dto.RecruitmentResponse;
+import com.boaz.backend.domain.recruitment.dto.RecruitmentStatusResponse;
+import com.boaz.backend.domain.recruitment.service.RecruitmentService;
+import com.boaz.backend.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Recruitment", description = "모집 공고 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/recruitment")
 public class RecruitmentController {
-    
+
+    private final RecruitmentService recruitmentService;
+
+    @Operation(summary = "모집 중 여부 조회")
+    @GetMapping("/status")
+    public ResponseEntity<ApiResponse<RecruitmentStatusResponse>> getRecruitmentStatus() {
+        return ResponseEntity.ok(ApiResponse.ok(recruitmentService.getRecruitmentStatus()));
+    }
+
+    @Operation(summary = "모집 공고 정보 조회")
+    @GetMapping("/{term}")
+    public ResponseEntity<ApiResponse<RecruitmentResponse>> getRecruitment(@PathVariable Integer term) {
+        return ResponseEntity.ok(ApiResponse.ok(recruitmentService.getRecruitment(term)));
+    }
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/RecruitmentResponse.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/RecruitmentResponse.java
@@ -1,11 +1,14 @@
 package com.boaz.backend.domain.recruitment.dto;
 
 import com.boaz.backend.domain.recruitment.entity.Recruitment;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class RecruitmentResponse {
 
     private final Integer term;

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/RecruitmentResponse.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/RecruitmentResponse.java
@@ -1,5 +1,40 @@
 package com.boaz.backend.domain.recruitment.dto;
 
+import com.boaz.backend.domain.recruitment.entity.Recruitment;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
 public class RecruitmentResponse {
-    
+
+    private final Integer term;
+    private final LocalDateTime startDate;
+    private final LocalDateTime endDate;
+    private final String brochureUrl;
+    private final Boolean isActive;
+
+    private RecruitmentResponse(Recruitment recruitment, boolean isActive) {
+        this.term = recruitment.getTerm();
+        this.startDate = recruitment.getStartDate();
+        this.endDate = recruitment.getEndDate();
+        this.brochureUrl = recruitment.getBrochureUrl();
+        this.isActive = isActive;
+    }
+
+    private RecruitmentResponse(boolean isActive) {
+        this.term = null;
+        this.startDate = null;
+        this.endDate = null;
+        this.brochureUrl = null;
+        this.isActive = isActive;
+    }
+
+    public static RecruitmentResponse from(Recruitment recruitment) {
+        return new RecruitmentResponse(recruitment, true);
+    }
+
+    public static RecruitmentResponse inactive() {
+        return new RecruitmentResponse(false);
+    }
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/RecruitmentStatusResponse.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/RecruitmentStatusResponse.java
@@ -1,0 +1,17 @@
+package com.boaz.backend.domain.recruitment.dto;
+
+import lombok.Getter;
+
+@Getter
+public class RecruitmentStatusResponse {
+
+    private final Boolean isActive;
+
+    private RecruitmentStatusResponse(boolean isActive) {
+        this.isActive = isActive;
+    }
+
+    public static RecruitmentStatusResponse of(boolean isActive) {
+        return new RecruitmentStatusResponse(isActive);
+    }
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/entity/Recruitment.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/entity/Recruitment.java
@@ -1,9 +1,10 @@
 package com.boaz.backend.domain.recruitment.entity;
 
 import com.boaz.backend.global.common.BaseEntity;
-
 import jakarta.persistence.*;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Entity
@@ -14,5 +15,15 @@ public class Recruitment extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private Integer term;
+
+    @Column(nullable = false)
+    private LocalDateTime startDate;
+
+    @Column(nullable = false)
+    private LocalDateTime endDate;
+
+    @Column(length = 255)
+    private String brochureUrl;
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/entity/Recruitment.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/entity/Recruitment.java
@@ -15,7 +15,7 @@ public class Recruitment extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private Integer term;
 
     @Column(nullable = false)

--- a/src/main/java/com/boaz/backend/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/repository/RecruitmentRepository.java
@@ -1,5 +1,18 @@
 package com.boaz.backend.domain.recruitment.repository;
 
-public class RecruitmentRepository {
-    
+import com.boaz.backend.domain.recruitment.entity.Recruitment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> {
+
+    // 현재 모집 중인 공고 조회 (현재 시간이 start_date ~ end_date 사이)
+    @Query("SELECT r FROM Recruitment r WHERE r.startDate <= :now AND r.endDate >= :now")
+    Optional<Recruitment> findActiveRecruitment(LocalDateTime now);
+
+    // 기수로 공고 조회
+    Optional<Recruitment> findByTerm(Integer term);
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -1,5 +1,44 @@
 package com.boaz.backend.domain.recruitment.service;
 
+import com.boaz.backend.domain.recruitment.dto.RecruitmentResponse;
+import com.boaz.backend.domain.recruitment.dto.RecruitmentStatusResponse;
+import com.boaz.backend.domain.recruitment.entity.Recruitment;
+import com.boaz.backend.domain.recruitment.repository.RecruitmentRepository;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class RecruitmentService {
-    
+
+    private final RecruitmentRepository recruitmentRepository;
+
+    // 모집 중 여부 조회
+    public RecruitmentStatusResponse getRecruitmentStatus() {
+        boolean isActive = recruitmentRepository
+                .findActiveRecruitment(LocalDateTime.now())
+                .isPresent();
+        return RecruitmentStatusResponse.of(isActive);
+    }
+
+    // 기수별 모집 공고 조회
+    public RecruitmentResponse getRecruitment(Integer term) {
+        Recruitment recruitment = recruitmentRepository.findByTerm(term)
+                .orElseThrow(() -> new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
+        
+        LocalDateTime now = LocalDateTime.now();
+        boolean isActive = now.isAfter(recruitment.getStartDate()) 
+                        && now.isBefore(recruitment.getEndDate());
+
+        if (!isActive) {
+            return RecruitmentResponse.inactive();
+        }
+        return RecruitmentResponse.from(recruitment);
+    }
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -33,8 +33,8 @@ public class RecruitmentService {
                 .orElseThrow(() -> new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
         
         LocalDateTime now = LocalDateTime.now();
-        boolean isActive = now.isAfter(recruitment.getStartDate()) 
-                        && now.isBefore(recruitment.getEndDate());
+        boolean isActive = !now.isBefore(recruitment.getStartDate()) 
+                        && !now.isAfter(recruitment.getEndDate());
 
         if (!isActive) {
             return RecruitmentResponse.inactive();

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,6 +1,6 @@
--- (예시) recruitment 임시 데이터
--- INSERT INTO recruitment (term, start_date, end_date, brochure_url, created_at, updated_at)
--- VALUES (26, '2026-03-01 00:00:00', '2026-03-11 23:59:59', 'https://example.com/brochure.pdf', NOW(), NOW());
+-- recruitment 임시 데이터
+INSERT INTO recruitment (term, start_date, end_date, brochure_url, created_at, updated_at)
+VALUES (26, '2026-03-01 00:00:00', '2026-03-11 23:59:59', 'https://example.com/brochure.pdf', NOW(), NOW());
 
--- INSERT INTO recruitment (term, start_date, end_date, brochure_url, created_at, updated_at)
--- VALUES (27, '2026-07-01 00:00:00', '2026-07-31 23:59:59', 'https://example.com/brochure.pdf', NOW(), NOW());
+INSERT INTO recruitment (term, start_date, end_date, brochure_url, created_at, updated_at)
+VALUES (27, '2026-07-01 00:00:00', '2026-07-31 23:59:59', 'https://example.com/brochure.pdf', NOW(), NOW());


### PR DESCRIPTION
## 💡 개요
Recruitment 엔티티 구현 및 지원서 관련 조회 API 구현
* Issue Number: #6 

## 🪐 주요 변경 사항
- Recruitment 엔티티 구현
- RecruitmentRepository 구현
- 모집 중 여부 조회하기 API (GET /api/v1/recruitment/status)
- 모집 공고 정보 조회 API (GET /api/v1/recruiting/{term})
- Recruitment 데이터 삽입 로직 추가 (data.sql)

## ✅ 상세 내용
- Recruitment 엔티티 및 초기 데이터
    - data.sql에 삽입된 inert문으로 테스트용 데이터가 주입되도록 설정
    - term을 unique 컬럼으로 설정
- RecruitmentRepository 구현
- 모집 중 여부 조회하기 API (GET /api/v1/recruitment/status)
    - repository에 구현한 메소드로 현재 모집 중인 공고가 있는지 여부를 조회
    - `@Query` 사용
- 모집 공고 정보 조회 API (GET /api/v1/recruiting/{term})
    - 기수 기준으로 공고를 조회한 뒤, 현재 모집 중인지 여부를 확인
    - 모집 중 여부(is_active)에 따라 다른 결과값을 리턴
    - is_active 판단 시에 딱 경계 값(now가 startDate나 endDate와 아예 같은 경우)에서 true라고 판단하도록 보완
    - is_active = true면 모집 공고 내용(startDate, endDate 등) 반환
    - is_active = false면 is_active만 반환 (이때 null인 필드는 반환하지 않도록 설정)

## 🔔 참고 사항
- 기능 명세서