### PR TITLE
[Feat] 지원서 관련 엔티티 설계 및 지원서 질문 조회 API 구현

### DIFF
--- a/src/main/java/com/boaz/backend/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/controller/RecruitmentController.java
@@ -1,5 +1,6 @@
 package com.boaz.backend.domain.recruitment.controller;
 
+import com.boaz.backend.domain.recruitment.dto.QuestionResponse;
 import com.boaz.backend.domain.recruitment.dto.RecruitmentResponse;
 import com.boaz.backend.domain.recruitment.dto.RecruitmentStatusResponse;
 import com.boaz.backend.domain.recruitment.service.RecruitmentService;
@@ -7,6 +8,9 @@ import com.boaz.backend.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,5 +32,13 @@ public class RecruitmentController {
     @GetMapping("/{term}")
     public ResponseEntity<ApiResponse<RecruitmentResponse>> getRecruitment(@PathVariable Integer term) {
         return ResponseEntity.ok(ApiResponse.ok(recruitmentService.getRecruitment(term)));
+    }
+
+    @Operation(summary = "지원서 질문 목록 조회")
+    @GetMapping("/questions")
+    public ResponseEntity<ApiResponse<List<QuestionResponse>>> getQuestions(
+            @RequestParam Long recruitmentId,
+            @RequestParam String track) {
+        return ResponseEntity.ok(ApiResponse.ok(recruitmentService.getQuestions(recruitmentId, track)));
     }
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/controller/RecruitmentController.java
@@ -5,6 +5,8 @@ import com.boaz.backend.domain.recruitment.dto.RecruitmentResponse;
 import com.boaz.backend.domain.recruitment.dto.RecruitmentStatusResponse;
 import com.boaz.backend.domain.recruitment.service.RecruitmentService;
 import com.boaz.backend.global.common.ApiResponse;
+import com.boaz.backend.global.common.enums.Track;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -38,7 +40,7 @@ public class RecruitmentController {
     @GetMapping("/questions")
     public ResponseEntity<ApiResponse<List<QuestionResponse>>> getQuestions(
             @RequestParam Long recruitmentId,
-            @RequestParam String track) {
+            @RequestParam Track track) {
         return ResponseEntity.ok(ApiResponse.ok(recruitmentService.getQuestions(recruitmentId, track)));
     }
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/QuestionResponse.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/QuestionResponse.java
@@ -1,0 +1,50 @@
+package com.boaz.backend.domain.recruitment.dto;
+
+import com.boaz.backend.domain.recruitment.entity.ApplicationQuestion;
+import com.boaz.backend.domain.recruitment.entity.QuestionType;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.Getter;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class QuestionResponse {
+
+    private final String questionId;
+    private final String category;
+    private final String type;
+    private final String content;
+    private final Integer limitLength;
+    private final JsonNode metadata;
+    private final Integer orderNum;
+    private final Boolean isRequired;
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private QuestionResponse(ApplicationQuestion question) {
+        this.questionId = question.getId();
+        this.category = question.getCategory().name();
+        this.type = question.getType().name();
+        this.content = question.getContent();
+        this.orderNum = question.getOrderNum();
+        this.isRequired = question.getIsRequired();
+
+        if (question.getType() == QuestionType.TEXT) {
+            this.limitLength = question.getLimitLength();
+            this.metadata = null;
+        } else {
+            this.limitLength = null;
+            try {
+                this.metadata = objectMapper.readTree(question.getMetadata());
+            } catch (Exception e) {
+                throw new RuntimeException("metadata JSON 파싱 실패: " + question.getId());
+            }
+        }
+    }
+
+    public static QuestionResponse from(ApplicationQuestion question) {
+        return new QuestionResponse(question);
+    }
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/QuestionResponse.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/QuestionResponse.java
@@ -2,6 +2,8 @@ package com.boaz.backend.domain.recruitment.dto;
 
 import com.boaz.backend.domain.recruitment.entity.ApplicationQuestion;
 import com.boaz.backend.domain.recruitment.entity.QuestionType;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -36,10 +38,13 @@ public class QuestionResponse {
             this.metadata = null;
         } else {
             this.limitLength = null;
+            if (question.getMetadata() == null) {
+                throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+            }
             try {
                 this.metadata = objectMapper.readTree(question.getMetadata());
             } catch (Exception e) {
-                throw new RuntimeException("metadata JSON 파싱 실패: " + question.getId());
+                throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
             }
         }
     }

--- a/src/main/java/com/boaz/backend/domain/recruitment/entity/Applicant.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/entity/Applicant.java
@@ -24,6 +24,7 @@ public class Applicant extends BaseEntity  {
     private Recruitment recruitment;
 
     @Column(length = 50)
+    @Enumerated(EnumType.STRING)
     private Track track;
 
     @Column(length = 100, nullable = false)

--- a/src/main/java/com/boaz/backend/domain/recruitment/entity/Applicant.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/entity/Applicant.java
@@ -1,0 +1,59 @@
+package com.boaz.backend.domain.recruitment.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.boaz.backend.global.common.BaseEntity;
+import com.boaz.backend.global.common.enums.Track;
+
+import java.time.LocalDate;
+
+@Getter
+@Entity
+@Table(name = "applicants")
+@EntityListeners(AuditingEntityListener.class)
+public class Applicant extends BaseEntity  {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recruitment_id", nullable = false)
+    private Recruitment recruitment;
+
+    @Column(length = 50)
+    private Track track;
+
+    @Column(length = 100, nullable = false)
+    private String name;
+
+    @Column(length = 255, nullable = false)
+    private String email;
+
+    @Column(length = 20)
+    private String phone;
+
+    @Column(length = 100)
+    private String university;
+
+    @Column(length = 100)
+    private String major;
+
+    @Column(columnDefinition = "JSON")
+    private String minorDoubleMajor;
+
+    private Integer lastSemester;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 50)
+    private MilitaryStatus militaryStatus;
+
+    private LocalDate birthDate;
+
+    @Column(length = 7)
+    private String graduationDate;
+
+    private Boolean gradSchoolPlan;
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/entity/ApplicantAnswer.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/entity/ApplicantAnswer.java
@@ -1,0 +1,30 @@
+package com.boaz.backend.domain.recruitment.entity;
+
+import com.boaz.backend.global.common.BaseEntity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "applicant_answer")
+public class ApplicantAnswer extends BaseEntity {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "applicant_id", nullable = false)
+    private Applicant applicant;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id", nullable = false)
+    private ApplicationQuestion question;
+
+    @Column(columnDefinition = "TEXT")
+    private String answerText;
+
+    @Column(columnDefinition = "JSON")
+    private String answerJson;
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/entity/ApplicationQuestion.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/entity/ApplicationQuestion.java
@@ -1,0 +1,40 @@
+package com.boaz.backend.domain.recruitment.entity;
+
+import com.boaz.backend.global.common.BaseEntity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "application_question")
+public class ApplicationQuestion extends BaseEntity {
+
+    @Id
+    @Column(length = 10)
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recruitment_id", nullable = false)
+    private Recruitment recruitment;
+
+    @Enumerated(EnumType.STRING)
+    private QuestionCategory category;
+
+    @Enumerated(EnumType.STRING)
+    private QuestionType type;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Column(columnDefinition = "JSON")
+    private String metadata;
+
+    private Integer limitLength;
+
+    @Column(nullable = false)
+    private Integer orderNum;
+
+    @Column(nullable = false)
+    private Boolean isRequired;
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/entity/ApplicationQuestion.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/entity/ApplicationQuestion.java
@@ -18,13 +18,15 @@ public class ApplicationQuestion extends BaseEntity {
     @JoinColumn(name = "recruitment_id", nullable = false)
     private Recruitment recruitment;
 
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private QuestionCategory category;
 
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private QuestionType type;
 
-    @Column(columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
     @Column(columnDefinition = "JSON")

--- a/src/main/java/com/boaz/backend/domain/recruitment/entity/MilitaryStatus.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/entity/MilitaryStatus.java
@@ -1,0 +1,5 @@
+package com.boaz.backend.domain.recruitment.entity;
+
+public enum MilitaryStatus {
+    필_또는_면제, 미필
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/entity/QuestionCategory.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/entity/QuestionCategory.java
@@ -1,0 +1,5 @@
+package com.boaz.backend.domain.recruitment.entity;
+
+public enum QuestionCategory {
+    공통, 시각화, 분석, 엔지니어링
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/entity/QuestionType.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/entity/QuestionType.java
@@ -1,0 +1,5 @@
+package com.boaz.backend.domain.recruitment.entity;
+
+public enum QuestionType {
+    TEXT, TABLE
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicationQuestionRepository.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicationQuestionRepository.java
@@ -1,0 +1,23 @@
+package com.boaz.backend.domain.recruitment.repository;
+
+import com.boaz.backend.domain.recruitment.entity.ApplicationQuestion;
+import com.boaz.backend.domain.recruitment.entity.QuestionCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.lang.String;
+import java.util.List;
+
+public interface ApplicationQuestionRepository extends JpaRepository<ApplicationQuestion, String> {
+
+    @Query("SELECT q FROM ApplicationQuestion q " +
+        "WHERE q.recruitment.id = :recruitmentId " +
+        "AND (q.category = :commonCategory OR q.category = :trackCategory) " +
+        "ORDER BY q.orderNum ASC")
+    List<ApplicationQuestion> findByRecruitmentIdAndCategories(
+        @Param("recruitmentId") Long recruitmentId,
+        @Param("commonCategory") QuestionCategory commonCategory,
+        @Param("trackCategory") QuestionCategory trackCategory
+    );
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -1,8 +1,12 @@
 package com.boaz.backend.domain.recruitment.service;
 
+import com.boaz.backend.domain.recruitment.dto.QuestionResponse;
 import com.boaz.backend.domain.recruitment.dto.RecruitmentResponse;
 import com.boaz.backend.domain.recruitment.dto.RecruitmentStatusResponse;
+import com.boaz.backend.domain.recruitment.entity.ApplicationQuestion;
+import com.boaz.backend.domain.recruitment.entity.QuestionCategory;
 import com.boaz.backend.domain.recruitment.entity.Recruitment;
+import com.boaz.backend.domain.recruitment.repository.ApplicationQuestionRepository;
 import com.boaz.backend.domain.recruitment.repository.RecruitmentRepository;
 import com.boaz.backend.global.exception.CustomException;
 import com.boaz.backend.global.exception.ErrorCode;
@@ -11,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +23,8 @@ import java.time.LocalDateTime;
 public class RecruitmentService {
 
     private final RecruitmentRepository recruitmentRepository;
+    private final ApplicationQuestionRepository applicationQuestionRepository;
+
 
     // 모집 중 여부 조회
     public RecruitmentStatusResponse getRecruitmentStatus() {
@@ -40,5 +47,41 @@ public class RecruitmentService {
             return RecruitmentResponse.inactive();
         }
         return RecruitmentResponse.from(recruitment);
+    }
+
+    // 지원서 조회하기
+    public List<QuestionResponse> getQuestions(Long recruitmentId, String trackParam) {
+
+        // 공고 존재 여부 확인
+        Recruitment recruitment = recruitmentRepository.findById(recruitmentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
+
+        // 모집 중 여부 확인
+        LocalDateTime now = LocalDateTime.now();
+        boolean isActive = now.isAfter(recruitment.getStartDate())
+                        && now.isBefore(recruitment.getEndDate());
+        if (!isActive) {
+            throw new CustomException(ErrorCode.RECRUITMENT_NOT_AVAILABLE);
+        }
+
+        // track 유효성 검사
+        QuestionCategory trackCategory;
+        try {
+            trackCategory = QuestionCategory.valueOf(trackParam);
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.INVALID_TRACK_NAME);
+        }
+
+        // 공통 + 해당 부문 질문 조회
+        List<ApplicationQuestion> questions = applicationQuestionRepository
+                .findByRecruitmentIdAndCategories(recruitmentId, QuestionCategory.공통, trackCategory);
+
+        if (questions.isEmpty()) {
+            throw new CustomException(ErrorCode.QUESTIONS_NOT_FOUND);
+        }
+
+        return questions.stream()
+                .map(QuestionResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -8,6 +8,7 @@ import com.boaz.backend.domain.recruitment.entity.QuestionCategory;
 import com.boaz.backend.domain.recruitment.entity.Recruitment;
 import com.boaz.backend.domain.recruitment.repository.ApplicationQuestionRepository;
 import com.boaz.backend.domain.recruitment.repository.RecruitmentRepository;
+import com.boaz.backend.global.common.enums.Track;
 import com.boaz.backend.global.exception.CustomException;
 import com.boaz.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -50,7 +51,7 @@ public class RecruitmentService {
     }
 
     // 지원서 질문 조회하기
-    public List<QuestionResponse> getQuestions(Long recruitmentId, String trackParam) {
+    public List<QuestionResponse> getQuestions(Long recruitmentId, Track track) {
 
         // 공고 존재 여부 확인
         Recruitment recruitment = recruitmentRepository.findById(recruitmentId)
@@ -64,13 +65,8 @@ public class RecruitmentService {
             throw new CustomException(ErrorCode.RECRUITMENT_NOT_AVAILABLE);
         }
 
-        // track 유효성 검사
-        QuestionCategory trackCategory;
-        try {
-            trackCategory = QuestionCategory.valueOf(trackParam);
-        } catch (IllegalArgumentException e) {
-            throw new CustomException(ErrorCode.INVALID_TRACK_NAME);
-        }
+        // Track → QuestionCategory 변환
+        QuestionCategory trackCategory = QuestionCategory.valueOf(track.name());
 
         // 공통 + 해당 부문 질문 조회
         List<ApplicationQuestion> questions = applicationQuestionRepository

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -58,8 +58,8 @@ public class RecruitmentService {
 
         // 모집 중 여부 확인
         LocalDateTime now = LocalDateTime.now();
-        boolean isActive = now.isAfter(recruitment.getStartDate())
-                        && now.isBefore(recruitment.getEndDate());
+        boolean isActive = !now.isBefore(recruitment.getStartDate()) 
+                        && !now.isAfter(recruitment.getEndDate());
         if (!isActive) {
             throw new CustomException(ErrorCode.RECRUITMENT_NOT_AVAILABLE);
         }

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -49,7 +49,7 @@ public class RecruitmentService {
         return RecruitmentResponse.from(recruitment);
     }
 
-    // 지원서 조회하기
+    // 지원서 질문 조회하기
     public List<QuestionResponse> getQuestions(Long recruitmentId, String trackParam) {
 
         // 공고 존재 여부 확인

--- a/src/main/java/com/boaz/backend/global/common/enums/Track.java
+++ b/src/main/java/com/boaz/backend/global/common/enums/Track.java
@@ -1,0 +1,5 @@
+package com.boaz.backend.global.common.enums;
+
+public enum Track {
+    전부문, 시각화, 분석, 엔지니어링
+}

--- a/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
@@ -13,6 +13,10 @@ public enum ErrorCode {
     // Recruitment
     RECRUITMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "RECRUITMENT_NOT_FOUND", "해당 모집 공고를 찾을 수 없습니다."),
     ALREADY_APPLIED(HttpStatus.CONFLICT, "ALREADY_APPLIED", "이미 지원한 모집 공고입니다."),
+    RECRUITMENT_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "RECRUITMENT_NOT_AVAILABLE", "현재 지원 가능한 기간이 아닙니다."),
+    INVALID_TRACK_NAME(HttpStatus.BAD_REQUEST, "INVALID_TRACK_NAME", "올바른 지원 부문을 선택해주세요."),
+    MISSING_PARAMETER(HttpStatus.BAD_REQUEST, "MISSING_PARAMETER", "요청 파라미터가 누락되었습니다."),
+    QUESTIONS_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "QUESTIONS_NOT_FOUND", "등록된 질문이 없습니다."),
 
     // Curriculum
     CURRICULUM_NOT_FOUND(HttpStatus.NOT_FOUND, "CURRICULUM_NOT_FOUND", "해당 커리큘럼을 찾을 수 없습니다."),

--- a/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
@@ -9,13 +9,13 @@ public enum ErrorCode {
     // Common
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "INVALID_INPUT_VALUE", "입력값이 올바르지 않습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다."),
+    MISSING_PARAMETER(HttpStatus.BAD_REQUEST, "MISSING_PARAMETER", "요청 파라미터가 누락되었습니다."),
 
     // Recruitment
     RECRUITMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "RECRUITMENT_NOT_FOUND", "해당 모집 공고를 찾을 수 없습니다."),
     ALREADY_APPLIED(HttpStatus.CONFLICT, "ALREADY_APPLIED", "이미 지원한 모집 공고입니다."),
     RECRUITMENT_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "RECRUITMENT_NOT_AVAILABLE", "현재 지원 가능한 기간이 아닙니다."),
     INVALID_TRACK_NAME(HttpStatus.BAD_REQUEST, "INVALID_TRACK_NAME", "올바른 지원 부문을 선택해주세요."),
-    MISSING_PARAMETER(HttpStatus.BAD_REQUEST, "MISSING_PARAMETER", "요청 파라미터가 누락되었습니다."),
     QUESTIONS_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "QUESTIONS_NOT_FOUND", "등록된 질문이 없습니다."),
 
     // Curriculum

--- a/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
@@ -16,7 +16,7 @@ public enum ErrorCode {
     ALREADY_APPLIED(HttpStatus.CONFLICT, "ALREADY_APPLIED", "이미 지원한 모집 공고입니다."),
     RECRUITMENT_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "RECRUITMENT_NOT_AVAILABLE", "현재 지원 가능한 기간이 아닙니다."),
     INVALID_TRACK_NAME(HttpStatus.BAD_REQUEST, "INVALID_TRACK_NAME", "올바른 지원 부문을 선택해주세요."),
-    QUESTIONS_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "QUESTIONS_NOT_FOUND", "등록된 질문이 없습니다."),
+    QUESTIONS_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTIONS_NOT_FOUND", "등록된 질문이 없습니다."),
 
     // Curriculum
     CURRICULUM_NOT_FOUND(HttpStatus.NOT_FOUND, "CURRICULUM_NOT_FOUND", "해당 커리큘럼을 찾을 수 없습니다."),

--- a/src/main/java/com/boaz/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/boaz/backend/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -33,6 +34,18 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .badRequest()
                 .body(ApiResponse.error(400, ErrorCode.INVALID_INPUT_VALUE.getCode(), message));
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMissingParameter(MissingServletRequestParameterException e) {
+        log.warn("MissingParameterException: {}", e.getParameterName());
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.error(
+                        400,
+                        ErrorCode.MISSING_PARAMETER.getCode(),
+                        ErrorCode.MISSING_PARAMETER.getMessage()
+                ));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,6 +1,36 @@
 -- recruitment 임시 데이터
-INSERT INTO recruitment (term, start_date, end_date, brochure_url, created_at, updated_at)
-VALUES (26, '2026-03-01 00:00:00', '2026-03-11 23:59:59', 'https://example.com/brochure.pdf', NOW(), NOW());
+INSERT INTO recruitment (id, term, start_date, end_date, brochure_url, created_at, updated_at)
+VALUES (1, 26, '2026-03-01 00:00:00', '2026-03-29 23:59:59', 'https://example.com/brochure.pdf', NOW(), NOW());
 
-INSERT INTO recruitment (term, start_date, end_date, brochure_url, created_at, updated_at)
-VALUES (27, '2026-07-01 00:00:00', '2026-07-31 23:59:59', 'https://example.com/brochure.pdf', NOW(), NOW());
+INSERT INTO recruitment (id, term, start_date, end_date, brochure_url, created_at, updated_at)
+VALUES (2, 27, '2026-07-01 00:00:00', '2026-07-31 23:59:59', 'https://example.com/brochure.pdf', NOW(), NOW());
+
+-- application_question 임시 데이터
+INSERT INTO application_question (id, recruitment_id, category, type, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
+VALUES ('공통1', 1, '공통', 'TEXT', '지원 동기는 무엇인가요? (500자 이내)', null, 500, 1, true, NOW(), NOW());
+
+INSERT INTO application_question (id, recruitment_id, category, type, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
+VALUES ('공통2', 1, '공통', 'TEXT', '본인을 나타낼 수 있는 기존의 활동 경험 (500자 이내)', null, 500, 2, true, NOW(), NOW());
+
+INSERT INTO application_question (id, recruitment_id, category, type, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
+VALUES ('공통5', 1, '공통', 'TEXT', '추가적으로 자신의 활동 중에서 특히 어필하고 싶은 프로젝트가 있다면.. (500자 이내)', null, 500, 99, true, NOW(), NOW());
+
+INSERT INTO application_question (id, recruitment_id, category, type, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
+VALUES ('시각화1', 1, '시각화', 'TABLE', '데이터 시각화 관련 TOOL 활용 경험', '{"rows":["Tableau", "Python"], "columns":["경험 없음", "관련 프로젝트 경험 있음"]}', null, 10, true, NOW(), NOW());
+
+INSERT INTO application_question (id, recruitment_id, category, type, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
+VALUES ('시각화2', 1, '시각화', 'TEXT', '본인이 진행했던 시각화를 통해 인사이트를 도출한 경험.. (700자 이내)', null, 700, 11, true, NOW(), NOW());
+
+
+INSERT INTO application_question (id, recruitment_id, category, type, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
+VALUES ('엔지니어링1', 1, '엔지니어링', 'TABLE', '데이터 엔지니어링 관련 경험', '{"rows":["데이터베이스", "서버 및 클라우드 서비스"], "columns":["경험 없음", "관련 프로젝트 경험 있음"]}', null, 10, true, NOW(), NOW());
+
+INSERT INTO application_question (id, recruitment_id, category, type, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
+VALUES ('엔지니어링2', 1, '엔지니어링', 'TEXT', '데이터 엔지니어링 분야 중 관심있는 세부 분야와 해당 분야와 관련된 경험 및 활동.. (700자 이내)', null, 700, 11, true, NOW(), NOW());
+
+
+INSERT INTO application_question (id, recruitment_id, category, type, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
+VALUES ('분석1', 1, '분석', 'TEXT', '[빅데이터 / 인공지능 / 머신러닝 / 통계 및 수학] 관련 수강 과목 혹은 세미나 경험.. (300자 이내)', null, 300, 10, true, NOW(), NOW());
+
+INSERT INTO application_question (id, recruitment_id, category, type, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
+VALUES ('분석2', 1, '분석', 'TEXT', '본인이 진행했던 [머신러닝 / 딥러닝 / 데이터분석] 관련 프로젝트를 소개.. (700자 이내)', null, 700, 11, true, NOW(), NOW());


### PR DESCRIPTION
## 💡 개요

* Issue Number: #7 

## 🪐 주요 변경 사항
- `ApplicationQuestion`, `Applicant`, `ApplicantAnswer` 엔티티 설계
- `MilitaryStatus`, `QuestionCategory`, `QuestionType`, `Track` Enum 생성
- 지원서 질문 조회 관련 에러 추가
- 지원서 질문 조회 API 구현

## ✅ 상세 내용
- `ApplicationQuestion`, `Applicant`, `ApplicantAnswer` 엔티티 설계
    - `ApplicationQuestion` id를 String으로 명시 (공통1, 공통2, ...)
    - JSON 타입인 컬럼은 서버 내에서 가공하는 경우가 당장 없다고 판단해 JPA에서는 String으로 선언 (추후 필요해지면 직렬화/역직렬화 로직 추가 예정)
    - `Applicatnt` Track에 `@Enumerated` 어노테이션 추가
    - `ApplicantQuestion` 컬럼에 `nullable = false` 추가
- `MilitaryStatus`, `QuestionCategory`, `QuestionType`, `Track` Enum 생성
- 지원서 질문 조회 관련 에러 추가
    - 서비스 로직에 ErrorCode 기반 예외처리 추가
- 지원서 질문 조회 API 구현
    - `TABLE` 타입 조회 시, JSON으로 DB에 저장된 metadata를 가져올 때 역슬래시(`\`)가 삽입되는 문제 => `JsonNode` 로 직렬화해 response
    - repository에서 `@Query` 사용 (공통 + 입력된 카테고리에 대한 질문만, `order_num`을 기준으로 정렬해서 반환
    - 공고 존재 여부, 모집 중 여부 확인, track 유효성 검사 후 질문 조회 및 반환
- 파라미터가 누락된 경우 `MissingServletRequestParameterException` 에러 처리 로직 `GlobalHandler`에 추가 (+ ErrorCode에 `MISSING_PARAMETER` 추가) 
- 

## 🔔 참고 사항
- X
---
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 지원서 관련 엔티티 설계 및 지원서 질문 조회 API 구현

- **변경 목적**: 지원서 도메인을 설계하고, 모집 공고별 지원 질문을 조회하는 API를 추가하여 지원자 질문 노출 기능을 구현함.

- **주요 변경 내용**:
  - 엔티티
    - ApplicationQuestion: id를 String으로 명시(예: 공통1), category/type/content/metadata(limitLength 포함)/orderNum/isRequired 등 필드 추가. metadata는 DB에 JSON 칼럼으로 저장하되 JPA에서는 String으로 선언(직렬화/역직렬화 로직은 추후).
    - Applicant: 지원자 개인정보·학적·병역 등 필드 추가(일부 JSON 칼럼 포함).
    - ApplicantAnswer: 지원자 답변 엔티티(텍스트 및 JSON 형태 답변 저장).
  - Enum 추가
    - QuestionCategory(공통, 시각화, 분석, 엔지니어링), QuestionType(TEXT, TABLE), MilitaryStatus(필_또는_면제, 미필), Track(전부문, 시각화, 분석, 엔지니어링).
  - Repository / Service / Controller
    - ApplicationQuestionRepository: 모집 ID 및 공통+트랙 카테고리 기준 질문 조회를 위한 @Query 메서드 추가(order_num 기준 정렬).
    - RecruitmentService.getQuestions(recruitmentId, Track): 모집 존재 여부·모집 기간(조회 가능 여부)·track 유효성 검증 후 공통 질문과 트랙별 질문 조회 및 QuestionResponse 매핑, 에러는 ErrorCode 기반 예외 처리.
    - RecruitmentController.getQuestions: recruitmentId와 track을 파라미터로 받는 질문 조회용 GET 엔드포인트 추가.
  - DTO 및 응답 처리
    - QuestionResponse: ApplicationQuestion → 응답 모델 변환. TEXT 타입은 limitLength 포함, TABLE 타입의 metadata(DB에 JSON 문자열 저장)는 JsonNode로 파싱하여 역슬래시 이스케이프 문제를 해결해 반환.
    - ErrorCode 확장: MISSING_PARAMETER, RECRUITMENT_NOT_AVAILABLE, INVALID_TRACK_NAME, QUESTIONS_NOT_FOUND 등 추가.
  - 초기 데이터
    - data.sql: recruitment 레코드(명시적 id 포함) 및 다수의 application_question 시드 데이터 추가/수정(테스트용).

- **영향 범위**:
  - API 변경: 신규 엔드포인트 추가(지원서 질문 조회).
  - DB 스키마 변경: application_question, applicants, applicant_answer 관련 테이블 및 컬럼(예: JSON 칼럼)과 시드 데이터 추가/변경.
  - 설정 변경: 없음.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->