### PR TITLE
Refactor : FAQ refactoring

### DIFF
--- a/src/main/java/com/boaz/backend/domain/faq/controller/FaqController.java
+++ b/src/main/java/com/boaz/backend/domain/faq/controller/FaqController.java
@@ -1,5 +1,5 @@
 package com.boaz.backend.domain.faq.controller;
-
+import com.boaz.backend.domain.faq.entity.Faq;
 import com.boaz.backend.domain.faq.dto.FaqResponse;
 import com.boaz.backend.domain.faq.service.FaqService;
 import com.boaz.backend.global.common.ApiResponse;
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
 
 import java.util.List;
 
@@ -25,7 +26,7 @@ public class FaqController {
     @GetMapping("/faqs")
     @Operation(summary = "FAQ 조회", description = "카테고리별 FAQ 목록을 order_num 오름차순으로 반환합니다.")
     public ResponseEntity<ApiResponse<List<FaqResponse>>> getFaqs(
-            @RequestParam String category) {
+            @RequestParam Faq.Category category) {
         return ResponseEntity.ok(ApiResponse.ok(faqService.getFaqs(category)));
     }
 }

--- a/src/main/java/com/boaz/backend/domain/faq/service/FaqService.java
+++ b/src/main/java/com/boaz/backend/domain/faq/service/FaqService.java
@@ -18,15 +18,8 @@ public class FaqService {
 
     private final FaqRepository faqRepository;
 
-    public List<FaqResponse> getFaqs(String category) {
-        Faq.Category categoryEnum;
-        try {
-            categoryEnum = Faq.Category.valueOf(category);
-        } catch (IllegalArgumentException e) {
-            throw new CustomException(ErrorCode.INVALID_PARAMETER);
-        }
-
-        return faqRepository.findAllByCategoryOrderByOrderNumAsc(categoryEnum)
+    public List<FaqResponse> getFaqs(Faq.Category category) {
+        return faqRepository.findAllByCategoryOrderByOrderNumAsc(category)
                 .stream()
                 .map(FaqResponse::from)
                 .toList();


### PR DESCRIPTION
## 💡 개요
* Issue Number: #37 

## 🪐 주요 변경 사항
- FAQ 조회 API category 파라미터 타입을 String에서 Enum으로 변경

## ✅ 상세 내용
- FaqController의 category 파라미터 타입 String → Faq.Category ENUM으로 변경
- FaqService에서 String → ENUM 변환 로직 및 try-catch 제거
- GlobalExceptionHandler의 MethodArgumentTypeMismatchException으로 유효하지 않은 category 값 처리 위임
- Service 레이어 단순화 및 예외 처리 책임 명확화

## 🔔 참고 사항
- 유효하지 않은 category 값은 Controller 진입 전 Spring이 자동으로 감지하여 GlobalExceptionHandler에서 처리
- 기존 INVALID_PARAMETER 예외 처리 코드 제거됨
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **변경 목적**: FAQ 조회 API의 category 파라미터를 String에서 Faq.Category enum으로 변경하여 타입 안전성을 개선하고, 유효하지 않은 category 값에 대한 예외 처리 책임을 명확히 함.

- **주요 변경 내용**:
  - **FaqController**: `getFaqs` 메서드의 category 파라미터 타입을 `String` → `Faq.Category`로 변경
  - **FaqService**: category 파라미터 타입을 `String` → `Faq.Category`로 변경하고, 문자열을 enum으로 변환하는 로직 및 관련 try-catch 블록 제거 (총 7줄 감소)

- **영향 범위**: **API 변경** - 클라이언트에서 전달하는 category 파라미터 형식이 변경되며, 유효하지 않은 값은 컨트롤러 진입 전 Spring에 의해 `MethodArgumentTypeMismatchException`으로 감지되어 GlobalExceptionHandler에서 처리됨

<!-- end of auto-generated comment: release notes by coderabbit.ai -->