### PR TITLE
[Chore] data.sql TRUNCATE 구문 추가

### DIFF
--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,3 +1,21 @@
+-- 외래 키 체크 해제 (실행 오류 방지)
+SET FOREIGN_KEY_CHECKS = 0;
+
+-- 모든 테이블 초기화
+TRUNCATE recruitment;
+TRUNCATE application_question;
+TRUNCATE archive;
+TRUNCATE applicants;
+TRUNCATE applicant_answer;
+TRUNCATE curriculum;
+TRUNCATE faq;
+TRUNCATE review;
+
+-- 외래 키 체크 재활성화
+SET FOREIGN_KEY_CHECKS = 1;
+
+-- 임시 데이터
+
 -- recruitment 임시 데이터
 INSERT INTO recruitment (id, term, start_date, end_date, schedule, brochure_url, created_at, updated_at)
 VALUES (1, 26, '2026-03-01 00:00:00', '2026-03-29 23:59:59', 
@@ -89,19 +107,27 @@ INSERT INTO archive (id, term, category, title, team_name, track, image_url, lin
 VALUES (14, 26, '활동사진', '26기 데이터 엔지니어링 워크샵', '데이터엔지니어링팀', '엔지니어링', 'https://example.com/activity4.png', '{"instagram":"https://instagram.com/p/example4","youtube":"https://youtube.com/watch?v=engineering-workshop"}', '2025-04-10', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
+<<<<<<< Updated upstream
 VALUES (15, 26, '활동사진', '26기 데이터 시각화 세션', '데이터시각화팀', '시각화', 'https://example.com/activity5.png', '{"instagram":"https://instagram.com/p/example5","youtube":"https://youtube.com/watch?v=visualization-session"}', '2025-04-15', NOW(), NOW());
+=======
+VALUES (15, 26, '활동사진', '26기 데이터 엔지니어링 워크샵', NULL, '엔지니어링', 'https://example.com/activity4.png', '{"instagram":"https://instagram.com/p/example4","youtube":"https://youtube.com/watch?v=engineering-workshop"}', '2025-04-10', NOW(), NOW());
+
+INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
+VALUES (16, 26, '활동사진', '26기 데이터 시각화 세션', NULL, '시각화', 'https://example.com/activity5.png', '{"instagram":"https://instagram.com/p/example5","youtube":"https://youtube.com/watch?v=visualization-session"}', '2025-04-15', NOW(), NOW());
+
+>>>>>>> Stashed changes
 -- applicant 임시 데이터
-INSERT INTO applicants (recruitment_id, track, name, email, phone, university, major, minor_double_major, last_semester, military_status, birth_date, graduation_date, grad_school_plan, created_at, updated_at)
-VALUES (1, '엔지니어링', '테스트1', 'string@example', '01012345678', 'university', 'major', '["minor_double_major"]', 7, '필_또는_면제', '2002-01-01', '2026-08', false, '2026-03-14 22:19:27', '2026-03-14 22:19:27');
+INSERT INTO applicants (id, recruitment_id, track, name, email, phone, university, major, minor_double_major, last_semester, military_status, birth_date, graduation_date, grad_school_plan, created_at, updated_at)
+VALUES (1, 1, '엔지니어링', '테스트1', 'string@example', '01012345678', 'university', 'major', '["minor_double_major"]', 7, '필_또는_면제', '2002-01-01', '2026-08', false, '2026-03-14 22:19:27', '2026-03-14 22:19:27');
 
-INSERT INTO applicants (recruitment_id, track, name, email, phone, university, major, minor_double_major, last_semester, military_status, birth_date, graduation_date, grad_school_plan, created_at, updated_at)
-VALUES (1, '엔지니어링', '테스트1', 'string@example', '01012345678', 'university', 'major', '["minor_double_major"]', 7, '필_또는_면제', '2002-01-01', '2026-08', false, '2026-03-14 22:38:15', '2026-03-14 22:38:15');
+INSERT INTO applicants (id, recruitment_id, track, name, email, phone, university, major, minor_double_major, last_semester, military_status, birth_date, graduation_date, grad_school_plan, created_at, updated_at)
+VALUES (2, 1, '엔지니어링', '테스트1', 'string@example', '01012345678', 'university', 'major', '["minor_double_major"]', 7, '필_또는_면제', '2002-01-01', '2026-08', false, '2026-03-14 22:38:15', '2026-03-14 22:38:15');
 
-INSERT INTO applicants (recruitment_id, track, name, email, phone, university, major, minor_double_major, last_semester, military_status, birth_date, graduation_date, grad_school_plan, created_at, updated_at)
-VALUES (1, '분석', '테스트2', 'string22@example', '01012345688', 'university', 'major', '["minor_double_major"]', 7, '필_또는_면제', '2002-01-01', '2026-08', false, '2026-03-14 22:21:18', '2026-03-14 22:21:18');
+INSERT INTO applicants (id, recruitment_id, track, name, email, phone, university, major, minor_double_major, last_semester, military_status, birth_date, graduation_date, grad_school_plan, created_at, updated_at)
+VALUES (3, 1, '분석', '테스트2', 'string22@example', '01012345688', 'university', 'major', '["minor_double_major"]', 7, '필_또는_면제', '2002-01-01', '2026-08', false, '2026-03-14 22:21:18', '2026-03-14 22:21:18');
 
-INSERT INTO applicants (recruitment_id, track, name, email, phone, university, major, minor_double_major, last_semester, military_status, birth_date, graduation_date, grad_school_plan, created_at, updated_at)
-VALUES (1, '시각화', '테스트3', 'string33@example', '01012345622', 'university', 'major', '["minor_double_major"]', 7, '필_또는_면제', '2002-01-01', '2026-08', false, '2026-03-14 22:21:58', '2026-03-14 22:21:58');
+INSERT INTO applicants (id, recruitment_id, track, name, email, phone, university, major, minor_double_major, last_semester, military_status, birth_date, graduation_date, grad_school_plan, created_at, updated_at)
+VALUES (4, 1, '시각화', '테스트3', 'string33@example', '01012345622', 'university', 'major', '["minor_double_major"]', 7, '필_또는_면제', '2002-01-01', '2026-08', false, '2026-03-14 22:21:58', '2026-03-14 22:21:58');
 
 -- applicant_answer 임시 데이터 (테스트1 첫 번째 제출 - id: 1)
 INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)


### PR DESCRIPTION
## 💡 개요

* Issue Number: #34 

🪐 주요 변경 사항
- data.sql 상단에 TRUNCATE 구문 추가

✅ 상세 내용
- 데이터 재주입 시 기존 데이터와의 중복 충돌 방지를 위해 data.sql 상단에 TRUNCATE 구문 추가
- 외래 키 제약 조건으로 인한 TRUNCATE 실패 방지를 위해 SET FOREIGN_KEY_CHECKS = 0/1 구문으로 감쌈
- sql.init.mode: never 유지, 수동 실행 방식 그대로 사용

🔔 참고 사항
- 로컬 환경(ddl-auto: create)에서는 테이블이 새로 생성되므로 TRUNCATE 실행 시 영향 없음
- 데이터 재주입 시 아래 명령어로 수동 실행
    `mysql -h [RDS엔드포인트] -u [유저명] -p boaz < data.sql`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **변경 목적:** data.sql을 재실행할 때 기존 데이터와 충돌하거나 중복 삽입되는 문제를 방지하기 위해 초기 데이터 삽입 전에 기존 데이터를 비우도록 TRUNCATE 구문을 추가했습니다. 외래키 제약으로 인한 오류 방지를 위해 FOREIGN_KEY_CHECKS를 일시 비활성화/재활성화합니다.

- **주요 변경 내용:**
  - data.sql: 파일 상단에 `SET FOREIGN_KEY_CHECKS = 0;` → 여러 테이블 TRUNCATE(`recruitment`, `application_question`, `archive`, `applicants`, `applicant_answer`, `curriculum`, `faq`, `review`) → `SET FOREIGN_KEY_CHECKS = 1;` 추가
  - seed 데이터 변경:
    - `archive`에 id=16 신규 INSERT 추가
    - `applicants` INSERT 문을 id를 명시하는 형태로 변경하고 recruitment_id를 1로 통일(기존 반복 삽입을 id 명시 방식으로 정리, id=2,3,4 등 추가)
  - sql.init.mode는 `never`로 유지하여 수동 실행 방식 유지

- **영향 범위:** DB 초기 데이터(시드) 레이어만 변경됨. API 변경 없음. 스키마(DDL) 변경 없음.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->