### PR TITLE
Feat/#19 archiving

### DIFF
--- a/src/main/java/com/boaz/backend/domain/archive/dto/ArchiveItemResponse.java
+++ b/src/main/java/com/boaz/backend/domain/archive/dto/ArchiveItemResponse.java
@@ -18,14 +18,13 @@ import java.time.LocalDate;
 
 @Getter
 @Builder
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @Slf4j
 public class ArchiveItemResponse {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private Long id;
-    private Integer term;   // 기술블로그일 경우 null이면 JSON에서 자동 제외
+    private Integer term;
     private String title;
     private String teamName;
     private Track track;

--- a/src/main/java/com/boaz/backend/domain/archive/entity/Archive.java
+++ b/src/main/java/com/boaz/backend/domain/archive/entity/Archive.java
@@ -21,7 +21,7 @@ public class Archive extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column
+    @Column(nullable = false)
     private Integer term;
 
     @Enumerated(EnumType.STRING)
@@ -31,20 +31,20 @@ public class Archive extends BaseEntity {
     @Column(nullable = false, length = 255)
     private String title;
 
-    @Column(name = "team_name", length = 100)
+    @Column(length = 100)
     private String teamName;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 50)
     private Track track;
 
-    @Column(name = "image_url", nullable = false, length = 255)
+    @Column(nullable = false, length = 255)
     private String imageUrl;
 
-    @Column(columnDefinition = "json")
+    @Column(nullable = false, columnDefinition = "json")
     private String links;
 
-    @Column(name = "content_date", nullable = false)
+    @Column(nullable = false)
     private LocalDate contentDate;
 
     @Builder

--- a/src/main/java/com/boaz/backend/domain/archive/service/ArchiveService.java
+++ b/src/main/java/com/boaz/backend/domain/archive/service/ArchiveService.java
@@ -36,6 +36,11 @@ public class ArchiveService {
         int size 
     ) {
         validatePagination(page, size);
+
+        if (term != null && term < 0) {
+            throw new CustomException(ErrorCode.INVALID_PARAMETER_TYPE);
+        }
+
         int zeroBasedPage = page - 1;   // 페이지 0기반으로 변환 
      
         String normalizedKeyword = normalizeKeyword(keyword);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -47,13 +47,13 @@ VALUES ('분석2', 1, '분석', 'TEXT', '본인이 진행했던 [머신러닝 / 
 
 -- archive 임시 데이터
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (1, 25, '프로젝트', '2024 BOAZ 컨퍼런스 추천시스템 발표', '자료연구팀', '분석', 'https://example.com/conf1.png', '{"slideshare":"https://slideshare.net/example1"}', '2024-08-10', NOW(), NOW());
+VALUES (1, 25, '프로젝트', '사용자 맞춤형 뭐뭐뭐뭐 추천시스템 발표', '자료연구팀', '분석', 'https://example.com/conf1.png', '{"slideshare":"https://slideshare.net/example1"}', '2024-08-10', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (2, 0, '프로젝트', '2024 BOAZ 컨퍼런스 우엥우엥우엥 발표', NULL, '분석', 'https://example.com/conf1.png', '{"slideshare":"https://slideshare.net/example1"}', '2024-08-10', NOW(), NOW());
+VALUES (2, 0, '프로젝트', '누구구구의 뭐뭐뭐뭐 오오오오우 발표', NULL, '분석', 'https://example.com/conf1.png', '{"slideshare":"https://slideshare.net/example1"}', '2024-08-10', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (3, 25, '프로젝트', '2024 BOAZ 데이터 파이프라인 발표', '자료연구팀', '엔지니어링', 'https://example.com/conf2.png', '{"slideshare":"https://slideshare.net/example2"}', '2024-08-10', NOW(), NOW());
+VALUES (3, 25, '프로젝트', '무엇무엇 데이터 파이프라인 발표', '자료연구팀', '엔지니어링', 'https://example.com/conf2.png', '{"slideshare":"https://slideshare.net/example2"}', '2024-08-10', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
 VALUES (4, 25, '기술블로그', 'Spring Boot 예외 처리 구조 정리', NULL, '엔지니어링', 'https://example.com/blog1.png', '{"medium":"https://medium.com/@boaz/example1"}', '2025-02-14', NOW(), NOW());
@@ -68,13 +68,13 @@ INSERT INTO archive (id, term, category, title, team_name, track, image_url, lin
 VALUES (7, 25, '활동사진', '25기 신입기수 OT', NULL, '전부문', 'https://example.com/activity2.png', '{"instagram":"https://instagram.com/p/example2"}', '2025-03-01', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (8, 26, '프로젝트', '2025 BOAZ 추천 시스템 고도화 발표', NULL, '엔지니어링', 'https://example.com/conf3.png', '{"slideshare":"https://slideshare.net/example3","github":"https://github.com/boaz/recommendation-system"}', '2025-08-12', NOW(), NOW());
+VALUES (8, 26, '프로젝트', '추천 시스템 고도화 땡땡 발표', NULL, '엔지니어링', 'https://example.com/conf3.png', '{"slideshare":"https://slideshare.net/example3","github":"https://github.com/boaz/recommendation-system"}', '2025-08-12', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (9, 26, '프로젝트', '2025 BOAZ 실시간 데이터 처리 시스템 발표', '데이터엔지니어링팀', '엔지니어링', 'https://example.com/conf4.png', '{"slideshare":"https://slideshare.net/example4","github":"https://github.com/boaz/stream-processing"}', '2025-08-18', NOW(), NOW());
+VALUES (9, 26, '프로젝트', '실시간 데이터 처리 뭐뭐뭐뭐 시스템 발표', '데이터엔지니어링팀', '엔지니어링', 'https://example.com/conf4.png', '{"slideshare":"https://slideshare.net/example4","github":"https://github.com/boaz/stream-processing"}', '2025-08-18', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (10, 26, '프로젝트', '2025 BOAZ 데이터 시각화 대시보드 발표', '데이터시각화팀', '시각화', 'https://example.com/conf5.png', '{"slideshare":"https://slideshare.net/example5","github":"https://github.com/boaz/dashboard-project"}', '2025-08-25', NOW(), NOW());
+VALUES (10, 26, '프로젝트', '데이터 시각화 대시보드 블라블라 발표', '데이터시각화팀', '시각화', 'https://example.com/conf5.png', '{"slideshare":"https://slideshare.net/example5","github":"https://github.com/boaz/dashboard-project"}', '2025-08-25', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
 VALUES (11, 26, '기술블로그', 'Kafka 기반 데이터 스트리밍 아키텍처 정리', NULL, '엔지니어링', 'https://example.com/blog3.png', '{"medium":"https://medium.com/@boaz/kafka-stream","github":"https://github.com/boaz/kafka-stream-example"}', '2025-03-01', NOW(), NOW());

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -50,46 +50,49 @@ INSERT INTO archive (id, term, category, title, team_name, track, image_url, lin
 VALUES (1, 25, '프로젝트', '2024 BOAZ 컨퍼런스 추천시스템 발표', '자료연구팀', '분석', 'https://example.com/conf1.png', '{"slideshare":"https://slideshare.net/example1"}', '2024-08-10', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (2, 25, '프로젝트', '2024 BOAZ 데이터 파이프라인 발표', '자료연구팀', '엔지니어링', 'https://example.com/conf2.png', '{"slideshare":"https://slideshare.net/example2"}', '2024-08-10', NOW(), NOW());
+VALUES (2, 0, '프로젝트', '2024 BOAZ 컨퍼런스 우엥우엥우엥 발표', NULL, '분석', 'https://example.com/conf1.png', '{"slideshare":"https://slideshare.net/example1"}', '2024-08-10', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (3, 25, '기술블로그', 'Spring Boot 예외 처리 구조 정리', '기술블로그', '엔지니어링', 'https://example.com/blog1.png', '{"medium":"https://medium.com/@boaz/example1"}', '2025-02-14', NOW(), NOW());
+VALUES (3, 25, '프로젝트', '2024 BOAZ 데이터 파이프라인 발표', '자료연구팀', '엔지니어링', 'https://example.com/conf2.png', '{"slideshare":"https://slideshare.net/example2"}', '2024-08-10', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (4, 25, '기술블로그', '데이터 분석 프로젝트 회고', '기술블로그', '분석', 'https://example.com/blog2.png', '{"medium":"https://medium.com/@boaz/example2"}', '2025-01-20', NOW(), NOW());
+VALUES (4, 25, '기술블로그', 'Spring Boot 예외 처리 구조 정리', NULL, '엔지니어링', 'https://example.com/blog1.png', '{"medium":"https://medium.com/@boaz/example1"}', '2025-02-14', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (5, 25, '활동사진', '250402 분석 7주차 Base세션', '분석팀', '분석', 'https://example.com/activity1.png', '{"instagram":"https://instagram.com/p/example1"}', '2025-04-02', NOW(), NOW());
+VALUES (5, 25, '기술블로그', '데이터 분석 프로젝트 회고', NULL, '분석', 'https://example.com/blog2.png', '{"medium":"https://medium.com/@boaz/example2"}', '2025-01-20', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (6, 25, '활동사진', '25기 신입기수 OT', 'BOAZ 운영팀', '전부문', 'https://example.com/activity2.png', '{"instagram":"https://instagram.com/p/example2"}', '2025-03-01', NOW(), NOW());
+VALUES (6, 25, '활동사진', '250402 분석 7주차 Base세션', NULL, '분석', 'https://example.com/activity1.png', '{"instagram":"https://instagram.com/p/example1"}', '2025-04-02', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (7, 26, '프로젝트', '2025 BOAZ 추천 시스템 고도화 발표', '추천시스템팀', '엔지니어링', 'https://example.com/conf3.png', '{"slideshare":"https://slideshare.net/example3","github":"https://github.com/boaz/recommendation-system"}', '2025-08-12', NOW(), NOW());
+VALUES (7, 25, '활동사진', '25기 신입기수 OT', NULL, '전부문', 'https://example.com/activity2.png', '{"instagram":"https://instagram.com/p/example2"}', '2025-03-01', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (8, 26, '프로젝트', '2025 BOAZ 실시간 데이터 처리 시스템 발표', '데이터엔지니어링팀', '엔지니어링', 'https://example.com/conf4.png', '{"slideshare":"https://slideshare.net/example4","github":"https://github.com/boaz/stream-processing"}', '2025-08-18', NOW(), NOW());
+VALUES (8, 26, '프로젝트', '2025 BOAZ 추천 시스템 고도화 발표', NULL, '엔지니어링', 'https://example.com/conf3.png', '{"slideshare":"https://slideshare.net/example3","github":"https://github.com/boaz/recommendation-system"}', '2025-08-12', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (9, 26, '프로젝트', '2025 BOAZ 데이터 시각화 대시보드 발표', '데이터시각화팀', '시각화', 'https://example.com/conf5.png', '{"slideshare":"https://slideshare.net/example5","github":"https://github.com/boaz/dashboard-project"}', '2025-08-25', NOW(), NOW());
+VALUES (9, 26, '프로젝트', '2025 BOAZ 실시간 데이터 처리 시스템 발표', '데이터엔지니어링팀', '엔지니어링', 'https://example.com/conf4.png', '{"slideshare":"https://slideshare.net/example4","github":"https://github.com/boaz/stream-processing"}', '2025-08-18', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (10, 26, '기술블로그', 'Kafka 기반 데이터 스트리밍 아키텍처 정리', '기술블로그', '엔지니어링', 'https://example.com/blog3.png', '{"medium":"https://medium.com/@boaz/kafka-stream","github":"https://github.com/boaz/kafka-stream-example"}', '2025-03-01', NOW(), NOW());
+VALUES (10, 26, '프로젝트', '2025 BOAZ 데이터 시각화 대시보드 발표', '데이터시각화팀', '시각화', 'https://example.com/conf5.png', '{"slideshare":"https://slideshare.net/example5","github":"https://github.com/boaz/dashboard-project"}', '2025-08-25', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (11, 26, '기술블로그', 'Spark 기반 대용량 데이터 처리 경험 정리', '기술블로그', '엔지니어링', 'https://example.com/blog4.png', '{"medium":"https://medium.com/@boaz/spark-processing","github":"https://github.com/boaz/spark-example"}', '2025-03-05', NOW(), NOW());
+VALUES (11, 26, '기술블로그', 'Kafka 기반 데이터 스트리밍 아키텍처 정리', NULL, '엔지니어링', 'https://example.com/blog3.png', '{"medium":"https://medium.com/@boaz/kafka-stream","github":"https://github.com/boaz/kafka-stream-example"}', '2025-03-01', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (12, 26, '기술블로그', '추천 시스템 협업 필터링 구현 과정', '기술블로그', '분석', 'https://example.com/blog5.png', '{"medium":"https://medium.com/@boaz/collaborative-filtering","github":"https://github.com/boaz/cf-recommendation"}', '2025-03-10', NOW(), NOW());
+VALUES (12, 26, '기술블로그', 'Spark 기반 대용량 데이터 처리 경험 정리', NULL, '엔지니어링', 'https://example.com/blog4.png', '{"medium":"https://medium.com/@boaz/spark-processing","github":"https://github.com/boaz/spark-example"}', '2025-03-05', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (13, 26, '활동사진', '26기 데이터 분석 스터디 세션', '분석팀', '분석', 'https://example.com/activity3.png', '{"instagram":"https://instagram.com/p/example3","youtube":"https://youtube.com/watch?v=analysis-session"}', '2025-04-05', NOW(), NOW());
+VALUES (13, 26, '기술블로그', '추천 시스템 협업 필터링 구현 과정', NULL, '분석', 'https://example.com/blog5.png', '{"medium":"https://medium.com/@boaz/collaborative-filtering","github":"https://github.com/boaz/cf-recommendation"}', '2025-03-10', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (14, 26, '활동사진', '26기 데이터 엔지니어링 워크샵', '데이터엔지니어링팀', '엔지니어링', 'https://example.com/activity4.png', '{"instagram":"https://instagram.com/p/example4","youtube":"https://youtube.com/watch?v=engineering-workshop"}', '2025-04-10', NOW(), NOW());
+VALUES (14, 26, '활동사진', '26기 데이터 분석 스터디 세션', NULL, '분석', 'https://example.com/activity3.png', '{"instagram":"https://instagram.com/p/example3","youtube":"https://youtube.com/watch?v=analysis-session"}', '2025-04-05', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (15, 26, '활동사진', '26기 데이터 시각화 세션', '데이터시각화팀', '시각화', 'https://example.com/activity5.png', '{"instagram":"https://instagram.com/p/example5","youtube":"https://youtube.com/watch?v=visualization-session"}', '2025-04-15', NOW(), NOW());
+VALUES (15, 26, '활동사진', '26기 데이터 엔지니어링 워크샵', NULL, '엔지니어링', 'https://example.com/activity4.png', '{"instagram":"https://instagram.com/p/example4","youtube":"https://youtube.com/watch?v=engineering-workshop"}', '2025-04-10', NOW(), NOW());
+
+INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
+VALUES (16, 26, '활동사진', '26기 데이터 시각화 세션', NULL, '시각화', 'https://example.com/activity5.png', '{"instagram":"https://instagram.com/p/example5","youtube":"https://youtube.com/watch?v=visualization-session"}', '2025-04-15', NOW(), NOW());
 -- applicant 임시 데이터
 INSERT INTO applicants (recruitment_id, track, name, email, phone, university, major, minor_double_major, last_semester, military_status, birth_date, graduation_date, grad_school_plan, created_at, updated_at)
 VALUES (1, '엔지니어링', '테스트1', 'string@example', '01012345678', 'university', 'major', '["minor_double_major"]', 7, '필_또는_면제', '2002-01-01', '2026-08', false, '2026-03-14 22:19:27', '2026-03-14 22:19:27');


### PR DESCRIPTION
## 💡 개요
프론트 협의 내용 반영 및 누락 사항 보완

* Issue Number: #33

## 🪐 주요 변경 사항
- Entity에 not null 조건 추가
- 응답 필드에 null 값 포함
- data.sql 실제 데이터 구조에 맞게 수정
- term 음수 입력 시 INVALID_PARAMETER_TYPE 예외 처리 추가

## ✅ 상세 내용
- teamName 필드만 nullable, 나머지 필드 @Column(nullable = false) 명시
- JSON 응답 시 null 필드도 포함되도록 수정
- term < 0 이면 CustomException(ErrorCode.INVALID_PARAMETER_TYPE) 반환

## 🔔 참고 사항
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **변경 목적**: 프론트엔드 협의사항 반영 및 데이터 무결성 강화 — 아카이빙 API 응답 포맷 보완(명시적 null 포함)과 엔티티 제약 강화, 음수 term 입력 방지로 입력 검증 보완.

- **주요 변경 내용**:
  - DTO 레이어 (ArchiveItemResponse)
    - 클래스 수준의 @JsonInclude(JsonInclude.Include.NON_NULL) 제거 → null 값도 JSON 응답에 포함되도록 변경
  - 엔티티 레이어 (Archive)
    - term, contentDate, links 필드에 @Column(nullable = false) 추가하여 NOT NULL 제약 적용
    - teamName은 여전히 nullable 유지
    - imageUrl 등 일부 컬럼 매핑/메타데이터 정리
  - 서비스 레이어 (ArchiveService)
    - searchArchives()에 term 검증 추가: term != null && term < 0 인 경우 CustomException(ErrorCode.INVALID_PARAMETER_TYPE) 발생
  - 시드 데이터 (src/main/resources/data.sql)
    - archive 임시 데이터 수정(기수/날짜/타이틀/팀명/링크 등 조정, id 1~16 범위에서 변경·추가)

- **영향 범위**:
  - API 변경: JSON 응답 포맷이 null 필드를 포함하도록 변경되어 클라이언트 수신/파싱 영향 가능
  - DB 스키마 변경: Archive 엔티티의 NOT NULL 제약으로 기존 null 데이터 삽입/마이그레이션 주의 필요
  - 입력 검증: term 파라미터에 대한 음수 입력 차단으로 잘못된 요청에 대해 400 계열 예외 발생 가능
<!-- end of auto-generated comment: release notes by coderabbit.ai -->