### PR TITLE
feat : Curriculum 도메인 기능 추가

### DIFF
--- a/src/main/java/com/boaz/backend/domain/curriculum/controller/CurriculumController.java
+++ b/src/main/java/com/boaz/backend/domain/curriculum/controller/CurriculumController.java
@@ -1,0 +1,31 @@
+package com.boaz.backend.domain.curriculum.controller;
+
+import com.boaz.backend.domain.curriculum.dto.CurriculumResponse;
+import com.boaz.backend.domain.curriculum.service.CurriculumService;
+import com.boaz.backend.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/curriculums")
+@Tag(name = "Curriculum", description = "커리큘럼 API")
+public class CurriculumController {
+
+    private final CurriculumService curriculumService;
+
+    @GetMapping
+    @Operation(summary = "커리큘럼 전체 조회", description = "트랙 필터링 가능. 미입력 시 전체 3개 트랙 반환.")
+    public ResponseEntity<ApiResponse<List<CurriculumResponse>>> getCurriculums(
+            @RequestParam(required = false) String track) {
+        return ResponseEntity.ok(ApiResponse.ok(curriculumService.getCurriculums(track)));
+    }
+}

--- a/src/main/java/com/boaz/backend/domain/curriculum/dto/CurriculumResponse.java
+++ b/src/main/java/com/boaz/backend/domain/curriculum/dto/CurriculumResponse.java
@@ -1,0 +1,31 @@
+package com.boaz.backend.domain.curriculum.dto;
+
+import com.boaz.backend.domain.curriculum.entity.Curriculum;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class CurriculumResponse {
+
+    private final Long id;
+    private final String track;
+
+    @JsonProperty("curriculum_steps")
+    private final List<CurriculumStepResponse> curriculumSteps;
+
+    private CurriculumResponse(Long id, String track, List<CurriculumStepResponse> curriculumSteps) {
+        this.id = id;
+        this.track = track;
+        this.curriculumSteps = curriculumSteps;
+    }
+
+    public static CurriculumResponse from(Curriculum curriculum, List<CurriculumStepResponse> steps) {
+        return new CurriculumResponse(
+                curriculum.getId(),
+                curriculum.getTrack().name(),
+                steps
+        );
+    }
+}

--- a/src/main/java/com/boaz/backend/domain/curriculum/dto/CurriculumStepResponse.java
+++ b/src/main/java/com/boaz/backend/domain/curriculum/dto/CurriculumStepResponse.java
@@ -1,0 +1,17 @@
+package com.boaz.backend.domain.curriculum.dto;
+
+import lombok.Getter;
+
+@Getter
+public class CurriculumStepResponse {
+
+    private final int step;
+    private final String title;
+    private final String desc;
+
+    public CurriculumStepResponse(int step, String title, String desc) {
+        this.step = step;
+        this.title = title;
+        this.desc = desc;
+    }
+}

--- a/src/main/java/com/boaz/backend/domain/curriculum/entity/Curriculum.java
+++ b/src/main/java/com/boaz/backend/domain/curriculum/entity/Curriculum.java
@@ -1,0 +1,25 @@
+package com.boaz.backend.domain.curriculum.entity;
+
+import com.boaz.backend.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "curriculum")
+public class Curriculum extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private Track track;
+
+    @Column(columnDefinition = "JSON")
+    private String curriculumSteps;
+
+    public enum Track {
+        ANALYSIS, VISUALIZATION, ENGINEERING
+    }
+}

--- a/src/main/java/com/boaz/backend/domain/curriculum/repository/CurriculumRepository.java
+++ b/src/main/java/com/boaz/backend/domain/curriculum/repository/CurriculumRepository.java
@@ -1,0 +1,14 @@
+package com.boaz.backend.domain.curriculum.repository;
+
+import com.boaz.backend.domain.curriculum.entity.Curriculum;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CurriculumRepository extends JpaRepository<Curriculum, Long> {
+
+    List<Curriculum> findAll();
+
+    Optional<Curriculum> findByTrack(Curriculum.Track track);
+}

--- a/src/main/java/com/boaz/backend/domain/curriculum/service/CurriculumService.java
+++ b/src/main/java/com/boaz/backend/domain/curriculum/service/CurriculumService.java
@@ -32,7 +32,7 @@ public class CurriculumService {
             try {
                 trackEnum = Curriculum.Track.valueOf(track.toUpperCase());
             } catch (IllegalArgumentException e) {
-                throw new CustomException(ErrorCode.INVALID_TRACK);
+                throw new CustomException(ErrorCode.CURRICULUM_NOT_FOUND);
             }
             curriculums = curriculumRepository.findByTrack(trackEnum)
                     .map(List::of)

--- a/src/main/java/com/boaz/backend/domain/curriculum/service/CurriculumService.java
+++ b/src/main/java/com/boaz/backend/domain/curriculum/service/CurriculumService.java
@@ -1,0 +1,65 @@
+package com.boaz.backend.domain.curriculum.service;
+
+import com.boaz.backend.domain.curriculum.dto.CurriculumResponse;
+import com.boaz.backend.domain.curriculum.dto.CurriculumStepResponse;
+import com.boaz.backend.domain.curriculum.entity.Curriculum;
+import com.boaz.backend.domain.curriculum.repository.CurriculumRepository;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CurriculumService {
+
+    private final CurriculumRepository curriculumRepository;
+    private final ObjectMapper objectMapper;
+
+    public List<CurriculumResponse> getCurriculums(String track) {
+        List<Curriculum> curriculums;
+
+        if (track != null) {
+            Curriculum.Track trackEnum;
+            try {
+                trackEnum = Curriculum.Track.valueOf(track.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                throw new CustomException(ErrorCode.INVALID_TRACK);
+            }
+            curriculums = curriculumRepository.findByTrack(trackEnum)
+                    .map(List::of)
+                    .orElse(List.of());
+        } else {
+            curriculums = curriculumRepository.findAll();
+        }
+
+        return curriculums.stream()
+                .map(c -> CurriculumResponse.from(c, parseSteps(c.getCurriculumSteps())))
+                .toList();
+    }
+
+    private List<CurriculumStepResponse> parseSteps(String json) {
+        if (json == null) return List.of();
+        try {
+            List<Map<String, Object>> raw = objectMapper.readValue(json, new TypeReference<>() {});
+            return raw.stream()
+                    .map(m -> new CurriculumStepResponse(
+                            (int) m.get("step"),
+                            (String) m.get("title"),
+                            (String) m.get("desc")
+                    ))
+                    .sorted(Comparator.comparingInt(CurriculumStepResponse::getStep))
+                    .toList();
+        } catch (Exception e) {
+            return List.of();
+        }
+    }
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/SubscriptionRequest.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/SubscriptionRequest.java
@@ -1,0 +1,13 @@
+package com.boaz.backend.domain.recruitment.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class SubscriptionRequest {
+
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "유효하지 않은 이메일 형식입니다.")
+    private String email;
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/SubscriptionResponse.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/SubscriptionResponse.java
@@ -1,0 +1,18 @@
+package com.boaz.backend.domain.recruitment.dto;
+
+import com.boaz.backend.domain.recruitment.entity.Subscription;
+import lombok.Getter;
+
+@Getter
+public class SubscriptionResponse {
+
+    private final String email;
+
+    private SubscriptionResponse(String email) {
+        this.email = email;
+    }
+
+    public static SubscriptionResponse from(Subscription subscription) {
+        return new SubscriptionResponse(subscription.getEmail());
+    }
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/entity/Subscription.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/entity/Subscription.java
@@ -1,0 +1,24 @@
+package com.boaz.backend.domain.recruitment.entity;
+
+import com.boaz.backend.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@Table(name = "subscription")
+public class Subscription extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    public Subscription(String email) {
+        this.email = email;
+    }
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/repository/SubscriptionRepository.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/repository/SubscriptionRepository.java
@@ -1,0 +1,9 @@
+package com.boaz.backend.domain.recruitment.repository;
+
+import com.boaz.backend.domain.recruitment.entity.Subscription;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
+
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/SubscriptionService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/SubscriptionService.java
@@ -1,0 +1,28 @@
+package com.boaz.backend.domain.recruitment.service;
+
+import com.boaz.backend.domain.recruitment.dto.SubscriptionRequest;
+import com.boaz.backend.domain.recruitment.dto.SubscriptionResponse;
+import com.boaz.backend.domain.recruitment.entity.Subscription;
+import com.boaz.backend.domain.recruitment.repository.SubscriptionRepository;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SubscriptionService {
+
+    private final SubscriptionRepository subscriptionRepository;
+
+    @Transactional
+    public SubscriptionResponse subscribe(SubscriptionRequest request) {
+        if (subscriptionRepository.existsByEmail(request.getEmail())) {
+            throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
+        }
+
+        Subscription subscription = new Subscription(request.getEmail());
+        return SubscriptionResponse.from(subscriptionRepository.save(subscription));
+    }
+}

--- a/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
@@ -16,7 +16,7 @@ public enum ErrorCode {
 
     // Curriculum
     CURRICULUM_NOT_FOUND(HttpStatus.NOT_FOUND, "CURRICULUM_NOT_FOUND", "해당 커리큘럼을 찾을 수 없습니다."),
-    INVALID_TRACK(HttpStatus.BAD_REQUEST, "INVALID_TRACK", "유효하지 않은 트랙입니다."),
+    
     // Review
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW_NOT_FOUND", "해당 후기를 찾을 수 없습니다."),
 

--- a/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
@@ -16,12 +16,16 @@ public enum ErrorCode {
 
     // Curriculum
     CURRICULUM_NOT_FOUND(HttpStatus.NOT_FOUND, "CURRICULUM_NOT_FOUND", "해당 커리큘럼을 찾을 수 없습니다."),
-
+    INVALID_TRACK(HttpStatus.BAD_REQUEST, "INVALID_TRACK", "유효하지 않은 트랙입니다."),
     // Review
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW_NOT_FOUND", "해당 후기를 찾을 수 없습니다."),
 
-    // FAQ
-    FAQ_NOT_FOUND(HttpStatus.NOT_FOUND, "FAQ_NOT_FOUND", "해당 FAQ를 찾을 수 없습니다.");
+     // FAQ
+    FAQ_NOT_FOUND(HttpStatus.NOT_FOUND, "FAQ_NOT_FOUND", "해당 FAQ를 찾을 수 없습니다."),
+
+    // Subscription
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "DUPLICATE_EMAIL", "이미 구독 신청된 이메일입니다."),
+    INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "INVALID_EMAIL_FORMAT", "유효하지 않은 이메일 형식입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## 💡 개요
* Issue Number: #24 

## 🪐 주요 변경 사항
- 커리큘럼 전체 조회 API 추가 (GET /api/v1/curriculums)

## ✅ 상세 내용
- Curriculum 엔티티 추가 (id, track, curriculum_steps, created_at, updated_at)
- Track ENUM 추가 (ANALYSIS, VISUALIZATION, ENGINEERING)
- curriculum_steps JSON 타입 파싱 및 step 오름차순 정렬 처리
- track 쿼리 파라미터로 단일 트랙 필터링 지원
- 미입력 시 전체 3개 트랙 반환
- 유효하지 않은 track 값 요청 시 400 CURRICULUM_NOT_FOUND 에러 반환
- CurriculumRepository, CurriculumService, CurriculumController, CurriculumResponse, CurriculumStepResponse DTO 추가

## 🔔 참고 사항
- INVALID_TRACK 에러코드는 추후 ErrorCode에 추가 후 교체 예정
- curriculum_steps JSON 타입으로 DB 마이그레이션 없이 step 수정 가능
- 트랙 데이터 누락 시 처리 방식 프론트와 협의 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**변경 목적:**
커리큘럼 조회 기능과 이메일 구독 기능을 추가하여 도메인 기능을 확장하고, 트랙 기반 필터링 및 중복 검증을 통해 클라이언트 요구를 지원합니다.

**주요 변경 내용:**

*Curriculum 도메인*
- Entity: `Curriculum` 추가 (id, track, curriculum_steps(JSON 문자열), created_at, updated_at)
  - Track enum 추가: ANALYSIS, VISUALIZATION, ENGINEERING
  - curriculum_steps JSON 파싱 및 step 오름차순 정렬 로직 포함(데이터는 JSON으로 보관되어 DB 마이그레이션 없이 편집 가능)
- Repository: `CurriculumRepository` 추가 (findAll, findByTrack)
- Service: `CurriculumService` 추가
  - `getCurriculums(String track)`로 단일 트랙 필터링 지원(파라미터 없으면 모든 트랙 반환)
  - 잘못된 track 값 입력 시 CustomException 발생(현재 CURRICULUM_NOT_FOUND 오류 사용; 구현상 INVALID_TRACK 플레이스홀더 존재)
  - JSON 파싱 실패나 null인 경우 빈 스텝 리스트 처리
- Controller: `CurriculumController` 추가 — GET /api/v1/curriculums (옵션: track 쿼리파라미터)
- DTO: `CurriculumResponse`, `CurriculumStepResponse` 추가

*Subscription 도메인 (Recruitment)*
- Entity: `Subscription` 추가 (id, email — unique)
- Repository: `SubscriptionRepository` 추가 (existsByEmail)
- Service: `SubscriptionService` 추가
  - `subscribe(SubscriptionRequest)`에서 중복 이메일 검증 후 저장, 중복이면 CustomException(DUPLICATE_EMAIL) 발생
- DTO: `SubscriptionRequest`, `SubscriptionResponse` 추가

*Global*
- ErrorCode에 `DUPLICATE_EMAIL`, `INVALID_EMAIL_FORMAT` 추가

**영향 범위:**
- API 변경: 신규 엔드포인트 GET /api/v1/curriculums 추가(선택적 track 쿼리 지원)
- DB 스키마 변경: `curriculum`, `subscription` 테이블(엔티티) 추가 필요
- 설정 변경: 없음 특별 표기 — 에러 코드(enum) 확장으로 예외 처리 영향 존재
<!-- end of auto-generated comment: release notes by coderabbit.ai -->