### PR TITLE
[Feat] 지원서 파일 생성 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 
     // env
     implementation 'io.github.cdimascio:dotenv-java:3.1.0'
+
+    // S3
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/boaz/backend/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/boaz/backend/domain/admin/controller/AdminController.java
@@ -1,13 +1,17 @@
 package com.boaz.backend.domain.admin.controller;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.boaz.backend.domain.recruitment.service.RecruitmentService;
 import com.boaz.backend.global.common.ApiResponse;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -19,12 +23,18 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/admin")
 public class AdminController {
 
+    @Value("${admin.api-key}")
+    private String adminKeyValue;
     private final RecruitmentService recruitmentService;
 
     @Operation(summary = "지원서 CSV 파일 생성")
     @PostMapping("/recruitment/applications/download")
     public ResponseEntity<ApiResponse<Void>> downloadApplications(
-            @RequestParam Integer term) {
+            @RequestParam Integer term,
+            @RequestHeader("X-Admin-Key") String adminKey) {
+        if (!adminKey.equals(adminKeyValue)) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
         recruitmentService.downloadApplications(term);
         return ResponseEntity.ok(ApiResponse.ok(null));
     }

--- a/src/main/java/com/boaz/backend/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/boaz/backend/domain/admin/controller/AdminController.java
@@ -1,0 +1,31 @@
+package com.boaz.backend.domain.admin.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.boaz.backend.domain.recruitment.service.RecruitmentService;
+import com.boaz.backend.global.common.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Admin", description = "관리자 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin")
+public class AdminController {
+
+    private final RecruitmentService recruitmentService;
+
+    @Operation(summary = "지원서 CSV 파일 생성")
+    @PostMapping("/recruitment/applications/download")
+    public ResponseEntity<ApiResponse<Void>> downloadApplications(
+            @RequestParam Integer term) {
+        recruitmentService.downloadApplications(term);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/controller/RecruitmentController.java
@@ -74,4 +74,12 @@ public class RecruitmentController {
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.created(recruitmentService.subscribe(request)));
     }
+
+    @Operation(summary = "지원서 CSV 파일 생성")
+    @GetMapping("/admin/recruitment/applications/download")
+    public ResponseEntity<ApiResponse<Void>> downloadApplications(
+            @RequestParam Integer term) {
+        recruitmentService.downloadApplications(term);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/controller/RecruitmentController.java
@@ -74,12 +74,4 @@ public class RecruitmentController {
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.created(recruitmentService.subscribe(request)));
     }
-
-    @Operation(summary = "지원서 CSV 파일 생성")
-    @GetMapping("/admin/recruitment/applications/download")
-    public ResponseEntity<ApiResponse<Void>> downloadApplications(
-            @RequestParam Integer term) {
-        recruitmentService.downloadApplications(term);
-        return ResponseEntity.ok(ApiResponse.ok(null));
-    }
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantAnswerRepository.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantAnswerRepository.java
@@ -1,7 +1,16 @@
 package com.boaz.backend.domain.recruitment.repository;
 
 import com.boaz.backend.domain.recruitment.entity.ApplicantAnswer;
+
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ApplicantAnswerRepository extends JpaRepository<ApplicantAnswer, Long> {
+
+    // applicant_id 기반 조회
+    @Query("SELECT aa FROM ApplicantAnswer aa WHERE aa.applicant.id IN :applicantIds")
+    List<ApplicantAnswer> findByApplicantIds(@Param("applicantIds") List<Long> applicantIds);
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantRepository.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantRepository.java
@@ -1,7 +1,30 @@
 package com.boaz.backend.domain.recruitment.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import com.boaz.backend.domain.recruitment.entity.Applicant;
+import com.boaz.backend.global.common.enums.Track;
 
 public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
+
+    // recruitment_id, track 기반 검색 (중복 제거)
+    @Query("""
+        SELECT a FROM Applicant a
+        WHERE a.recruitment.id = :recruitmentId
+        AND a.track = :track
+        AND a.createdAt = (
+            SELECT MAX(a2.createdAt) FROM Applicant a2
+            WHERE a2.email = a.email
+            AND a2.recruitment.id = :recruitmentId
+        )
+        ORDER BY a.createdAt ASC
+    """)
+    List<Applicant> findLatestByRecruitmentIdAndTrack(
+            @Param("recruitmentId") Long recruitmentId,
+            @Param("track") Track track
+    );
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/CsvService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/CsvService.java
@@ -64,11 +64,11 @@ public class CsvService {
                 row.add(applicant.getUniversity());
                 row.add(applicant.getMajor());
                 row.add(formatMinorDoubleMajor(applicant.getMinorDoubleMajor()));
-                row.add(String.valueOf(applicant.getLastSemester()));
-                row.add(applicant.getMilitaryStatus().name());
-                row.add(applicant.getBirthDate().toString());
-                row.add(applicant.getGraduationDate());
-                row.add(applicant.getGradSchoolPlan() ? "Y" : "N");
+                row.add(String.valueOf(applicant.getLastSemester() != null ? applicant.getLastSemester() : ""));
+                row.add(applicant.getMilitaryStatus() != null ? applicant.getMilitaryStatus().name() : "");
+                row.add(applicant.getBirthDate() != null ? applicant.getBirthDate().toString() : "");
+                row.add(applicant.getGraduationDate() != null ? applicant.getGraduationDate() : "");
+                row.add(applicant.getGradSchoolPlan() != null ? (applicant.getGradSchoolPlan() ? "Y" : "N") : "");
                 row.add(applicant.getCreatedAt().toString());
 
                 Map<String, ApplicantAnswer> applicantAnswers = answerMap.getOrDefault(applicant.getId(), Collections.emptyMap());

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/CsvService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/CsvService.java
@@ -121,10 +121,18 @@ public class CsvService {
 
     private String escapeCsvValue(String value) {
         if (value == null) return "\"\"";
-        // 쌍따옴표, 쉼표, 줄바꿈이 포함된 경우 쌍따옴표로 감싸기
-        if (value.contains("\"") || value.contains(",") || value.contains("\n")) {
-            return "\"" + value.replace("\"", "\"\"") + "\"";
+        String sanitized = sanitizeForSpreadsheet(value);
+        return "\"" + sanitized.replace("\"", "\"\"") + "\"";
+    }
+
+    private String sanitizeForSpreadsheet(String value) {
+        String trimmed = value.stripLeading();
+        if (!trimmed.isEmpty()) {
+            char first = trimmed.charAt(0);
+            if (first == '=' || first == '+' || first == '-' || first == '@') {
+                return "'" + value;
+            }
         }
-        return "\"" + value + "\"";
+        return value;
     }
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/CsvService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/CsvService.java
@@ -57,12 +57,12 @@ public class CsvService {
             // 지원자별 행 작성
             for (Applicant applicant : applicants) {
                 List<String> row = new ArrayList<>();
-                row.add(applicant.getTrack().name());
+                row.add(applicant.getTrack() != null ? applicant.getTrack().name() : "");
                 row.add(applicant.getName());
                 row.add(applicant.getEmail());
-                row.add(applicant.getPhone());
-                row.add(applicant.getUniversity());
-                row.add(applicant.getMajor());
+                row.add(applicant.getPhone() != null ? applicant.getPhone() : "");
+                row.add(applicant.getUniversity() != null ? applicant.getUniversity() : "");
+                row.add(applicant.getMajor() != null ? applicant.getMajor() : "");
                 row.add(formatMinorDoubleMajor(applicant.getMinorDoubleMajor()));
                 row.add(String.valueOf(applicant.getLastSemester() != null ? applicant.getLastSemester() : ""));
                 row.add(applicant.getMilitaryStatus() != null ? applicant.getMilitaryStatus().name() : "");

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/CsvService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/CsvService.java
@@ -1,0 +1,130 @@
+package com.boaz.backend.domain.recruitment.service;
+
+import com.boaz.backend.domain.recruitment.entity.*;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CsvService {
+
+    private final ObjectMapper objectMapper;
+
+    private static final List<String> BASE_HEADERS = List.of(
+            "지원 부문", "성명", "이메일 주소", "전화번호", "대학교", "본전공",
+            "복수/부전공", "마지막 재학 학기", "병역 이수 여부", "생년월일",
+            "졸업 예정 시점", "대학원 진학 여부", "지원서 제출 일시"
+    );
+
+    public byte[] generateCsv(
+            List<Applicant> applicants,
+            List<ApplicationQuestion> questions,
+            List<ApplicantAnswer> answers
+    ) throws IOException {
+
+        // 질문 ID 순서 리스트
+        List<String> questionIds = questions.stream()
+                .map(ApplicationQuestion::getId)
+                .toList();
+
+        // 지원자별 답변 맵 구성 (applicantId -> (questionId -> answer))
+        Map<Long, Map<String, ApplicantAnswer>> answerMap = new HashMap<>();
+        for (ApplicantAnswer answer : answers) {
+            Long applicantId = answer.getApplicant().getId();
+            answerMap.computeIfAbsent(applicantId, k -> new HashMap<>())
+                    .put(answer.getQuestion().getId(), answer);
+        }
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        // UTF-8 BOM 추가
+        baos.write(new byte[]{(byte) 0xEF, (byte) 0xBB, (byte) 0xBF});
+
+        try (OutputStreamWriter writer = new OutputStreamWriter(baos, StandardCharsets.UTF_8)) {
+            // 헤더 작성
+            List<String> headers = new ArrayList<>(BASE_HEADERS);
+            headers.addAll(questionIds);
+            writer.write(toCsvRow(headers));
+
+            // 지원자별 행 작성
+            for (Applicant applicant : applicants) {
+                List<String> row = new ArrayList<>();
+                row.add(applicant.getTrack().name());
+                row.add(applicant.getName());
+                row.add(applicant.getEmail());
+                row.add(applicant.getPhone());
+                row.add(applicant.getUniversity());
+                row.add(applicant.getMajor());
+                row.add(formatMinorDoubleMajor(applicant.getMinorDoubleMajor()));
+                row.add(String.valueOf(applicant.getLastSemester()));
+                row.add(applicant.getMilitaryStatus().name());
+                row.add(applicant.getBirthDate().toString());
+                row.add(applicant.getGraduationDate());
+                row.add(applicant.getGradSchoolPlan() ? "Y" : "N");
+                row.add(applicant.getCreatedAt().toString());
+
+                Map<String, ApplicantAnswer> applicantAnswers = answerMap.getOrDefault(applicant.getId(), Collections.emptyMap());
+                for (String questionId : questionIds) {
+                    ApplicantAnswer answer = applicantAnswers.get(questionId);
+                    row.add(answer != null ? formatAnswer(answer) : "");
+                }
+                writer.write(toCsvRow(row));
+            }
+        }
+        return baos.toByteArray();
+    }
+
+    private String formatMinorDoubleMajor(String minorDoubleMajorJson) {
+        if (minorDoubleMajorJson == null) return "";
+        try {
+            JsonNode node = objectMapper.readTree(minorDoubleMajorJson);
+            List<String> values = new ArrayList<>();
+            node.forEach(n -> values.add(n.asText()));
+            return String.join(", ", values);
+        } catch (Exception e) {
+            return minorDoubleMajorJson;
+        }
+    }
+
+    private String formatAnswer(ApplicantAnswer answer) {
+        if (answer.getAnswerText() != null) {
+            return answer.getAnswerText();
+        }
+        if (answer.getAnswerJson() != null) {
+            try {
+                JsonNode node = objectMapper.readTree(answer.getAnswerJson());
+                StringBuilder sb = new StringBuilder();
+                node.fields().forEachRemaining(entry ->
+                        sb.append(entry.getKey()).append(": ").append(entry.getValue().asText()).append("\n")
+                );
+                return sb.toString().trim();
+            } catch (Exception e) {
+                return answer.getAnswerJson();
+            }
+        }
+        return "";
+    }
+
+    private String toCsvRow(List<String> values) {
+        return values.stream()
+                .map(this::escapeCsvValue)
+                .collect(Collectors.joining(",")) + "\n";
+    }
+
+    private String escapeCsvValue(String value) {
+        if (value == null) return "\"\"";
+        // 쌍따옴표, 쉼표, 줄바꿈이 포함된 경우 쌍따옴표로 감싸기
+        if (value.contains("\"") || value.contains(",") || value.contains("\n")) {
+            return "\"" + value.replace("\"", "\"\"") + "\"";
+        }
+        return "\"" + value + "\"";
+    }
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -33,9 +33,12 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -52,7 +55,8 @@ public class RecruitmentService {
     private final ApplicantAnswerRepository applicantAnswerRepository;
     private final ObjectMapper objectMapper;
     private final SubscriptionRepository subscriptionRepository;
-
+    private final CsvService csvService;
+    private final S3Service s3Service;
 
     // 모집 중 여부 조회
     public RecruitmentStatusResponse getRecruitmentStatus() {
@@ -303,6 +307,55 @@ public class RecruitmentService {
             return SubscriptionResponse.from(subscription);
         } catch (DataIntegrityViolationException e) {
             throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
+        }
+    }
+
+    // 지원서 파일 다운로드
+    public void downloadApplications(Integer term) {
+
+        // 공고 존재 여부 확인
+        Recruitment recruitment = recruitmentRepository.findByTerm(term)
+                .orElseThrow(() -> new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
+
+        String timestamp = LocalDateTime.now()
+                .format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
+
+        // 부문별 CSV 생성 및 S3 업로드
+        for (Track track : List.of(Track.시각화, Track.분석, Track.엔지니어링)) {
+
+            // 해당 부문 지원자 조회
+            List<Applicant> applicants = applicantRepository
+                    .findLatestByRecruitmentIdAndTrack(recruitment.getId(), track);
+
+            // 공통 + 해당 부문 질문 조회
+            List<ApplicationQuestion> questions = applicationQuestionRepository
+                    .findByRecruitmentIdAndCategories(
+                            recruitment.getId(),
+                            QuestionCategory.공통, 
+                            QuestionCategory.valueOf(track.name())
+                    );
+
+            // 지원자 답변 조회
+            List<Long> applicantIds = applicants.stream()
+                    .map(Applicant::getId)
+                    .toList();
+
+            List<ApplicantAnswer> answers = applicantIds.isEmpty()
+                    ? Collections.emptyList()
+                    : applicantAnswerRepository.findByApplicantIds(applicantIds);
+
+            // CSV 생성
+            byte[] csv;
+            try {
+                csv = csvService.generateCsv(applicants, questions, answers);
+            } catch (IOException e) {
+                throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+            }
+
+            // S3 업로드
+            String key = String.format("%d/applicants_%s_%s.csv",
+                    term, track.name(), timestamp);
+            s3Service.uploadCsv(key, csv);
         }
     }
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/S3Service.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/S3Service.java
@@ -1,0 +1,33 @@
+package com.boaz.backend.domain.recruitment.service;
+
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public void uploadCsv(String key, byte[] content) {
+        try {
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .contentType("text/csv")
+                    .build();
+            s3Client.putObject(request, RequestBody.fromBytes(content));
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.S3_UPLOAD_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/boaz/backend/global/config/S3Config.java
+++ b/src/main/java/com/boaz/backend/global/config/S3Config.java
@@ -1,0 +1,37 @@
+package com.boaz.backend.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Value("${cloud.aws.credentials.access-key:}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key:}")
+    private String secretKey;
+
+    @Bean
+    public S3Client s3Client() {
+        S3ClientBuilder builder = S3Client.builder()
+                .region(Region.of(region));
+
+        if (!accessKey.isBlank() && !secretKey.isBlank()) {
+            builder.credentialsProvider(StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(accessKey, secretKey)
+            ));
+        }
+
+        return builder.build();
+    }
+}

--- a/src/main/java/com/boaz/backend/global/config/S3Config.java
+++ b/src/main/java/com/boaz/backend/global/config/S3Config.java
@@ -26,7 +26,14 @@ public class S3Config {
         S3ClientBuilder builder = S3Client.builder()
                 .region(Region.of(region));
 
-        if (!accessKey.isBlank() && !secretKey.isBlank()) {
+        boolean hasAccessKey = !accessKey.isBlank();
+        boolean hasSecretKey = !secretKey.isBlank();
+
+        if (hasAccessKey != hasSecretKey) {
+            throw new IllegalStateException("AWS 자격증명 설정 오류: access-key와 secret-key는 둘 다 설정하거나 둘 다 비워야 합니다.");
+        }
+
+        if (hasAccessKey) {
             builder.credentialsProvider(StaticCredentialsProvider.create(
                     AwsBasicCredentials.create(accessKey, secretKey)
             ));

--- a/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
@@ -23,7 +23,8 @@ public enum ErrorCode {
     INVALID_BIRTH_DATE_FORMAT(HttpStatus.BAD_REQUEST, "INVALID_BIRTH_DATE_FORMAT", "생년월일 형식이 올바르지 않습니다. (YYYY-MM-DD)"),
     MISSING_CONTACT(HttpStatus.BAD_REQUEST, "MISSING_CONTACT", "이메일을 입력해주세요."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "DUPLICATE_EMAIL", "이미 구독 신청된 이메일입니다."),
-
+    S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3_UPLOAD_FAILED", "파일 업로드 중 오류가 발생했습니다."),
+    
     // Curriculum
     CURRICULUM_NOT_FOUND(HttpStatus.NOT_FOUND, "CURRICULUM_NOT_FOUND", "해당 커리큘럼을 찾을 수 없습니다."),
 

--- a/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "INVALID_INPUT_VALUE", "입력값이 올바르지 않습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다."),
     MISSING_PARAMETER(HttpStatus.BAD_REQUEST, "MISSING_PARAMETER", "요청 파라미터가 누락되었습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "접근 권한이 없습니다."),
 
     // Recruitment
     RECRUITMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "RECRUITMENT_NOT_FOUND", "해당 모집 공고를 찾을 수 없습니다."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,5 @@
 spring:
+
   datasource:
     url: ${DB_URL:jdbc:mysql://localhost:3306/boaz?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
     username: ${DB_USERNAME:root}
@@ -31,3 +32,13 @@ springdoc:
     tags-sorter: alpha
   api-docs:
     path: /api-docs
+
+cloud:
+  aws:
+    s3:
+      bucket: ${S3_BUCKET_NAME}
+    region:
+      static: ap-northeast-2
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,5 +40,5 @@ cloud:
     region:
       static: ap-northeast-2
     credentials:
-      access-key: ${AWS_ACCESS_KEY}
-      secret-key: ${AWS_SECRET_KEY}
+      access-key: ${AWS_ACCESS_KEY:}
+      secret-key: ${AWS_SECRET_KEY:}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,3 +42,6 @@ cloud:
     credentials:
       access-key: ${AWS_ACCESS_KEY:}
       secret-key: ${AWS_SECRET_KEY:}
+
+admin:
+  api-key: ${ADMIN_API_KEY}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -21,16 +21,91 @@ VALUES ('시각화1', 1, '시각화', 'TABLE', '데이터 시각화 관련 TOOL 
 INSERT INTO application_question (id, recruitment_id, category, type, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
 VALUES ('시각화2', 1, '시각화', 'TEXT', '본인이 진행했던 시각화를 통해 인사이트를 도출한 경험.. (700자 이내)', null, 700, 11, true, NOW(), NOW());
 
-
 INSERT INTO application_question (id, recruitment_id, category, type, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
 VALUES ('엔지니어링1', 1, '엔지니어링', 'TABLE', '데이터 엔지니어링 관련 경험', '{"rows":["데이터베이스", "서버 및 클라우드 서비스"], "columns":["경험 없음", "관련 프로젝트 경험 있음"]}', null, 10, true, NOW(), NOW());
 
 INSERT INTO application_question (id, recruitment_id, category, type, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
 VALUES ('엔지니어링2', 1, '엔지니어링', 'TEXT', '데이터 엔지니어링 분야 중 관심있는 세부 분야와 해당 분야와 관련된 경험 및 활동.. (700자 이내)', null, 700, 11, true, NOW(), NOW());
 
-
 INSERT INTO application_question (id, recruitment_id, category, type, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
 VALUES ('분석1', 1, '분석', 'TEXT', '[빅데이터 / 인공지능 / 머신러닝 / 통계 및 수학] 관련 수강 과목 혹은 세미나 경험.. (300자 이내)', null, 300, 10, true, NOW(), NOW());
 
 INSERT INTO application_question (id, recruitment_id, category, type, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
 VALUES ('분석2', 1, '분석', 'TEXT', '본인이 진행했던 [머신러닝 / 딥러닝 / 데이터분석] 관련 프로젝트를 소개.. (700자 이내)', null, 700, 11, true, NOW(), NOW());
+
+-- applicant 임시 데이터
+INSERT INTO applicants (recruitment_id, track, name, email, phone, university, major, minor_double_major, last_semester, military_status, birth_date, graduation_date, grad_school_plan, created_at, updated_at)
+VALUES (1, '엔지니어링', '테스트1', 'string@example', '01012345678', 'university', 'major', '["minor_double_major"]', 7, '필_또는_면제', '2002-01-01', '2026-08', false, '2026-03-14 22:19:27', '2026-03-14 22:19:27');
+
+INSERT INTO applicants (recruitment_id, track, name, email, phone, university, major, minor_double_major, last_semester, military_status, birth_date, graduation_date, grad_school_plan, created_at, updated_at)
+VALUES (1, '엔지니어링', '테스트1', 'string@example', '01012345678', 'university', 'major', '["minor_double_major"]', 7, '필_또는_면제', '2002-01-01', '2026-08', false, '2026-03-14 22:38:15', '2026-03-14 22:38:15');
+
+INSERT INTO applicants (recruitment_id, track, name, email, phone, university, major, minor_double_major, last_semester, military_status, birth_date, graduation_date, grad_school_plan, created_at, updated_at)
+VALUES (1, '분석', '테스트2', 'string22@example', '01012345688', 'university', 'major', '["minor_double_major"]', 7, '필_또는_면제', '2002-01-01', '2026-08', false, '2026-03-14 22:21:18', '2026-03-14 22:21:18');
+
+INSERT INTO applicants (recruitment_id, track, name, email, phone, university, major, minor_double_major, last_semester, military_status, birth_date, graduation_date, grad_school_plan, created_at, updated_at)
+VALUES (1, '시각화', '테스트3', 'string33@example', '01012345622', 'university', 'major', '["minor_double_major"]', 7, '필_또는_면제', '2002-01-01', '2026-08', false, '2026-03-14 22:21:58', '2026-03-14 22:21:58');
+
+-- applicant_answer 임시 데이터 (테스트1 첫 번째 제출 - id: 1)
+INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
+VALUES (1, '공통1', '공통1답변', null, '2026-03-14 22:19:27', '2026-03-14 22:19:27');
+
+INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
+VALUES (1, '공통2', '공통2답변', null, '2026-03-14 22:19:27', '2026-03-14 22:19:27');
+
+INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
+VALUES (1, '엔지니어링1', null, '{"데이터베이스": "경험 없음", "서버 및 클라우드 서비스": "경험 없음"}', '2026-03-14 22:19:27', '2026-03-14 22:19:27');
+
+INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
+VALUES (1, '엔지니어링2', '엔지2답변', null, '2026-03-14 22:19:27', '2026-03-14 22:19:27');
+
+INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
+VALUES (1, '공통5', '공통5답변\nurl', null, '2026-03-14 22:19:27', '2026-03-14 22:19:27');
+
+-- applicant_answer 임시 데이터 (테스트1 두 번째 제출 - id: 2)
+INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
+VALUES (2, '공통1', '공통1답변11111', null, '2026-03-14 22:38:15', '2026-03-14 22:38:15');
+
+INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
+VALUES (2, '공통2', '공통2답변22222', null, '2026-03-14 22:38:15', '2026-03-14 22:38:15');
+
+INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
+VALUES (2, '엔지니어링1', null, '{"데이터베이스": "경험 없음", "서버 및 클라우드 서비스": "경험 없음"}', '2026-03-14 22:38:15', '2026-03-14 22:38:15');
+
+INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
+VALUES (2, '엔지니어링2', '엔지2답변2222', null, '2026-03-14 22:38:15', '2026-03-14 22:38:15');
+
+INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
+VALUES (2, '공통5', '공통5답변5555\nurl', null, '2026-03-14 22:38:15', '2026-03-14 22:38:15');
+
+-- applicant_answer 임시 데이터 (테스트2 분석 - id: 3)
+INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
+VALUES (3, '공통1', '공통1답변', null, NOW(), NOW());
+
+INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
+VALUES (3, '공통2', '공통2답변', null, NOW(), NOW());
+
+INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
+VALUES (3, '분석1', '분석1답변', null, NOW(), NOW());
+
+INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
+VALUES (3, '분석2', '분석2답변', null, NOW(), NOW());
+
+INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
+VALUES (3, '공통5', '공통5답변\nurl', null, NOW(), NOW());
+
+-- applicant_answer 임시 데이터 (테스트3 시각화 - id: 4)
+INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
+VALUES (4, '공통1', '공통1답변', null, NOW(), NOW());
+
+INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
+VALUES (4, '공통2', '공통2답변', null, NOW(), NOW());
+
+INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
+VALUES (4, '시각화1', null, '{"Python": "경험 없음", "Tableau": "경험 없음"}', NOW(), NOW());
+
+INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
+VALUES (4, '시각화2', '시각화2답변', null, NOW(), NOW());
+
+INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
+VALUES (4, '공통5', '공통5답변\nurl', null, NOW(), NOW());


### PR DESCRIPTION
## 💡 개요
* Issue Number: #8

## 🪐 주요 변경 사항
- AWS S3 연동 설정 추가
- 지원서 CSV 파일 생성 및 S3 업로드 API 구현 (`POST /api/v1/admin/recruitment/applications/download`)
- 지원자 임시 데이터 추가

## ✅ 상세 내용
- `build.gradle`에 AWS Spring Cloud S3 의존성 추가
- `S3Config` 구현 (로컬: 액세스 키 인증 / EC2 배포 시: IAM Role 자동 인증)
  - 액세스 키와 시크릿 키 중 하나만 설정된 경우 서버 시작 시점에 fail-fast 처리
- `S3Service` 구현 (CSV 파일 S3 업로드)
- `CsvService` 구현 (지원자 데이터 → CSV 바이트 배열 변환)
  - UTF-8 BOM 적용
  - CSV Formula Injection 방어 로직 추가 (`=`, `+`, `-`, `@` 시작 값 앞에 `'` 접두사 추가)
  - nullable 필드 null-safe 처리 (`track`, `lastSemester`, `militaryStatus`, `birthDate`, `graduationDate`, `gradSchoolPlan`)
- `AdminController` 추가 (`/api/v1/admin`) 및 API Key 기반 접근 제어 적용
- `ApplicantRepository`에 중복 제출 처리 쿼리 추가 (이메일 기준 최신 제출만 조회, 부문 무관)
- `ApplicantAnswerRepository`에 `findByApplicantIds()` 추가
- `RecruitmentService`에 `downloadApplications()` 메서드 추가
- `ErrorCode`에 `S3_UPLOAD_FAILED`, `UNAUTHORIZED` 추가
- `data.sql`에 지원자 및 답변 임시 데이터 추가 (중복 제출 테스트 케이스 포함)

## 🔔 참고 사항
- HTTP 메서드를 GET → POST로 변경 (S3 객체 생성 작업이므로)
- 부문별 CSV 파일 3개 생성 (시각화, 분석, 엔지니어링)
- S3 저장 경로: `{term}/applicants_{track}_{timestamp}.csv`
- 지원자가 없는 경우 헤더만 포함된 CSV 파일 생성
- 로컬 테스트 시 `AWS_ACCESS_KEY`, `AWS_SECRET_KEY`, `S3_BUCKET_NAME`, `ADMIN_API_KEY` 환경변수 설정 필요
- 관리자 인증은 현재 API Key 방식으로 임시 적용, 데모 이후 Spring Security + JWT로 전환 예정
- EC2 배포 후 IAM Role로 전환 시 `application.yml` 분리 리팩토링 예정
---
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 지원서 파일 생성 API 구현

**변경 목적**: 
AWS S3을 활용하여 지원서 데이터를 CSV 형식으로 자동 생성·업로드하는 관리자 API를 구현합니다. 부문별(시각화, 분석, 엔지니어링) CSV 파일을 생성하여 지원자 정보를 효율적으로 관리하고 내려받을 수 있도록 지원합니다.

**주요 변경 내용**:

**빌드 및 설정**
- AWS Spring Cloud S3 의존성 추가 (`io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1`)
- S3 클라이언트 설정 (S3Config): 로컬 환경은 액세스 키 인증, 배포 후 IAM Role로 전환 예정
- application.yml에 AWS S3 버킷, 리전, 자격증명 설정 추가

**저장소 계층 (Repository)**
- `ApplicantRepository.findLatestByRecruitmentIdAndTrack()`: 이메일별 최신 지원자만 조회 (중복 제출 처리)
- `ApplicantAnswerRepository.findByApplicantIds()`: 지원자 ID 목록으로 답변 조회

**서비스 계층 (Service)**
- `CsvService`: 지원자 데이터를 UTF-8 BOM이 적용된 CSV 바이트 배열로 변환
  - 공통 및 부문별 질문에 대한 답변을 행으로 포함
  - JSON 형식 답변(중복전공 등) 파싱 및 포매팅 처리
- `S3Service`: CSV 파일을 S3에 업로드 (에러 발생 시 `S3_UPLOAD_FAILED` 예외 처리)
- `RecruitmentService.downloadApplications()`: 부문별 CSV 생성 및 업로드 오케스트레이션
  - 저장 경로: `{term}/applicants_{track}_{timestamp}.csv`
  - 지원자 없을 경우 헤더만 포함된 CSV 생성

**API 계층**
- `AdminController`: `POST /api/v1/admin/recruitment/applications/download` 엔드포인트 추가
  - 요청 파라미터: `term` (Integer)

**예외 처리**
- `ErrorCode.S3_UPLOAD_FAILED` 추가 (HTTP 500, "파일 업로드 중 오류가 발생했습니다.")

**테스트 데이터**
- data.sql에 중복 제출 테스트용 지원자(applicants) 및 답변(applicant_answer) 데이터 추가

**영향 범위**:
- **API 변경**: 새로운 admin 다운로드 엔드포인트 추가
- **설정 변경**: 환경변수 필수 (`AWS_ACCESS_KEY`, `AWS_SECRET_KEY`, `S3_BUCKET_NAME`)
- **DB 스키마 변경**: 없음 (기존 테이블 활용)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->