### PR TITLE
[Feat] 모집 사전 알림 신청 API 구현

### DIFF
--- a/src/main/java/com/boaz/backend/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/controller/RecruitmentController.java
@@ -5,6 +5,8 @@ import com.boaz.backend.domain.recruitment.dto.ApplicationResponse;
 import com.boaz.backend.domain.recruitment.dto.QuestionResponse;
 import com.boaz.backend.domain.recruitment.dto.RecruitmentResponse;
 import com.boaz.backend.domain.recruitment.dto.RecruitmentStatusResponse;
+import com.boaz.backend.domain.recruitment.dto.SubscriptionRequest;
+import com.boaz.backend.domain.recruitment.dto.SubscriptionResponse;
 import com.boaz.backend.domain.recruitment.service.RecruitmentService;
 import com.boaz.backend.global.common.ApiResponse;
 import com.boaz.backend.global.common.enums.Track;
@@ -27,7 +29,7 @@ import org.springframework.web.bind.annotation.*;
 public class RecruitmentController {
 
     private final RecruitmentService recruitmentService;
-
+    ;
     @Operation(summary = "모집 중 여부 조회")
     @GetMapping("/status")
     public ResponseEntity<ApiResponse<RecruitmentStatusResponse>> getRecruitmentStatus() {
@@ -55,5 +57,14 @@ public class RecruitmentController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.created(recruitmentService.submitApplication(request)));
+    }
+
+    @Operation(summary = "모집 사전 알림 구독")
+    @PostMapping
+    public ResponseEntity<ApiResponse<SubscriptionResponse>> subscribe(
+            @RequestBody @Valid SubscriptionRequest request) {
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.created(recruitmentService.subscribe(request)));
     }
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/controller/RecruitmentController.java
@@ -60,7 +60,7 @@ public class RecruitmentController {
     }
 
     @Operation(summary = "모집 사전 알림 구독")
-    @PostMapping
+    @PostMapping("/subscriptions")
     public ResponseEntity<ApiResponse<SubscriptionResponse>> subscribe(
             @RequestBody @Valid SubscriptionRequest request) {
         return ResponseEntity

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/SubscriptionRequest.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/SubscriptionRequest.java
@@ -1,0 +1,11 @@
+package com.boaz.backend.domain.recruitment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class SubscriptionRequest {
+
+    @NotBlank(message = "이메일을 입력해주세요.")
+    private String email;
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/SubscriptionResponse.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/SubscriptionResponse.java
@@ -1,0 +1,18 @@
+package com.boaz.backend.domain.recruitment.dto;
+
+import com.boaz.backend.domain.recruitment.entity.Subscription;
+import lombok.Getter;
+
+@Getter
+public class SubscriptionResponse {
+
+    private final String email;
+
+    private SubscriptionResponse(Subscription subscription) {
+        this.email = subscription.getEmail();
+    }
+
+    public static SubscriptionResponse from(Subscription subscription) {
+        return new SubscriptionResponse(subscription);
+    }
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/entity/Subscription.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/entity/Subscription.java
@@ -1,0 +1,27 @@
+package com.boaz.backend.domain.recruitment.entity;
+
+import com.boaz.backend.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "subscription")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Subscription extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 255, nullable = false, unique = true)
+    private String email;
+
+    @Builder
+    public Subscription(String email) {
+        this.email = email;
+    }
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/repository/SubscriptionRepository.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/repository/SubscriptionRepository.java
@@ -1,0 +1,9 @@
+package com.boaz.backend.domain.recruitment.repository;
+
+import com.boaz.backend.domain.recruitment.entity.Subscription;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
+
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -27,6 +27,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -284,8 +286,11 @@ public class RecruitmentService {
                 .email(request.getEmail())
                 .build();
 
-        subscriptionRepository.save(subscription);
-
-        return SubscriptionResponse.from(subscription);
+        try {
+            subscriptionRepository.save(subscription);
+            return SubscriptionResponse.from(subscription);
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
+        }
     }
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -287,7 +287,7 @@ public class RecruitmentService {
                 .build();
 
         try {
-            subscriptionRepository.save(subscription);
+            subscriptionRepository.saveAndFlush(subscription);
             return SubscriptionResponse.from(subscription);
         } catch (DataIntegrityViolationException e) {
             throw new CustomException(ErrorCode.DUPLICATE_EMAIL);

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -6,16 +6,20 @@ import com.boaz.backend.domain.recruitment.dto.ApplicationResponse;
 import com.boaz.backend.domain.recruitment.dto.QuestionResponse;
 import com.boaz.backend.domain.recruitment.dto.RecruitmentResponse;
 import com.boaz.backend.domain.recruitment.dto.RecruitmentStatusResponse;
+import com.boaz.backend.domain.recruitment.dto.SubscriptionRequest;
+import com.boaz.backend.domain.recruitment.dto.SubscriptionResponse;
 import com.boaz.backend.domain.recruitment.entity.Applicant;
 import com.boaz.backend.domain.recruitment.entity.ApplicantAnswer;
 import com.boaz.backend.domain.recruitment.entity.ApplicationQuestion;
 import com.boaz.backend.domain.recruitment.entity.QuestionCategory;
 import com.boaz.backend.domain.recruitment.entity.QuestionType;
 import com.boaz.backend.domain.recruitment.entity.Recruitment;
+import com.boaz.backend.domain.recruitment.entity.Subscription;
 import com.boaz.backend.domain.recruitment.repository.ApplicantAnswerRepository;
 import com.boaz.backend.domain.recruitment.repository.ApplicantRepository;
 import com.boaz.backend.domain.recruitment.repository.ApplicationQuestionRepository;
 import com.boaz.backend.domain.recruitment.repository.RecruitmentRepository;
+import com.boaz.backend.domain.recruitment.repository.SubscriptionRepository;
 import com.boaz.backend.global.common.enums.Track;
 import com.boaz.backend.global.exception.CustomException;
 import com.boaz.backend.global.exception.ErrorCode;
@@ -43,6 +47,7 @@ public class RecruitmentService {
     private final ApplicantRepository applicantRepository;
     private final ApplicantAnswerRepository applicantAnswerRepository;
     private final ObjectMapper objectMapper;
+    private final SubscriptionRepository subscriptionRepository;
 
 
     // 모집 중 여부 조회
@@ -259,5 +264,28 @@ public class RecruitmentService {
         }
 
         return ApplicationResponse.of(applicant.getId(), applicant.getCreatedAt());
+    }
+
+    // 모집 사전 알림 신청하기
+    @Transactional
+    public SubscriptionResponse subscribe(SubscriptionRequest request) {
+
+        // 이메일 형식 검증
+        if (!request.getEmail().matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$")) {
+            throw new CustomException(ErrorCode.INVALID_EMAIL_FORMAT);
+        }
+
+        // 중복 이메일 확인
+        if (subscriptionRepository.existsByEmail(request.getEmail())) {
+            throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
+        }
+
+        Subscription subscription = Subscription.builder()
+                .email(request.getEmail())
+                .build();
+
+        subscriptionRepository.save(subscription);
+
+        return SubscriptionResponse.from(subscription);
     }
 }

--- a/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
@@ -21,6 +21,8 @@ public enum ErrorCode {
     INVALID_PHONE_FORMAT(HttpStatus.BAD_REQUEST, "INVALID_PHONE_FORMAT", "전화번호 형식이 올바르지 않습니다."),
     INVALID_ANSWER_TYPE(HttpStatus.BAD_REQUEST, "INVALID_ANSWER_TYPE", "답변 형식이 올바르지 않습니다."),
     INVALID_BIRTH_DATE_FORMAT(HttpStatus.BAD_REQUEST, "INVALID_BIRTH_DATE_FORMAT", "생년월일 형식이 올바르지 않습니다. (YYYY-MM-DD)"),
+    MISSING_CONTACT(HttpStatus.BAD_REQUEST, "MISSING_CONTACT", "이메일을 입력해주세요."),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "DUPLICATE_EMAIL", "이미 구독 신청된 이메일입니다."),
 
     // Curriculum
     CURRICULUM_NOT_FOUND(HttpStatus.NOT_FOUND, "CURRICULUM_NOT_FOUND", "해당 커리큘럼을 찾을 수 없습니다."),


### PR DESCRIPTION
## 💡 개요

* Issue Number: #9 

## 🪐 주요 변경 사항
- 모집 사전 알림 구독 API 구현 (`POST /api/v1/recruitment/subscriptions`)
- 구독 관련 엔티티 및 에러 코드 추가

## ✅ 상세 내용
- `Subscription` 엔티티 구현
- `SubscriptionRepository` 구현 (`existsByEmail`로 중복 체크)
- `SubscriptionRequest`, `SubscriptionResponse` DTO 구현
- `RecruitmentService`에 `subscribe()` 메서드 추가
- `RecruitmentController`에 구독 엔드포인트 추가
- `ErrorCode`에 `MISSING_CONTACT`, `DUPLICATE_EMAIL` 추가

## 🔔 참고 사항
- 이메일 형식 검증은 `RecruitmentService`의 기존 정규식 로직 재사용
- 별도 컨트롤러/서비스 분리 없이 기존 `RecruitmentController`, `RecruitmentService`에 통합
---
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## PR 요약

**변경 목적**: 사용자가 모집 공고 사전 알림을 이메일로 신청할 수 있도록 구독 API를 추가합니다. 이메일 형식 검증과 중복 신청 방지 및 즉시 삽입 보장을 위한 저장 로직을 포함합니다.

**주요 변경 내용**:
- Controller 레이어: `RecruitmentController`에 POST `/api/v1/recruitment/subscriptions` 엔드포인트 추가 (`subscribe` 메서드)
- DTO 레이어:
  - `SubscriptionRequest` 추가 (@NotBlank로 이메일 필수 검증)
  - `SubscriptionResponse` 추가 (저장된 Subscription 엔티티를 응답으로 매핑)
- Entity 레이어: `Subscription` JPA 엔티티 추가 (`subscription` 테이블, id 및 고유한 email 필드)
- Repository 레이어: `SubscriptionRepository` 추가 (`existsByEmail(String email)` 메서드)
- Service 레이어: `RecruitmentService`에 `subscribe(SubscriptionRequest)` 메서드 추가 — 기존 이메일 정규식 재사용, 중복 확인, 저장(즉시 INSERT를 위한 saveAndFlush 사용) 및 응답 반환; DataIntegrityViolationException 처리로 중복 이메일 대응
- Exception/글로벌 에러: `ErrorCode`에 `MISSING_CONTACT`(Bad Request) 및 `DUPLICATE_EMAIL`(Conflict) 추가
- 커밋 관련: 영속성 저장을 강제하기 위해 saveAndFlush() 사용 및 이에 따른 예외 처리 조정

**영향 범위**:
- API 변경: 신규 엔드포인트 POST `/api/v1/recruitment/subscriptions` 추가
- DB 스키마 변경: `subscription` 테이블 신규 생성 (id, email 컬럼, email에 유니크 제약)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->