### PR TITLE
#43 docs : 예시 데이터 설명 추가

### DIFF
--- a/src/main/java/com/boaz/backend/domain/curriculum/dto/CurriculumResponse.java
+++ b/src/main/java/com/boaz/backend/domain/curriculum/dto/CurriculumResponse.java
@@ -2,6 +2,7 @@ package com.boaz.backend.domain.curriculum.dto;
 
 import com.boaz.backend.domain.curriculum.entity.Curriculum;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 import java.util.List;
@@ -9,10 +10,14 @@ import java.util.List;
 @Getter
 public class CurriculumResponse {
 
+    @Schema(description = "커리큘럼 ID", example = "1")
     private final Long id;
+
+    @Schema(description = "트랙", example = "ANALYSIS", allowableValues = {"ANALYSIS", "VISUALIZATION", "ENGINEERING"})
     private final String track;
 
     @JsonProperty("curriculum_steps")
+    @Schema(description = "커리큘럼 단계 목록")
     private final List<CurriculumStepResponse> curriculumSteps;
 
     private CurriculumResponse(Long id, String track, List<CurriculumStepResponse> curriculumSteps) {

--- a/src/main/java/com/boaz/backend/domain/curriculum/dto/CurriculumStepResponse.java
+++ b/src/main/java/com/boaz/backend/domain/curriculum/dto/CurriculumStepResponse.java
@@ -1,12 +1,18 @@
 package com.boaz.backend.domain.curriculum.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
 public class CurriculumStepResponse {
 
+    @Schema(description = "단계 번호", example = "1")
     private final int step;
+
+    @Schema(description = "단계 제목", example = "데이터 분석 기초")
     private final String title;
+
+    @Schema(description = "단계 설명", example = "통계 기초, 파이썬 기초")
     private final String desc;
 
     public CurriculumStepResponse(int step, String title, String desc) {

--- a/src/main/java/com/boaz/backend/domain/faq/dto/FaqResponse.java
+++ b/src/main/java/com/boaz/backend/domain/faq/dto/FaqResponse.java
@@ -2,17 +2,26 @@ package com.boaz.backend.domain.faq.dto;
 
 import com.boaz.backend.domain.faq.entity.Faq;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
 public class FaqResponse {
 
+    @Schema(description = "FAQ ID", example = "1")
     private final Long id;
+
+    @Schema(description = "질문", example = "BOAZ에 지원하려면 어떤 조건이 필요한가요?")
     private final String question;
+
+    @Schema(description = "답변", example = "학부생 및 대학원생이라면 누구나 지원 가능합니다. 전공 제한 없이 데이터에 관심 있는 분이라면 환영합니다.")
     private final String answer;
+
+    @Schema(description = "카테고리", example = "지원", allowableValues = {"지원", "활동", "기타"})
     private final String category;
 
     @JsonProperty("order_num")
+    @Schema(description = "정렬 순서", example = "1")
     private final Integer orderNum;
 
     private FaqResponse(Long id, String question, String answer, String category, Integer orderNum) {

--- a/src/main/java/com/boaz/backend/domain/review/dto/ReviewResponse.java
+++ b/src/main/java/com/boaz/backend/domain/review/dto/ReviewResponse.java
@@ -2,18 +2,29 @@ package com.boaz.backend.domain.review.dto;
 
 import com.boaz.backend.domain.review.entity.Review;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
 public class ReviewResponse {
 
+    @Schema(description = "후기 ID", example = "1")
     private final Long id;
+
+    @Schema(description = "작성자 이름", example = "김분석")
     private final String name;
+
+    @Schema(description = "트랙", example = "ANALYSIS", allowableValues = {"ANALYSIS", "VISUALIZATION", "ENGINEERING"})
     private final String track;
+
+    @Schema(description = "기수", example = "15")
     private final Integer term;
+
+    @Schema(description = "후기 내용", example = "BOAZ에서 데이터 분석을 공부하며 정말 많이 성장했습니다. 실전 프로젝트를 통해 이론으로만 알던 머신러닝을 직접 적용해볼 수 있어서 좋았어요.")
     private final String content;
 
     @JsonProperty("image_url")
+    @Schema(description = "프로필 이미지 URL", example = "https://example.com/images/review1.jpg", nullable = true)
     private final String imageUrl;
 
     private ReviewResponse(Long id, String name, String track, Integer term, String content, String imageUrl) {


### PR DESCRIPTION
## 💡 개요
* Issue Number: #43

## 🪐 주요 변경 사항
- Swagger Example Value 및 API 문서 설정 추가

## ✅ 상세 내용
- DTO 필드에 `@Schema(example = "...")` 어노테이션 추가


## 🔔 참고 사항
- springdoc-openapi 기반 Swagger UI 적용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**변경 목적**
Swagger/OpenAPI 문서에 예시 데이터와 필드 설명을 표시하기 위해 DTO 필드에 @Schema 애노테이션을 추가합니다. 이를 통해 API 클라이언트가 각 필드의 예상 값과 설명을 명확히 이해할 수 있습니다.

**주요 변경 내용**
- **CurriculumResponse**: `id`, `track`, `curriculumSteps` 필드에 @Schema 애노테이션 추가 (설명, 예시값, 허용값 포함)
- **CurriculumStepResponse**: `step`, `title`, `desc` 필드에 @Schema 애노테이션 추가 (설명, 예시값)
- **FaqResponse**: `id`, `question`, `answer`, `category`, `orderNum` 필드에 @Schema 애노테이션 추가 (설명, 예시값, 허용값)
- **ReviewResponse**: `id`, `name`, `track`, `term`, `content`, `imageUrl` 필드에 @Schema 애노테이션 추가 (설명, 예시값, nullable 표시)

**영향 범위**
- 문서화 개선만 해당 (Swagger UI 표시 향상)
- API 응답 구조, DB 스키마, 설정 변경 없음

<!-- end of auto-generated comment: release notes by coderabbit.ai -->