### PR TITLE
Feat/#39 ci/cd pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,27 +35,38 @@ jobs:
             backend-0.0.1-SNAPSHOT.jar \
             ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/home/ubuntu/backend/build/libs/backend-0.0.1-SNAPSHOT.jar
 
-      - name: .env 파일 주입 및 서비스 재시작
+      - name: .env 파일 주입
+        run: |
+          # Secrets 값을 환경변수로 받아서 SSH로 전달 (heredoc 이스케이프 문제 방지)
+          ssh -i ~/.ssh/boaz.pem ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} "
+            cat > /home/ubuntu/backend/.env << EOF
+          DB_URL=$DB_URL
+          DB_USERNAME=$DB_USERNAME
+          DB_PASSWORD=$DB_PASSWORD
+          S3_BUCKET_NAME=$S3_BUCKET_NAME
+          ADMIN_API_KEY=$ADMIN_API_KEY
+          EOF
+          "
+        env:
+          DB_URL: ${{ secrets.DB_URL }}
+          DB_USERNAME: ${{ secrets.DB_USERNAME }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
+          ADMIN_API_KEY: ${{ secrets.ADMIN_API_KEY }}
+
+      - name: 서비스 재시작
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            cat > /home/ubuntu/backend/.env << 'ENVEOF'
-            DB_URL=${{ secrets.DB_URL }}
-            DB_USERNAME=${{ secrets.DB_USERNAME }}
-            DB_PASSWORD=${{ secrets.DB_PASSWORD }}
-            S3_BUCKET_NAME=${{ secrets.S3_BUCKET_NAME }}
-            ADMIN_API_KEY=${{ secrets.ADMIN_API_KEY }}
-            ENVEOF
-
             sudo systemctl restart boaz.service
 
             sleep 5
             sudo systemctl is-active --quiet boaz.service \
               && echo "✅ 배포 성공" \
-              || (echo "❌ 배포 실패" && sudo journalctl -u boaz.service -n 50 && exit 1)
+              || (echo "❌ 배포 실패 — 로그:" && sudo journalctl -u boaz.service -n 50 && exit 1)
 
       - name: 헬스체크
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,96 @@
+name: CD
+
+on:
+  # CI 워크플로우 완료 후 자동 트리거 (dev 브랜치 push 시에만)
+  workflow_run:
+    workflows: [ "CI" ]
+    types: [ completed ]
+    branches: [ dev ]
+
+  # 수동 배포가 필요할 때 Actions 탭에서 실행
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Deploy to EC2
+    runs-on: ubuntu-latest
+
+    # CI가 실패했으면 배포 중단
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+
+    steps:
+      - name: CI에서 빌드된 JAR 다운로드
+        uses: actions/download-artifact@v4
+        with:
+          name: app-jar
+          # workflow_run 트리거일 때는 이전 워크플로우의 아티팩트를 가져와야 함
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # ── JAR을 EC2로 전송 ──────────────────────────────────────────────
+      - name: SSH 키 설정
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.EC2_SSH_KEY }}" > ~/.ssh/boaz.pem
+          chmod 600 ~/.ssh/boaz.pem
+          # EC2 호스트 키 사전 등록 (known_hosts 경고 방지)
+          ssh-keyscan -H ${{ secrets.EC2_HOST }} >> ~/.ssh/known_hosts
+
+      - name: JAR 파일 EC2로 전송 (scp)
+        run: |
+          scp -i ~/.ssh/boaz.pem \
+            backend-0.0.1-SNAPSHOT.jar \
+            ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/home/ubuntu/backend/build/libs/backend-0.0.1-SNAPSHOT.jar
+
+      # ── EC2에서 앱 재시작 ─────────────────────────────────────────────
+      - name: systemd 서비스 재시작
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            # 1. 기존 서비스 중단
+            sudo systemctl stop boaz.service
+
+            # 2. 새 JAR은 이미 scp로 전송 완료된 상태
+
+            # 3. 서비스 시작
+            sudo systemctl start boaz.service
+
+            # 4. 서비스 상태 확인 (실패 시 워크플로우 실패 처리)
+            sleep 5
+            sudo systemctl is-active --quiet boaz.service \
+              && echo "✅ 서비스 정상 실행 중" \
+              || (echo "❌ 서비스 시작 실패" && sudo journalctl -u boaz.service -n 30 && exit 1)
+
+      # ── 헬스체크 ─────────────────────────────────────────────────────
+      - name: 헬스체크 (Spring Actuator)
+        run: |
+          sleep 10   # 앱 기동 대기
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            https://dev.bigdataboaz.com/actuator/health \
+            --max-time 15 \
+            --retry 3 \
+            --retry-delay 5)
+
+          if [ "$STATUS" = "200" ]; then
+            echo "✅ 헬스체크 성공: HTTP $STATUS"
+          else
+            echo "❌ 헬스체크 실패: HTTP $STATUS"
+            exit 1
+          fi
+
+      # ── .env 환경변수 동기화 (필요 시 주석 해제) ─────────────────────
+      # .env 파일을 GitHub Secret에 통째로 저장해두고 배포 시 덮어쓰는 방식
+      # Secret 이름: ENV_FILE / 값: .env 파일 내용 전체
+      #
+      # - name: .env 파일 업데이트
+      #   uses: appleboy/ssh-action@v1
+      #   with:
+      #     host: ${{ secrets.EC2_HOST }}
+      #     username: ${{ secrets.EC2_USER }}
+      #     key: ${{ secrets.EC2_SSH_KEY }}
+      #     script: |
+      #       echo "${{ secrets.ENV_FILE }}" > /home/ubuntu/backend/.env
+      #       sudo systemctl restart boaz.service

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,92 +5,45 @@ on:
   workflow_run:
     workflows: [ "CI" ]
     types: [ completed ]
-    branches: [ dev ]
+    branches: [ dev , feat/#39-CI/CD-pipeline ]
 
   # 수동 배포가 필요할 때 Actions 탭에서 실행
   workflow_dispatch:
 
 jobs:
-  deploy:
-    name: Deploy to EC2
+  build:
+    name: Gradle Build
     runs-on: ubuntu-latest
-
-    # CI가 실패했으면 배포 중단
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
-
+ 
     steps:
-      - name: CI에서 빌드된 JAR 다운로드
-        uses: actions/download-artifact@v4
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+ 
+      - name: JDK 21 설정
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+ 
+      - name: Gradle 캐시 설정
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: gradle-
+ 
+      - name: Gradle 실행 권한 부여
+        run: chmod +x gradlew
+ 
+      - name: JAR 빌드 (테스트 스킵)
+        run: ./gradlew bootJar -x test
+ 
+      - name: 빌드된 JAR 아티팩트 업로드
+        uses: actions/upload-artifact@v4
         with:
           name: app-jar
-          # workflow_run 트리거일 때는 이전 워크플로우의 아티팩트를 가져와야 함
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      # ── JAR을 EC2로 전송 ──────────────────────────────────────────────
-      - name: SSH 키 설정
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.EC2_SSH_KEY }}" > ~/.ssh/boaz.pem
-          chmod 600 ~/.ssh/boaz.pem
-          # EC2 호스트 키 사전 등록 (known_hosts 경고 방지)
-          ssh-keyscan -H ${{ secrets.EC2_HOST }} >> ~/.ssh/known_hosts
-
-      - name: JAR 파일 EC2로 전송 (scp)
-        run: |
-          scp -i ~/.ssh/boaz.pem \
-            backend-0.0.1-SNAPSHOT.jar \
-            ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/home/ubuntu/backend/build/libs/backend-0.0.1-SNAPSHOT.jar
-
-      # ── EC2에서 앱 재시작 ─────────────────────────────────────────────
-      - name: systemd 서비스 재시작
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          script: |
-            # 1. 기존 서비스 중단
-            sudo systemctl stop boaz.service
-
-            # 2. 새 JAR은 이미 scp로 전송 완료된 상태
-
-            # 3. 서비스 시작
-            sudo systemctl start boaz.service
-
-            # 4. 서비스 상태 확인 (실패 시 워크플로우 실패 처리)
-            sleep 5
-            sudo systemctl is-active --quiet boaz.service \
-              && echo "✅ 서비스 정상 실행 중" \
-              || (echo "❌ 서비스 시작 실패" && sudo journalctl -u boaz.service -n 30 && exit 1)
-
-      # ── 헬스체크 ─────────────────────────────────────────────────────
-      - name: 헬스체크 (Spring Actuator)
-        run: |
-          sleep 10   # 앱 기동 대기
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-            https://dev.bigdataboaz.com/actuator/health \
-            --max-time 15 \
-            --retry 3 \
-            --retry-delay 5)
-
-          if [ "$STATUS" = "200" ]; then
-            echo "✅ 헬스체크 성공: HTTP $STATUS"
-          else
-            echo "❌ 헬스체크 실패: HTTP $STATUS"
-            exit 1
-          fi
-
-      # ── .env 환경변수 동기화 (필요 시 주석 해제) ─────────────────────
-      # .env 파일을 GitHub Secret에 통째로 저장해두고 배포 시 덮어쓰는 방식
-      # Secret 이름: ENV_FILE / 값: .env 파일 내용 전체
-      #
-      # - name: .env 파일 업데이트
-      #   uses: appleboy/ssh-action@v1
-      #   with:
-      #     host: ${{ secrets.EC2_HOST }}
-      #     username: ${{ secrets.EC2_USER }}
-      #     key: ${{ secrets.EC2_SSH_KEY }}
-      #     script: |
-      #       echo "${{ secrets.ENV_FILE }}" > /home/ubuntu/backend/.env
-      #       sudo systemctl restart boaz.service
+          path: build/libs/backend-0.0.1-SNAPSHOT.jar
+          retention-days: 1
+ 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,49 +1,71 @@
 name: CD
 
 on:
-  # CI 워크플로우 완료 후 자동 트리거 (dev 브랜치 push 시에만)
   workflow_run:
     workflows: [ "CI" ]
     types: [ completed ]
-    branches: [ dev , feat/#39-CI/CD-pipeline ]
+    branches: [ dev, feat/#39-CI/CD-pipeline ]
 
-  # 수동 배포가 필요할 때 Actions 탭에서 실행
   workflow_dispatch:
 
 jobs:
-  build:
-    name: Gradle Build
+  deploy:
+    name: Deploy to EC2
     runs-on: ubuntu-latest
- 
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+
     steps:
-      - name: 코드 체크아웃
-        uses: actions/checkout@v4
- 
-      - name: JDK 21 설정
-        uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'temurin'
- 
-      - name: Gradle 캐시 설정
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: gradle-
- 
-      - name: Gradle 실행 권한 부여
-        run: chmod +x gradlew
- 
-      - name: JAR 빌드 (테스트 스킵)
-        run: ./gradlew bootJar -x test
- 
-      - name: 빌드된 JAR 아티팩트 업로드
-        uses: actions/upload-artifact@v4
+      - name: CI에서 빌드된 JAR 다운로드
+        uses: actions/download-artifact@v4
         with:
           name: app-jar
-          path: build/libs/backend-0.0.1-SNAPSHOT.jar
-          retention-days: 1
- 
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: SSH 키 설정
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.EC2_SSH_KEY }}" > ~/.ssh/boaz.pem
+          chmod 600 ~/.ssh/boaz.pem
+          ssh-keyscan -H ${{ secrets.EC2_HOST }} >> ~/.ssh/known_hosts
+
+      - name: JAR 파일 EC2로 전송
+        run: |
+          scp -i ~/.ssh/boaz.pem \
+            backend-0.0.1-SNAPSHOT.jar \
+            ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/home/ubuntu/backend/build/libs/backend-0.0.1-SNAPSHOT.jar
+
+      - name: .env 파일 주입 및 서비스 재시작
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            cat > /home/ubuntu/backend/.env << 'ENVEOF'
+            DB_URL=${{ secrets.DB_URL }}
+            DB_USERNAME=${{ secrets.DB_USERNAME }}
+            DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+            S3_BUCKET_NAME=${{ secrets.S3_BUCKET_NAME }}
+            ADMIN_API_KEY=${{ secrets.ADMIN_API_KEY }}
+            ENVEOF
+
+            sudo systemctl restart boaz.service
+
+            sleep 5
+            sudo systemctl is-active --quiet boaz.service \
+              && echo "✅ 배포 성공" \
+              || (echo "❌ 배포 실패" && sudo journalctl -u boaz.service -n 50 && exit 1)
+
+      - name: 헬스체크
+        run: |
+          sleep 10
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            https://dev.bigdataboaz.com/actuator/health \
+            --max-time 15 --retry 3 --retry-delay 5)
+          if [ "$STATUS" = "200" ]; then
+            echo "✅ 헬스체크 성공: HTTP $STATUS"
+          else
+            echo "❌ 헬스체크 실패: HTTP $STATUS"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches: [ dev ]
+  pull_request:
+    branches: [ dev]
+
+jobs:
+  build:
+    name: Gradle Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: JDK 21 설정
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'          # 프로젝트 Java 버전에 맞게 수정
+          distribution: 'temurin'
+
+      - name: Gradle 캐시 설정
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: gradle-
+
+      - name: Gradle 실행 권한 부여
+        run: chmod +x gradlew
+
+      - name: 테스트 실행
+        run: ./gradlew test
+        env:
+          SPRING_PROFILES_ACTIVE: test
+          # 테스트 DB가 따로 있다면 아래 추가
+          # SPRING_DATASOURCE_URL: ${{ secrets.TEST_DB_URL }}
+          # SPRING_DATASOURCE_USERNAME: ${{ secrets.TEST_DB_USER }}
+          # SPRING_DATASOURCE_PASSWORD: ${{ secrets.TEST_DB_PASSWORD }}
+
+      - name: JAR 빌드 (테스트 스킵)
+        run: ./gradlew bootJar -x test
+
+      - name: 빌드된 JAR 아티팩트 업로드
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-jar
+          path: build/libs/backend-0.0.1-SNAPSHOT.jar
+          retention-days: 1           # CD 워크플로우에서 바로 사용하므로 1일

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,19 +8,19 @@ on:
 
 jobs:
   build:
-    name: Gradle Build & Test
+    name: Gradle Build
     runs-on: ubuntu-latest
-
+ 
     steps:
       - name: 코드 체크아웃
         uses: actions/checkout@v4
-
+ 
       - name: JDK 21 설정
         uses: actions/setup-java@v4
         with:
-          java-version: '21'          # 프로젝트 Java 버전에 맞게 수정
+          java-version: '21'
           distribution: 'temurin'
-
+ 
       - name: Gradle 캐시 설정
         uses: actions/cache@v4
         with:
@@ -29,25 +29,17 @@ jobs:
             ~/.gradle/wrapper
           key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: gradle-
-
+ 
       - name: Gradle 실행 권한 부여
         run: chmod +x gradlew
-
-      - name: 테스트 실행
-        run: ./gradlew test
-        env:
-          SPRING_PROFILES_ACTIVE: test
-          # 테스트 DB가 따로 있다면 아래 추가
-          # SPRING_DATASOURCE_URL: ${{ secrets.TEST_DB_URL }}
-          # SPRING_DATASOURCE_USERNAME: ${{ secrets.TEST_DB_USER }}
-          # SPRING_DATASOURCE_PASSWORD: ${{ secrets.TEST_DB_PASSWORD }}
-
+ 
       - name: JAR 빌드 (테스트 스킵)
         run: ./gradlew bootJar -x test
-
+ 
       - name: 빌드된 JAR 아티팩트 업로드
         uses: actions/upload-artifact@v4
         with:
           name: app-jar
           path: build/libs/backend-0.0.1-SNAPSHOT.jar
-          retention-days: 1           # CD 워크플로우에서 바로 사용하므로 1일
+          retention-days: 1
+ 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ dev ]
+    branches: [ dev , feat/#39-CI/CD-pipeline]
   pull_request:
-    branches: [ dev]
+    branches: [ dev , feat/#39-CI/CD-pipeline]
 
 jobs:
   build:


### PR DESCRIPTION
## 💡 개요
* Issue Number: #39

## 🪐 주요 변경 사항
- GitHub Actions 기반 CI/CD 파이프라인 구축
- CI: Gradle 빌드 자동화 (테스트 스킵, JAR 아티팩트 업로드)
- CD: EC2 자동 배포 (JAR 전송 → .env 주입 → systemd 재시작 → 헬스체크)

## ✅ 상세 내용
- `.github/workflows/ci.yml` 추가
  - `dev`, `feat/#39-CI/CD-pipeline` 브랜치 push/PR 시 트리거
  - JDK 21 + Gradle 캐시 설정으로 빌드 속도 최적화
  - `bootJar -x test` 로 JAR 빌드 후 아티팩트 업로드
- `.github/workflows/cd.yml` 추가
  - CI 성공 시 자동 트리거 (`workflow_run`)
  - SCP로 EC2에 JAR 전송
  - GitHub Secrets에서 환경변수를 EC2 `.env` 파일로 주입
  - `systemd restart` 후 서비스 상태 확인
  - `https://dev.bigdataboaz.com/actuator/health` 헬스체크로 배포 성공 검증
- GitHub Actions Secrets 등록
  - `EC2_HOST`, `EC2_USER`, `EC2_SSH_KEY`
  - `DB_URL`, `DB_USERNAME`, `DB_PASSWORD`
  - `S3_BUCKET_NAME`, `ADMIN_API_KEY`

## 🔔 참고 사항
- `workflow_run` 트리거 특성상 CD는 default 브랜치(`dev`)에 merge 후 활성화됨
- AWS 자격증명(`AWS_ACCESS_KEY`, `AWS_SECRET_KEY`)은 EC2에 IAM 역할(`boaz-ec2-s3-role`)이 연결되어 있어 Secrets 등록 불필요
- 현재 테스트는 CI에서 스킵 처리 (`-x test`), 추후 test 환경 구성 시 별도 개선 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 변경 목적
Issue #39를 해결하기 위해 GitHub Actions 기반의 자동화된 CI/CD 파이선을 도입하여 코드 빌드 및 EC2 배포 프로세스를 자동화합니다.

## 주요 변경 내용

- **`.github/workflows/ci.yml` 추가**
  - `dev` 및 `feat/#39-CI/CD-pipeline` 브랜치의 push/PR 트리거
  - JDK 21(Temurin) 설정 및 Gradle 캐시 최적화
  - `./gradlew bootJar -x test` 명령어로 JAR 빌드 (테스트 스킵)
  - 빌드된 JAR(`backend-0.0.1-SNAPSHOT.jar`)를 `app-jar` 아티팩트로 업로드 (1일 보관)

- **`.github/workflows/cd.yml` 추가**
  - CI 워크플로우 성공 시 자동 트리거 (`workflow_run` 방식)
  - EC2로의 배포 자동화: SCP를 통한 JAR 전송
  - GitHub Secrets 환경 변수를 EC2 `.env` 파일에 주입
  - `boaz.service` systemd 서비스 재시작
  - `/actuator/health` 엔드포인트 기반 배포 후 헬스 체크

## 영향 범위
**설정 변경**: GitHub Actions 워크플로우 및 배포 설정 추가 (API/DB 스키마 변경 없음)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->