### PR TITLE
Fix/#39 ci/cd pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,13 +70,15 @@ jobs:
 
       - name: 헬스체크
         run: |
-          sleep 10
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-            https://dev.bigdataboaz.com/actuator/health \
-            --max-time 15 --retry 3 --retry-delay 5)
-          if [ "$STATUS" = "200" ]; then
-            echo "✅ 헬스체크 성공: HTTP $STATUS"
-          else
-            echo "❌ 헬스체크 실패: HTTP $STATUS"
-            exit 1
-          fi
+          sleep 15
+          for i in 1 2 3 4 5; do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://dev.bigdataboaz.com/actuator/health)
+            echo "시도 $i: HTTP $STATUS"
+            if [ "$STATUS" = "200" ]; then
+              echo "✅ 헬스체크 성공"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "❌ 헬스체크 실패"
+          exit 1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,8 +61,8 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
+            sudo systemctl daemon-reload        # ← 이 줄 추가
             sudo systemctl restart boaz.service
-
             sleep 5
             sudo systemctl is-active --quiet boaz.service \
               && echo "✅ 배포 성공" \


### PR DESCRIPTION
## 💡 개요
* Issue Number: #39

## 🪐 주요 변경 사항
- CD 파이프라인 헬스체크 로직 수정
- systemd 서비스 재시작 전 daemon-reload 추가

## ✅ 상세 내용
- `cd.yml` 헬스체크 step 수정
  - 기존 `curl --retry` 옵션 제거 (exit code 23 오류 원인)
  - shell `for` 루프 기반 재시도 방식으로 교체 (최대 5회, 5초 간격)
- 서비스 재시작 script에 `sudo systemctl daemon-reload` 추가
  - unit 파일 변경 감지 경고(`Warning: The unit file changed on disk`) 해소

## 🔔 참고 사항
- `curl --retry` 옵션이 `-o /dev/null` 과 충돌하여 exit code 23 발생하는 버그 수정
- 헬스체크 대기 시간 sleep 10 → sleep 15 로 조정 (앱 기동 시간 확보)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**변경 목적:**
CI/CD 파이프라인에서 `curl --retry` 명령의 exit code 23 오류를 해결하고, 서비스 재시작 및 헬스 체크의 신뢰성을 개선하기 위한 수정사항입니다.

**주요 변경 내용:**
- **.github/workflows/cd.yml**
  - **서비스 재시작 단계**: `sudo systemctl daemon-reload` 추가 (서비스 재시작 전 daemon 설정 reload)
  - **헬스체크 단계**: 
    - 초기 대기 시간 증가: 10초 → 15초
    - 재시도 메커니즘 구현: `curl --retry` 제거 → `for` 루프 기반 5회 재시도 (5초 간격)
    - 각 시도마다 HTTP 상태 코드 로깅 (`echo "시도 $i: HTTP $STATUS"`)
    - 첫 번째 HTTP 200 응답 시 즉시 성공, 모든 시도 실패 시 exit code 1로 종료

**영향 범위:**
- 설정 변경 (워크플로우 YAML 설정만 수정, API/DB 스키마 변경 없음)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->