### PR TITLE
[Feat] 트랙별 지원서 질문 content 동적 치환 기능 추가

### DIFF
--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/QuestionResponse.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/QuestionResponse.java
@@ -13,6 +13,8 @@ import lombok.Getter;
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class QuestionResponse {
+    
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private final String questionId;
     private final String category;
@@ -22,14 +24,24 @@ public class QuestionResponse {
     private final JsonNode metadata;
     private final Integer orderNum;
     private final Boolean isRequired;
-
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    
+    public static QuestionResponse from(ApplicationQuestion question) {
+        return new QuestionResponse(question);
+    }
+    
+    public static QuestionResponse from(ApplicationQuestion question, String content) {
+        return new QuestionResponse(question, content);
+    }
 
     private QuestionResponse(ApplicationQuestion question) {
+        this(question, question.getContent());
+    }
+    
+    private QuestionResponse(ApplicationQuestion question, String content) {
         this.questionId = question.getId();
         this.category = question.getCategory().name();
         this.type = question.getType().name();
-        this.content = question.getContent();
+        this.content = content;
         this.orderNum = question.getOrderNum();
         this.isRequired = question.getIsRequired();
 
@@ -47,9 +59,5 @@ public class QuestionResponse {
                 throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
             }
         }
-    }
-
-    public static QuestionResponse from(ApplicationQuestion question) {
-        return new QuestionResponse(question);
     }
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -118,8 +118,13 @@ public class RecruitmentService {
         }
 
         return questions.stream()
-                .map(QuestionResponse::from)
-                .toList();
+            .map(question -> {
+                String content = question.getContent() != null
+                        ? question.getContent().replace("{Track}", track.name())
+                        : null;
+                return QuestionResponse.from(question, content);
+            })
+            .toList();
     }
 
     // 지원서 제출하기


### PR DESCRIPTION
## 💡 개요

* Issue Number: #7 

## 🪐 주요 변경 사항
- 트랙별로 공통 질문의 content가 동적으로 치환되어 반환되도록 수정

## ✅ 상세 내용
- DB에 {Track} 플레이스홀더로 저장된 공통 질문 content를 요청한 트랙명으로 치환하여 반환
- 서비스 레이어에서 치환 처리 후 QuestionResponse.from(question, content) 호출
- QuestionResponse에 content를 파라미터로 받는 생성자 및 from() 오버로딩 추가
- 기존 생성자는 this(question, question.getContent())로 내부 위임하여 코드 중복 제거

## 🔔 참고 사항
- DB 저장 형식: BOAZ {Track} 부문에 지원한 동기를 서술해주세요.
- {Track} 플레이스홀더가 없는 질문은 기존 from(question) 그대로 사용
- 치환 로직은 서비스 레이어에 위치, DTO는 데이터 담는 역할만 유지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## PR 요약

**변경 목적:**
트랙별 모집 질문의 {Track} 플레이스홀더를 요청된 트랙명으로 동적 치환하여 사용자에게 맞춤형 질문 콘텐츠를 제공합니다.

**주요 변경 내용:**

- **서비스 레이어 (RecruitmentService.java)**
  - `getQuestions()` 메서드의 스트림 매핑 로직 수정
  - 질문 콘텐츠에서 `{Track}` 플레이스홀더를 `track.name()`으로 치환
  - null 콘텐츠에 대한 안전성 처리 추가
  - 수정된 콘텐츠를 `QuestionResponse.from(question, content)` 오버로드로 전달

- **DTO 레이어 (QuestionResponse.java)**
  - `from()` 메서드 오버로드 추가: `from(ApplicationQuestion)`, `from(ApplicationQuestion, String content)`
  - 새로운 private 생성자 추가: `(ApplicationQuestion question, String content)`
  - 기존 생성자를 새 생성자로 위임하여 중복 제거
  - `content` 매개변수로 유연한 콘텐츠 설정 지원

**영향 범위:**
- API 변경: 없음 (기존 엔드포인트 동작 유지)
- DB 스키마 변경: 없음
- 설정 변경: 없음

<!-- end of auto-generated comment: release notes by coderabbit.ai -->