### PR TITLE
[Feat] 모집 마감 일시 조회 API 구현 및 모집 중 여부 조회 API 응답 개선

### DIFF
--- a/src/main/java/com/boaz/backend/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/controller/RecruitmentController.java
@@ -2,6 +2,7 @@ package com.boaz.backend.domain.recruitment.controller;
 
 import com.boaz.backend.domain.recruitment.dto.ApplicationRequest;
 import com.boaz.backend.domain.recruitment.dto.ApplicationResponse;
+import com.boaz.backend.domain.recruitment.dto.DeadlineResponse;
 import com.boaz.backend.domain.recruitment.dto.QuestionResponse;
 import com.boaz.backend.domain.recruitment.dto.RecruitmentResponse;
 import com.boaz.backend.domain.recruitment.dto.RecruitmentStatusResponse;
@@ -29,11 +30,17 @@ import org.springframework.web.bind.annotation.*;
 public class RecruitmentController {
 
     private final RecruitmentService recruitmentService;
-    ;
+    
     @Operation(summary = "모집 중 여부 조회")
     @GetMapping("/status")
     public ResponseEntity<ApiResponse<RecruitmentStatusResponse>> getRecruitmentStatus() {
         return ResponseEntity.ok(ApiResponse.ok(recruitmentService.getRecruitmentStatus()));
+    }
+
+    @Operation(summary = "모집 마감 일시 조회")
+    @GetMapping("/deadline")
+    public ResponseEntity<ApiResponse<DeadlineResponse>> getDeadline() {
+        return ResponseEntity.ok(ApiResponse.ok(recruitmentService.getDeadline()));
     }
 
     @Operation(summary = "모집 공고 정보 조회")

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/DeadlineResponse.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/DeadlineResponse.java
@@ -1,0 +1,27 @@
+package com.boaz.backend.domain.recruitment.dto;
+
+import com.boaz.backend.domain.recruitment.entity.Recruitment;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class DeadlineResponse {
+
+    @JsonProperty("recruitment_id")
+    private final Long recruitmentId;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private final LocalDateTime deadline;
+
+    private DeadlineResponse(Recruitment recruitment) {
+        this.recruitmentId = recruitment.getId();
+        this.deadline = recruitment.getEndDate();
+    }
+
+    public static DeadlineResponse from(Recruitment recruitment) {
+        return new DeadlineResponse(recruitment);
+    }
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/RecruitmentStatusResponse.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/RecruitmentStatusResponse.java
@@ -1,17 +1,22 @@
 package com.boaz.backend.domain.recruitment.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import lombok.Getter;
 
 @Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class RecruitmentStatusResponse {
 
     private final Boolean isActive;
+    private final Integer term;
 
-    private RecruitmentStatusResponse(boolean isActive) {
+    private RecruitmentStatusResponse(boolean isActive, Integer term) {
         this.isActive = isActive;
+        this.term = term;
     }
 
-    public static RecruitmentStatusResponse of(boolean isActive) {
-        return new RecruitmentStatusResponse(isActive);
+    public static RecruitmentStatusResponse of(boolean isActive, Integer term) {
+        return new RecruitmentStatusResponse(isActive, term);
     }
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/repository/RecruitmentRepository.java
@@ -3,6 +3,7 @@ package com.boaz.backend.domain.recruitment.repository;
 import com.boaz.backend.domain.recruitment.entity.Recruitment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.Optional;

--- a/src/main/java/com/boaz/backend/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/repository/RecruitmentRepository.java
@@ -3,7 +3,6 @@ package com.boaz.backend.domain.recruitment.repository;
 import com.boaz.backend.domain.recruitment.entity.Recruitment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.Optional;

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -3,6 +3,7 @@ package com.boaz.backend.domain.recruitment.service;
 import com.boaz.backend.domain.recruitment.dto.AnswerRequest;
 import com.boaz.backend.domain.recruitment.dto.ApplicationRequest;
 import com.boaz.backend.domain.recruitment.dto.ApplicationResponse;
+import com.boaz.backend.domain.recruitment.dto.DeadlineResponse;
 import com.boaz.backend.domain.recruitment.dto.QuestionResponse;
 import com.boaz.backend.domain.recruitment.dto.RecruitmentResponse;
 import com.boaz.backend.domain.recruitment.dto.RecruitmentStatusResponse;
@@ -58,6 +59,14 @@ public class RecruitmentService {
                 .findActiveRecruitment(LocalDateTime.now())
                 .isPresent();
         return RecruitmentStatusResponse.of(isActive);
+    }
+
+    // 모집 공고 마감 일시 조회
+    public DeadlineResponse getDeadline() {
+        LocalDateTime now = LocalDateTime.now();
+        Recruitment recruitment = recruitmentRepository.findActiveRecruitment(now)
+                .orElseThrow(() -> new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
+        return DeadlineResponse.from(recruitment);
     }
 
     // 기수별 모집 공고 조회

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -38,6 +38,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -55,10 +56,12 @@ public class RecruitmentService {
 
     // 모집 중 여부 조회
     public RecruitmentStatusResponse getRecruitmentStatus() {
-        boolean isActive = recruitmentRepository
-                .findActiveRecruitment(LocalDateTime.now())
-                .isPresent();
-        return RecruitmentStatusResponse.of(isActive);
+        Optional<Recruitment> activeRecruitment = recruitmentRepository
+                .findActiveRecruitment(LocalDateTime.now());
+        
+        return activeRecruitment
+                .map(r -> RecruitmentStatusResponse.of(true, r.getTerm()))
+                .orElse(RecruitmentStatusResponse.of(false, null));
     }
 
     // 모집 공고 마감 일시 조회


### PR DESCRIPTION
## 💡 개요
* Issue Number: #6 

## 🪐 주요 변경 사항
- 모집 마감 일시 조회 API 구현 (`GET /api/v1/recruitment/deadline`)
- 모집 중 여부 조회 시 `term` 함께 반환하도록 수정

## ✅ 상세 내용
- `DeadlineResponse` DTO 구현
- `RecruitmentService`에 `getDeadline()` 메서드 추가
- `RecruitmentController`에 `/deadline` 엔드포인트 추가
- `RecruitmentStatusResponse`에 `term` 필드 추가 및 `@JsonInclude(NON_NULL)` 적용
- 모집 중이 아닐 때는 `term` 필드 응답에서 제외되도록 처리
- 사용하지 않는 import 문 정리

## 🔔 참고 사항
- 마감 일시는 ISO 8601 형식(`yyyy-MM-dd'T'HH:mm:ss`)으로 반환
- 현재 모집 중인 공고가 없을 경우 `RECRUITMENT_NOT_FOUND` 에러 반환
---
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**변경 목적**
모집 마감 일시를 조회하는 새로운 API 엔드포인트를 제공하고, 모집 상태 조회 응답에 모집 기간(term) 정보를 추가하여 클라이언트가 더욱 상세한 모집 관련 정보를 획득할 수 있도록 개선합니다.

**주요 변경 내용**
- **Controller**: GET /api/v1/recruitment/deadline 엔드포인트 신규 추가
- **DTO**: 
  - DeadlineResponse 신규 추가 (recruitmentId, deadline 필드)
  - RecruitmentStatusResponse에 term 필드 추가 및 @JsonInclude(NON_NULL) 적용 (모집 중일 때만 포함)
- **Service**: 
  - getDeadline() 메서드 신규 추가 (현재 모집 중인 공고의 마감 일시 반환)
  - getRecruitmentStatus() 메서드 리팩토링 (Optional 활용, term 파라미터 추가)

**영향 범위**
- **API 변경**: GET /api/v1/recruitment/deadline 신규 엔드포인트 추가, 기존 모집 상태 조회 응답 스키마 변경 (term 필드 조건부 포함)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->