### PR TITLE
[Feat] 모집 공고 조회하기 API 응답에 타임라인(schedule) 추가

### DIFF
--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/RecruitmentResponse.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/RecruitmentResponse.java
@@ -1,7 +1,11 @@
 package com.boaz.backend.domain.recruitment.dto;
 
 import com.boaz.backend.domain.recruitment.entity.Recruitment;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.Getter;
 
@@ -14,13 +18,21 @@ public class RecruitmentResponse {
     private final Integer term;
     private final LocalDateTime startDate;
     private final LocalDateTime endDate;
+    private final JsonNode schedule;
     private final String brochureUrl;
     private final Boolean isActive;
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private RecruitmentResponse(Recruitment recruitment, boolean isActive) {
         this.term = recruitment.getTerm();
         this.startDate = recruitment.getStartDate();
         this.endDate = recruitment.getEndDate();
+        try {
+                this.schedule = objectMapper.readTree(recruitment.getSchedule());
+            } catch (Exception e) {
+                throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+            }
         this.brochureUrl = recruitment.getBrochureUrl();
         this.isActive = isActive;
     }
@@ -29,6 +41,7 @@ public class RecruitmentResponse {
         this.term = null;
         this.startDate = null;
         this.endDate = null;
+        this.schedule = null;
         this.brochureUrl = null;
         this.isActive = isActive;
     }

--- a/src/main/java/com/boaz/backend/domain/recruitment/entity/Recruitment.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/entity/Recruitment.java
@@ -23,6 +23,9 @@ public class Recruitment extends BaseEntity {
 
     @Column(nullable = false)
     private LocalDateTime endDate;
+    
+    @Column(columnDefinition = "JSON", nullable = false)
+    private String schedule;
 
     @Column(length = 255)
     private String brochureUrl;

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,9 +1,21 @@
 -- recruitment 임시 데이터
-INSERT INTO recruitment (id, term, start_date, end_date, brochure_url, created_at, updated_at)
-VALUES (1, 26, '2026-03-01 00:00:00', '2026-03-29 23:59:59', 'https://example.com/brochure.pdf', NOW(), NOW());
+INSERT INTO recruitment (id, term, start_date, end_date, schedule, brochure_url, created_at, updated_at)
+VALUES (1, 26, '2026-03-01 00:00:00', '2026-03-29 23:59:59', 
+'[
+  { "step": "서류 모집", "start": "2026-03-01", "end": "2026-03-29", "sequence": 1 },
+  { "step": "서류 합격 발표", "start": "2026-04-04", "end": "2026-04-04", "sequence": 2 },
+  { "step": "면접", "start": "2026-04-06", "end": "2026-04-07", "sequence": 3 },
+  { "step": "최종 합격 발표", "start": "2026-04-10", "end": "2026-04-10", "sequence": 4 }
+]', 'https://example.com/brochure.pdf', NOW(), NOW());
 
-INSERT INTO recruitment (id, term, start_date, end_date, brochure_url, created_at, updated_at)
-VALUES (2, 27, '2026-07-01 00:00:00', '2026-07-31 23:59:59', 'https://example.com/brochure.pdf', NOW(), NOW());
+INSERT INTO recruitment (id, term, start_date, end_date, schedule, brochure_url, created_at, updated_at)
+VALUES (2, 27, '2026-07-01 00:00:00', '2026-07-31 23:59:59', 
+'[
+  { "step": "서류 모집", "start": "2026-07-01", "end": "2026-07-31", "sequence": 1 },
+  { "step": "서류 합격 발표", "start": "2026-08-04", "end": "2026-08-04", "sequence": 2 },
+  { "step": "면접", "start": "2026-08-06", "end": "2026-08-07", "sequence": 3 },
+  { "step": "최종 합격 발표", "start": "2026-08-10", "end": "2026-08-10", "sequence": 4 }
+]', 'https://example.com/brochure.pdf', NOW(), NOW());
 
 -- application_question 임시 데이터
 INSERT INTO application_question (id, recruitment_id, category, type, content, metadata, limit_length, order_num, is_required, created_at, updated_at)


### PR DESCRIPTION
## 💡 개요

* Issue Number: #6 

## 🪐 주요 변경 사항
- 모집 공고 조회하기 API 응답으로 schedule 추가
- `data.sql` 에 recruitment schedule 데이터 추가

## ✅ 상세 내용
- `Recruitment` 엔티티에 `schedule` 필드 추가
- `RecruitmentResponse` DTO에 `schedule` 필드 추가
- `RecruitmentResponse` DTO에 `schedule` 필드 `objectMapper` 에러 시 예외 처리 추가

## 🔔 참고 사항
- X
---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**변경 목적**  
모집 공고 조회 API의 응답에 schedule(타임라인) 정보를 추가하여 모집 일정에 대한 단계별 일정 정보를 클라이언트에 제공합니다.

**주요 변경 내용**
- **Entity 레이어** (`Recruitment.java`): JSON 타입의 `schedule` 필드 추가 (nullable = false)
- **DTO 레이어** (`RecruitmentResponse.java`): `JsonNode` 타입의 `schedule` 필드 추가 및 ObjectMapper를 통한 파싱 시 예외 처리 추가
- **테스트 데이터** (`data.sql`): recruitment 테이블의 시드 데이터에 step, start, end, sequence를 포함한 schedule 정보 추가

**영향 범위**
- **API 변경**: 모집 공고 조회 응답 DTO에 schedule 필드 포함
- **DB 스키마 변경**: recruitment 테이블에 JSON 타입의 schedule 컬럼 추가 (NOT NULL)
- **테스트/데모 데이터**: data.sql을 통한 초기 schedule 데이터 포함

<!-- end of auto-generated comment: release notes by coderabbit.ai -->