### PR TITLE
feat : Review-All & Personal

### DIFF
--- a/src/main/java/com/boaz/backend/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/boaz/backend/domain/review/controller/ReviewController.java
@@ -1,0 +1,33 @@
+package com.boaz.backend.domain.review.controller;
+
+import com.boaz.backend.domain.review.dto.ReviewResponse;
+import com.boaz.backend.domain.review.service.ReviewService;
+import com.boaz.backend.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/reviews")
+@Tag(name = "Review", description = "후기 API")
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @GetMapping
+    @Operation(summary = "후기 전체 조회", description = "트랙/기수 필터링 가능. 기본 정렬은 기수 내림차순.")
+    public ResponseEntity<ApiResponse<List<ReviewResponse>>> getReviews(
+            @RequestParam(required = false) String track,
+            @RequestParam(required = false) Integer term) {
+        return ResponseEntity.ok(ApiResponse.ok(reviewService.getReviews(track, term)));
+    }
+}
+

--- a/src/main/java/com/boaz/backend/domain/review/dto/ReviewResponse.java
+++ b/src/main/java/com/boaz/backend/domain/review/dto/ReviewResponse.java
@@ -1,0 +1,38 @@
+package com.boaz.backend.domain.review.dto;
+
+import com.boaz.backend.domain.review.entity.Review;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class ReviewResponse {
+
+    private final Long id;
+    private final String name;
+    private final String track;
+    private final Integer term;
+    private final String content;
+
+    @JsonProperty("image_url")
+    private final String imageUrl;
+
+    private ReviewResponse(Long id, String name, String track, Integer term, String content, String imageUrl) {
+        this.id = id;
+        this.name = name;
+        this.track = track;
+        this.term = term;
+        this.content = content;
+        this.imageUrl = imageUrl;
+    }
+
+    public static ReviewResponse from(Review review) {
+        return new ReviewResponse(
+                review.getId(),
+                review.getName(),
+                review.getTrack().name(),
+                review.getTerm(),
+                review.getContent(),
+                review.getImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/boaz/backend/domain/review/entity/Review.java
+++ b/src/main/java/com/boaz/backend/domain/review/entity/Review.java
@@ -1,0 +1,31 @@
+package com.boaz.backend.domain.review.entity;
+
+import com.boaz.backend.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "review")
+public class Review extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private Track track;
+
+    private Integer term;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    private String imageUrl;
+
+    public enum Track {
+      VISUALIZATION, ANALYSIS, ENGINEERING
+     }
+}

--- a/src/main/java/com/boaz/backend/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/boaz/backend/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,17 @@
+package com.boaz.backend.domain.review.repository;
+
+import com.boaz.backend.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    List<Review> findAllByOrderByTermDesc();
+
+    List<Review> findAllByTrackOrderByTermDesc(Review.Track track);
+
+    List<Review> findAllByTermOrderByTermDesc(Integer term);
+
+    List<Review> findAllByTrackAndTermOrderByTermDesc(Review.Track track, Integer term);
+}

--- a/src/main/java/com/boaz/backend/domain/review/service/ReviewService.java
+++ b/src/main/java/com/boaz/backend/domain/review/service/ReviewService.java
@@ -1,0 +1,38 @@
+package com.boaz.backend.domain.review.service;
+
+import com.boaz.backend.domain.review.dto.ReviewResponse;
+import com.boaz.backend.domain.review.entity.Review;
+import com.boaz.backend.domain.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+
+    public List<ReviewResponse> getReviews(String track, Integer term) {
+        List<Review> reviews;
+
+        if (track != null && term != null) {
+            reviews = reviewRepository.findAllByTrackAndTermOrderByTermDesc(
+                    Review.Track.valueOf(track), term);
+        } else if (track != null) {
+            reviews = reviewRepository.findAllByTrackOrderByTermDesc(
+                    Review.Track.valueOf(track));
+        } else if (term != null) {
+            reviews = reviewRepository.findAllByTermOrderByTermDesc(term);
+        } else {
+            reviews = reviewRepository.findAllByOrderByTermDesc();
+        }
+
+        return reviews.stream()
+                .map(ReviewResponse::from)
+                .toList();
+    }
+}


### PR DESCRIPTION
## 💡 개요
* Issue Number: #21 

## 🪐 주요 변경 사항
- 수료자 후기 전체 조회 API 추가 (GET /api/v1/reviews)

## ✅ 상세 내용
- Review 엔티티 추가 (id, name, track, term, content, image_url)
- Track ENUM 추가 (VISUALIZATION, ANALYSIS, ENGINEERING)
- track, term 쿼리 파라미터로 필터링 지원
- 기본 정렬 기수(term) 내림차순
- 후기 없을 경우 404가 아닌 빈 배열 반환
- ReviewRepository, ReviewService, ReviewController, ReviewResponse DTO 추가

## 🔔 참고 사항
- track 다중 선택 필터링은 추후 협의 후 구현 예정
- content 전문 반환 vs preview 반환 여부는 프론트와 협의 필요
- 페이지네이션은 후기 수 증가 시 별도 이슈로 분리 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 변경 목적
Graduate 리뷰를 조회하기 위한 새로운 REST API 엔드포인트를 추가하고, 이를 지원하는 엔티티, 레포지토리, 서비스 계층을 구현합니다. Track과 Term에 따른 필터링을 지원합니다.

## 주요 변경 내용
- **Entity**: Review 엔티티 추가 (id, name, track, term, content, imageUrl)
  - Track enum 내포 (VISUALIZATION, ANALYSIS, ENGINEERING)
- **Repository**: ReviewRepository 인터페이스 추가
  - 4가지 쿼리 메서드 (조건 없음, track만, term만, track+term 필터링)
  - 모두 term 내림차순 정렬
- **Service**: ReviewService 추가
  - getReviews(String track, Integer term) 메서드로 필터링 조건에 따라 적절한 레포지토리 메서드 호출
  - 결과를 ReviewResponse로 매핑
- **DTO**: ReviewResponse 추가
  - Review 엔티티를 API 응답 형식으로 변환하는 팩토리 메서드 포함
- **Controller**: ReviewController 추가
  - GET /api/v1/reviews 엔드포인트 구현
  - track(String)과 term(Integer) 쿼리 파라미터 지원

## 영향 범위
- **API 변경**: GET /api/v1/reviews 엔드포인트 추가 (선택적 track, term 필터링)
- **DB 스키마 변경**: "review" 테이블 신규 생성

<!-- end of auto-generated comment: release notes by coderabbit.ai -->