### PR TITLE
[Feat] 지원서 제출하기 API 구현

### DIFF
--- a/src/main/java/com/boaz/backend/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/controller/RecruitmentController.java
@@ -1,5 +1,7 @@
 package com.boaz.backend.domain.recruitment.controller;
 
+import com.boaz.backend.domain.recruitment.dto.ApplicationRequest;
+import com.boaz.backend.domain.recruitment.dto.ApplicationResponse;
 import com.boaz.backend.domain.recruitment.dto.QuestionResponse;
 import com.boaz.backend.domain.recruitment.dto.RecruitmentResponse;
 import com.boaz.backend.domain.recruitment.dto.RecruitmentStatusResponse;
@@ -9,10 +11,12 @@ import com.boaz.backend.global.common.enums.Track;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -42,5 +46,14 @@ public class RecruitmentController {
             @RequestParam Long recruitmentId,
             @RequestParam Track track) {
         return ResponseEntity.ok(ApiResponse.ok(recruitmentService.getQuestions(recruitmentId, track)));
+    }
+
+    @Operation(summary = "지원서 제출")
+    @PostMapping("/applications")
+    public ResponseEntity<ApiResponse<ApplicationResponse>> submitApplication(
+            @RequestBody @Valid ApplicationRequest request) {
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.created(recruitmentService.submitApplication(request)));
     }
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/AnswerRequest.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/AnswerRequest.java
@@ -1,0 +1,18 @@
+package com.boaz.backend.domain.recruitment.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class AnswerRequest {
+
+    @NotNull
+    @JsonProperty("question_id")
+    private String questionId;
+
+    @NotNull
+    private JsonNode answer;
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/ApplicationRequest.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/ApplicationRequest.java
@@ -1,0 +1,64 @@
+package com.boaz.backend.domain.recruitment.dto;
+
+import com.boaz.backend.domain.recruitment.entity.MilitaryStatus;
+import com.boaz.backend.global.common.enums.Track;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ApplicationRequest {
+
+    @NotNull
+    @JsonProperty("recruitment_id")
+    private Long recruitmentId;
+
+    @NotNull
+    private Track track;
+
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String phone;
+
+    @NotBlank
+    private String university;
+
+    @NotBlank
+    private String major;
+
+    @JsonProperty("minor_double_major")
+    private List<String> minorDoubleMajor;
+
+    @NotNull
+    @JsonProperty("last_semester")
+    private Integer lastSemester;
+
+    @NotNull
+    @JsonProperty("military_status")
+    private MilitaryStatus militaryStatus;
+
+    @NotBlank
+    @JsonProperty("birth_date")
+    private String birthDate;
+
+    @NotBlank
+    @JsonProperty("graduation_date")
+    private String graduationDate;
+
+    @NotNull
+    @JsonProperty("grad_school_plan")
+    private Boolean gradSchoolPlan;
+
+    @NotNull
+    @Valid
+    private List<AnswerRequest> answers;
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/ApplicationResponse.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/ApplicationResponse.java
@@ -1,0 +1,25 @@
+package com.boaz.backend.domain.recruitment.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ApplicationResponse {
+
+    @JsonProperty("applicant_id")
+    private final Long applicantId;
+
+    @JsonProperty("submitted_at")
+    private final LocalDateTime submittedAt;
+
+    private ApplicationResponse(Long applicantId, LocalDateTime submittedAt) {
+        this.applicantId = applicantId;
+        this.submittedAt = submittedAt;
+    }
+
+    public static ApplicationResponse of(Long applicantId, LocalDateTime submittedAt) {
+        return new ApplicationResponse(applicantId, submittedAt);
+    }
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/entity/Applicant.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/entity/Applicant.java
@@ -1,6 +1,7 @@
 package com.boaz.backend.domain.recruitment.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -57,4 +58,24 @@ public class Applicant extends BaseEntity  {
     private String graduationDate;
 
     private Boolean gradSchoolPlan;
+
+    @Builder
+    public Applicant(Recruitment recruitment, Track track, String name, String email,
+                    String phone, String university, String major, String minorDoubleMajor,
+                    Integer lastSemester, MilitaryStatus militaryStatus, LocalDate birthDate,
+                    String graduationDate, Boolean gradSchoolPlan) {
+        this.recruitment = recruitment;
+        this.track = track;
+        this.name = name;
+        this.email = email;
+        this.phone = phone;
+        this.university = university;
+        this.major = major;
+        this.minorDoubleMajor = minorDoubleMajor;
+        this.lastSemester = lastSemester;
+        this.militaryStatus = militaryStatus;
+        this.birthDate = birthDate;
+        this.graduationDate = graduationDate;
+        this.gradSchoolPlan = gradSchoolPlan;
+    }
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/entity/Applicant.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/entity/Applicant.java
@@ -1,8 +1,11 @@
 package com.boaz.backend.domain.recruitment.entity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.boaz.backend.global.common.BaseEntity;
@@ -12,6 +15,7 @@ import java.time.LocalDate;
 
 @Getter
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "applicants")
 @EntityListeners(AuditingEntityListener.class)
 public class Applicant extends BaseEntity  {

--- a/src/main/java/com/boaz/backend/domain/recruitment/entity/ApplicantAnswer.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/entity/ApplicantAnswer.java
@@ -3,6 +3,7 @@ package com.boaz.backend.domain.recruitment.entity;
 import com.boaz.backend.global.common.BaseEntity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -27,4 +28,13 @@ public class ApplicantAnswer extends BaseEntity {
 
     @Column(columnDefinition = "JSON")
     private String answerJson;
+
+    @Builder
+    public ApplicantAnswer(Applicant applicant, ApplicationQuestion question,
+                            String answerText, String answerJson) {
+        this.applicant = applicant;
+        this.question = question;
+        this.answerText = answerText;
+        this.answerJson = answerJson;
+    }
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/entity/ApplicantAnswer.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/entity/ApplicantAnswer.java
@@ -3,11 +3,14 @@ package com.boaz.backend.domain.recruitment.entity;
 import com.boaz.backend.global.common.BaseEntity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "applicant_answer")
 public class ApplicantAnswer extends BaseEntity {
     

--- a/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantAnswerRepository.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantAnswerRepository.java
@@ -1,0 +1,7 @@
+package com.boaz.backend.domain.recruitment.repository;
+
+import com.boaz.backend.domain.recruitment.entity.ApplicantAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ApplicantAnswerRepository extends JpaRepository<ApplicantAnswer, Long> {
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantRepository.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantRepository.java
@@ -1,0 +1,7 @@
+package com.boaz.backend.domain.recruitment.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.boaz.backend.domain.recruitment.entity.Applicant;
+
+public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -1,22 +1,37 @@
 package com.boaz.backend.domain.recruitment.service;
 
+import com.boaz.backend.domain.recruitment.dto.AnswerRequest;
+import com.boaz.backend.domain.recruitment.dto.ApplicationRequest;
+import com.boaz.backend.domain.recruitment.dto.ApplicationResponse;
 import com.boaz.backend.domain.recruitment.dto.QuestionResponse;
 import com.boaz.backend.domain.recruitment.dto.RecruitmentResponse;
 import com.boaz.backend.domain.recruitment.dto.RecruitmentStatusResponse;
+import com.boaz.backend.domain.recruitment.entity.Applicant;
+import com.boaz.backend.domain.recruitment.entity.ApplicantAnswer;
 import com.boaz.backend.domain.recruitment.entity.ApplicationQuestion;
 import com.boaz.backend.domain.recruitment.entity.QuestionCategory;
+import com.boaz.backend.domain.recruitment.entity.QuestionType;
 import com.boaz.backend.domain.recruitment.entity.Recruitment;
+import com.boaz.backend.domain.recruitment.repository.ApplicantAnswerRepository;
+import com.boaz.backend.domain.recruitment.repository.ApplicantRepository;
 import com.boaz.backend.domain.recruitment.repository.ApplicationQuestionRepository;
 import com.boaz.backend.domain.recruitment.repository.RecruitmentRepository;
 import com.boaz.backend.global.common.enums.Track;
 import com.boaz.backend.global.exception.CustomException;
 import com.boaz.backend.global.exception.ErrorCode;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -25,8 +40,11 @@ public class RecruitmentService {
 
     private final RecruitmentRepository recruitmentRepository;
     private final ApplicationQuestionRepository applicationQuestionRepository;
+    private final ApplicantRepository applicantRepository;
+    private final ApplicantAnswerRepository applicantAnswerRepository;
+    private final ObjectMapper objectMapper;
 
-
+    
     // 모집 중 여부 조회
     public RecruitmentStatusResponse getRecruitmentStatus() {
         boolean isActive = recruitmentRepository
@@ -79,5 +97,141 @@ public class RecruitmentService {
         return questions.stream()
                 .map(QuestionResponse::from)
                 .toList();
+    }
+
+    // 지원서 제출하기
+    @Transactional
+    public ApplicationResponse submitApplication(ApplicationRequest request) {
+
+        // 공고 존재 여부 확인
+        Recruitment recruitment = recruitmentRepository.findById(request.getRecruitmentId())
+                .orElseThrow(() -> new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
+
+        // 모집 기간 확인
+        LocalDateTime now = LocalDateTime.now();
+        boolean isActive = !now.isBefore(recruitment.getStartDate())
+                        && !now.isAfter(recruitment.getEndDate());
+        if (!isActive) {
+            throw new CustomException(ErrorCode.RECRUITMENT_CLOSED);
+        }
+
+        // 이메일 형식 검증
+        if (!request.getEmail().matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$")) {
+            throw new CustomException(ErrorCode.INVALID_EMAIL_FORMAT);
+        }
+
+        // 전화번호 형식 검증 (하이픈 제외 숫자만)
+        if (!request.getPhone().matches("^[0-9]{10,11}$")) {
+            throw new CustomException(ErrorCode.INVALID_PHONE_FORMAT);
+        }
+
+        // 생년월일 형식 검증 (YYYY-MM-DD)
+        LocalDate birthDate;
+        try {
+            birthDate = LocalDate.parse(request.getBirthDate());
+        } catch (DateTimeParseException e) {
+            throw new CustomException(ErrorCode.INVALID_BIRTH_DATE_FORMAT);
+        }
+        
+        // 해당 공고의 질문 목록 조회
+        QuestionCategory trackCategory = QuestionCategory.valueOf(request.getTrack().name());
+        List<ApplicationQuestion> questions = applicationQuestionRepository
+                .findByRecruitmentIdAndCategories(
+                        request.getRecruitmentId(),
+                        QuestionCategory.공통,
+                        trackCategory
+                );
+
+        // 필수 질문 답변 여부 확인
+        List<String> requiredQuestionIds = questions.stream()
+                .filter(ApplicationQuestion::getIsRequired)
+                .map(ApplicationQuestion::getId)
+                .toList();
+
+        List<String> answeredQuestionIds = request.getAnswers().stream()
+                .map(AnswerRequest::getQuestionId)
+                .toList();
+
+        boolean allRequiredAnswered = answeredQuestionIds.containsAll(requiredQuestionIds);
+        if (!allRequiredAnswered) {
+            throw new CustomException(ErrorCode.ANSWER_REQUIRED);
+        }
+
+        // 답변 형식 검증 (TEXT → String, TABLE → JSON)
+        Map<String, ApplicationQuestion> questionMap = questions.stream()
+                .collect(Collectors.toMap(ApplicationQuestion::getId, q -> q));
+
+        for (AnswerRequest answerRequest : request.getAnswers()) {
+            ApplicationQuestion question = questionMap.get(answerRequest.getQuestionId());
+            if (question == null) continue;
+
+            JsonNode answer = answerRequest.getAnswer();
+            if (question.getType() == QuestionType.TEXT && !answer.isTextual()) {
+                throw new CustomException(ErrorCode.INVALID_ANSWER_TYPE);
+            }
+            if (question.getType() == QuestionType.TABLE && !answer.isObject()) {
+                throw new CustomException(ErrorCode.INVALID_ANSWER_TYPE);
+            }
+        }
+
+        // minorDoubleMajor JSON 변환
+        String minorDoubleMajorJson = null;
+        if (request.getMinorDoubleMajor() != null && !request.getMinorDoubleMajor().isEmpty()) {
+            try {
+                minorDoubleMajorJson = objectMapper.writeValueAsString(request.getMinorDoubleMajor());
+            } catch (Exception e) {
+                throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+            }
+        }
+
+        // 지원자 저장
+        Applicant applicant = Applicant.builder()
+                .recruitment(recruitment)
+                .track(request.getTrack())
+                .name(request.getName())
+                .email(request.getEmail())
+                .phone(request.getPhone())
+                .university(request.getUniversity())
+                .major(request.getMajor())
+                .minorDoubleMajor(minorDoubleMajorJson)
+                .lastSemester(request.getLastSemester())
+                .militaryStatus(request.getMilitaryStatus())
+                .birthDate(birthDate)
+                .graduationDate(request.getGraduationDate())
+                .gradSchoolPlan(request.getGradSchoolPlan())
+                .build();
+
+        applicantRepository.save(applicant);
+
+        // 답변 저장
+        for (AnswerRequest answerRequest : request.getAnswers()) {
+            ApplicationQuestion question = questionMap.get(answerRequest.getQuestionId());
+            if (question == null) continue;
+
+            JsonNode answer = answerRequest.getAnswer();
+            String answerText = null;
+            String answerJson = null;
+
+            if (question.getType() == QuestionType.TEXT) {
+                answerText = answer.asText();
+            } else {
+                try {
+                    answerJson = objectMapper.writeValueAsString(answer);
+                } catch (Exception e) {
+                    throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+                }
+            }
+
+            ApplicantAnswer applicantAnswer = ApplicantAnswer.builder()
+                    .applicant(applicant)
+                    .question(question)
+                    .answerText(answerText)
+                    .answerJson(answerJson)
+                    .build();
+
+            applicantAnswerRepository.save(applicantAnswer);
+        }
+
+        return ApplicationResponse.of(applicant.getId(), applicant.getCreatedAt());
     }
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -44,7 +44,7 @@ public class RecruitmentService {
     private final ApplicantAnswerRepository applicantAnswerRepository;
     private final ObjectMapper objectMapper;
 
-    
+
     // 모집 중 여부 조회
     public RecruitmentStatusResponse getRecruitmentStatus() {
         boolean isActive = recruitmentRepository
@@ -141,6 +141,9 @@ public class RecruitmentService {
                         QuestionCategory.공통,
                         trackCategory
                 );
+        if (questions.isEmpty()) {
+            throw new CustomException(ErrorCode.QUESTIONS_NOT_FOUND);
+        }
 
         // 필수 질문 답변 여부 확인
         List<String> requiredQuestionIds = questions.stream()
@@ -157,6 +160,22 @@ public class RecruitmentService {
             throw new CustomException(ErrorCode.ANSWER_REQUIRED);
         }
 
+        // 중복 questionId 검증
+        if (answeredQuestionIds.size() != answeredQuestionIds.stream().distinct().count()) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        // 잘못된 questionId 검증
+        List<String> validQuestionIds = questions.stream()
+                .map(ApplicationQuestion::getId)
+                .toList();
+
+        for (AnswerRequest answerRequest : request.getAnswers()) {
+            if (!validQuestionIds.contains(answerRequest.getQuestionId())) {
+                throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+            }
+        }
+        
         // 답변 형식 검증 (TEXT → String, TABLE → JSON)
         Map<String, ApplicationQuestion> questionMap = questions.stream()
                 .collect(Collectors.toMap(ApplicationQuestion::getId, q -> q));
@@ -166,6 +185,13 @@ public class RecruitmentService {
             if (question == null) continue;
 
             JsonNode answer = answerRequest.getAnswer();
+            if (question.getIsRequired()) {
+                if (answer == null || answer.isNull()
+                        || (question.getType() == QuestionType.TEXT && answer.asText().trim().isEmpty())
+                        || (question.getType() == QuestionType.TABLE && (!answer.isObject() || answer.size() == 0))) {
+                    throw new CustomException(ErrorCode.ANSWER_REQUIRED);
+                }
+            }
             if (question.getType() == QuestionType.TEXT && !answer.isTextual()) {
                 throw new CustomException(ErrorCode.INVALID_ANSWER_TYPE);
             }

--- a/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
@@ -13,10 +13,14 @@ public enum ErrorCode {
 
     // Recruitment
     RECRUITMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "RECRUITMENT_NOT_FOUND", "해당 모집 공고를 찾을 수 없습니다."),
-    ALREADY_APPLIED(HttpStatus.CONFLICT, "ALREADY_APPLIED", "이미 지원한 모집 공고입니다."),
     RECRUITMENT_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "RECRUITMENT_NOT_AVAILABLE", "현재 지원 가능한 기간이 아닙니다."),
-    INVALID_TRACK_NAME(HttpStatus.BAD_REQUEST, "INVALID_TRACK_NAME", "올바른 지원 부문을 선택해주세요."),
     QUESTIONS_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTIONS_NOT_FOUND", "등록된 질문이 없습니다."),
+    RECRUITMENT_CLOSED(HttpStatus.BAD_REQUEST, "RECRUITMENT_CLOSED", "현재 지원 기간이 아닙니다."),
+    ANSWER_REQUIRED(HttpStatus.BAD_REQUEST, "ANSWER_REQUIRED", "필수 질문에 답변해주세요."),
+    INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "INVALID_EMAIL_FORMAT", "이메일 형식이 올바르지 않습니다."),
+    INVALID_PHONE_FORMAT(HttpStatus.BAD_REQUEST, "INVALID_PHONE_FORMAT", "전화번호 형식이 올바르지 않습니다."),
+    INVALID_ANSWER_TYPE(HttpStatus.BAD_REQUEST, "INVALID_ANSWER_TYPE", "답변 형식이 올바르지 않습니다."),
+    INVALID_BIRTH_DATE_FORMAT(HttpStatus.BAD_REQUEST, "INVALID_BIRTH_DATE_FORMAT", "생년월일 형식이 올바르지 않습니다. (YYYY-MM-DD)"),
 
     // Curriculum
     CURRICULUM_NOT_FOUND(HttpStatus.NOT_FOUND, "CURRICULUM_NOT_FOUND", "해당 커리큘럼을 찾을 수 없습니다."),


### PR DESCRIPTION
## 💡 개요

* Issue Number: #7 

## 🪐 주요 변경 사항
- 지원서 제출 관련 에러 코드 추가 및 안쓰는 코드 삭제
- `Applicant`, 'ApplicantAnswer' builder, `@NoArgsConstructor` 추가
- 지원서 제출하기 API 구현

## ✅ 상세 내용
- `ErrorCode`에 `RECRUITMENT_CLOSED`, `INVALID_DIVISION`, `REQUIRED_FIELD_MISSING`, `ANSWER_REQUIRED`, `INVALID_EMAIL_FORMAT`, `INVALID_PHONE_FORMAT`, `INVALID_ANSWER_TYPE`, `INVALID_BIRTH_DATE_FORMAT` 추가
- `ApplicationRequest`, `AnswerRequest`, `ApplicationResponse` DTO 구현
- `ApplicantRepository`, `ApplicantAnswerRepository` 구현
- 서비스 레벨에서 아래 검증 로직 구현
  - 모집 기간 외 제출 방지
  - 이메일/전화번호/생년월일 형식 검증
  - 필수 질문 답변 누락 검증
  - 질문 타입(TEXT/TABLE)에 따른 답변 형식 검증
- `answer` 필드는 `JsonNode` 타입으로 받아 TEXT 질문은 문자열, TABLE 질문은 JSON 객체로 구분

## 🔔 참고 사항
- X
---
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**변경 목적**: 모집 지원서 제출 API를 구현하여 사용자가 지원 기간 내에 지원서를 제출할 수 있도록 하고, 입력 값(이메일/휴대폰/생년월일) 및 질문 답변 형식에 대한 서버측 유효성 검사를 강화함.

**주요 변경 내용**:
- Controller 레이어
  - POST /api/v1/recruitment/applications 엔드포인트 추가 (201 Created 반환)
- DTO
  - ApplicationRequest: 지원자 정보(이름, 이메일, 휴대폰, 학력 등) 및 AnswerRequest 목록(@Valid)
  - AnswerRequest: question_id, answer(JsonNode) — TEXT는 문자열, TABLE은 JSON 객체로 수용
  - ApplicationResponse: applicant_id, submitted_at 반환
- Entity / Builder
  - Applicant, ApplicantAnswer에 Lombok 기반 생성자/빌더(@NoArgsConstructor(access = PROTECTED), @Builder) 추가
- Repository
  - ApplicantRepository, ApplicantAnswerRepository 신규 추가 (JpaRepository 확장)
- Service 레이어
  - submitApplication(ApplicationRequest) 구현
    - 모집 존재 및 지원 기간 검증(지원 기간 외 제출 방지)
    - 이메일 / 전화번호 / 생년월일(YYYY-MM-DD) 형식 검증
    - 모집 질문 조회 후 필수 질문 답변 누락 검사
    - 질문 유형에 따른 답변 형식 검증 (TEXT: 문자열, TABLE: JSON 객체)
    - minorDoubleMajor 등 일부 필드 JSON 변환 및 Applicant/ApplicantAnswer 트랜잭션 저장
- 에러 코드
  - 기존 ALREADY_APPLIED, INVALID_TRACK_NAME 제거
  - 신규 추가: RECRUITMENT_CLOSED, ANSWER_REQUIRED, INVALID_EMAIL_FORMAT, INVALID_PHONE_FORMAT, INVALID_ANSWER_TYPE, INVALID_BIRTH_DATE_FORMAT
- 기타
  - 제출 처리 관련 미사용 코드 제거

**영향 범위**:
- API 변경: 새로운 POST 엔드포인트 추가 (응답: 201 Created, applicant_id 및 submitted_at 반환)
- DB 스키마 변경: 없음(기존 Applicant 및 ApplicantAnswer 엔티티/테이블 재사용)
- 설정 변경: 없음
- 주의사항: 서버측 검증 로직 강화로 클라이언트는 이메일/전화번호/생년월일 형식 및 질문 유형에 맞는 답변(JSON 형식)을 보내야 함
<!-- end of auto-generated comment: release notes by coderabbit.ai -->