### PR TITLE
[Chore] ENUM 영어로 통일

### DIFF
--- a/src/main/java/com/boaz/backend/domain/archive/controller/ArchiveController.java
+++ b/src/main/java/com/boaz/backend/domain/archive/controller/ArchiveController.java
@@ -27,14 +27,14 @@ public class ArchiveController {
     @Operation(summary = "프로젝트 아카이빙 목록 조회")
     @GetMapping("/projects")
     public ResponseEntity<ApiResponse<ArchivePageResponse>> getProjects(
-        @RequestParam(defaultValue = "전부문") Track track, 
+        @RequestParam(defaultValue = "ALL") Track track, 
         @RequestParam(required = false) Integer term, 
         @RequestParam(required = false) String keyword, 
         @RequestParam(defaultValue = "1") int page, 
         @RequestParam(defaultValue = "6") int size 
     ) {
         ArchivePageResponse response = archiveService.searchArchives(
-            ArchiveCategory.프로젝트, 
+            ArchiveCategory.PROJECT, 
             track, 
             term, 
             keyword, 
@@ -54,7 +54,7 @@ public class ArchiveController {
         @RequestParam(defaultValue = "6") int size
     ) {
         ArchivePageResponse response = archiveService.searchArchives(
-            ArchiveCategory.활동사진, 
+            ArchiveCategory.ACTIVITY, 
             null, 
             term, 
             keyword, 
@@ -68,13 +68,13 @@ public class ArchiveController {
     @Operation(summary = "기술 블로그 아카이빙 조회")
     @GetMapping("/blogs")
     public ResponseEntity<ApiResponse<ArchivePageResponse>> getBlogs(
-        @RequestParam(defaultValue = "전부문") Track track, 
+        @RequestParam(defaultValue = "ALL") Track track, 
         @RequestParam(required = false) String keyword, 
         @RequestParam(defaultValue = "1") int page, 
         @RequestParam(defaultValue = "6") int size 
     ) {
         ArchivePageResponse response = archiveService.searchArchives(
-            ArchiveCategory.기술블로그, 
+            ArchiveCategory.BLOG, 
             track, 
             null, 
             keyword, 

--- a/src/main/java/com/boaz/backend/domain/archive/entity/ArchiveCategory.java
+++ b/src/main/java/com/boaz/backend/domain/archive/entity/ArchiveCategory.java
@@ -1,5 +1,6 @@
 package com.boaz.backend.domain.archive.entity;
 
 public enum ArchiveCategory {
-    프로젝트, 기술블로그, 활동사진
+    // 프로젝트, 기술블로그, 활동사진
+    PROJECT, ACTIVITY, BLOG
 }

--- a/src/main/java/com/boaz/backend/domain/archive/service/ArchiveService.java
+++ b/src/main/java/com/boaz/backend/domain/archive/service/ArchiveService.java
@@ -46,7 +46,7 @@ public class ArchiveService {
         String normalizedKeyword = normalizeKeyword(keyword);
 
         // 전부문이면 track 조건을 아예 걸지 않도록 null 처리
-        Track effectiveTrack = (track == Track.전부문) ? null : track;
+        Track effectiveTrack = (track == Track.ALL) ? null : track;
 
         // Repository에 검색 조건과 페이징 정보를 전달해 DB 조회 수행 
         Page<Archive> archives = archiveRepository.searchArchives(

--- a/src/main/java/com/boaz/backend/domain/curriculum/controller/CurriculumController.java
+++ b/src/main/java/com/boaz/backend/domain/curriculum/controller/CurriculumController.java
@@ -3,6 +3,8 @@ package com.boaz.backend.domain.curriculum.controller;
 import com.boaz.backend.domain.curriculum.dto.CurriculumResponse;
 import com.boaz.backend.domain.curriculum.service.CurriculumService;
 import com.boaz.backend.global.common.ApiResponse;
+import com.boaz.backend.global.common.enums.Track;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +27,7 @@ public class CurriculumController {
     @GetMapping
     @Operation(summary = "커리큘럼 전체 조회", description = "트랙 필터링 가능. 미입력 시 전체 3개 트랙 반환.")
     public ResponseEntity<ApiResponse<List<CurriculumResponse>>> getCurriculums(
-            @RequestParam(required = false) String track) {
+            @RequestParam(required = false) Track track) {
         return ResponseEntity.ok(ApiResponse.ok(curriculumService.getCurriculums(track)));
     }
 }

--- a/src/main/java/com/boaz/backend/domain/curriculum/entity/Curriculum.java
+++ b/src/main/java/com/boaz/backend/domain/curriculum/entity/Curriculum.java
@@ -1,6 +1,8 @@
 package com.boaz.backend.domain.curriculum.entity;
 
 import com.boaz.backend.global.common.BaseEntity;
+import com.boaz.backend.global.common.enums.Track;
+
 import jakarta.persistence.*;
 import lombok.Getter;
 
@@ -18,8 +20,4 @@ public class Curriculum extends BaseEntity {
 
     @Column(columnDefinition = "JSON")
     private String curriculumSteps;
-
-    public enum Track {
-        ANALYSIS, VISUALIZATION, ENGINEERING
-    }
 }

--- a/src/main/java/com/boaz/backend/domain/curriculum/repository/CurriculumRepository.java
+++ b/src/main/java/com/boaz/backend/domain/curriculum/repository/CurriculumRepository.java
@@ -1,6 +1,8 @@
 package com.boaz.backend.domain.curriculum.repository;
 
 import com.boaz.backend.domain.curriculum.entity.Curriculum;
+import com.boaz.backend.global.common.enums.Track;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -10,5 +12,5 @@ public interface CurriculumRepository extends JpaRepository<Curriculum, Long> {
 
     List<Curriculum> findAll();
 
-    Optional<Curriculum> findByTrack(Curriculum.Track track);
+    Optional<Curriculum> findByTrack(Track track);
 }

--- a/src/main/java/com/boaz/backend/domain/curriculum/service/CurriculumService.java
+++ b/src/main/java/com/boaz/backend/domain/curriculum/service/CurriculumService.java
@@ -4,6 +4,7 @@ import com.boaz.backend.domain.curriculum.dto.CurriculumResponse;
 import com.boaz.backend.domain.curriculum.dto.CurriculumStepResponse;
 import com.boaz.backend.domain.curriculum.entity.Curriculum;
 import com.boaz.backend.domain.curriculum.repository.CurriculumRepository;
+import com.boaz.backend.global.common.enums.Track;
 import com.boaz.backend.global.exception.CustomException;
 import com.boaz.backend.global.exception.ErrorCode;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -24,17 +25,11 @@ public class CurriculumService {
     private final CurriculumRepository curriculumRepository;
     private final ObjectMapper objectMapper;
 
-    public List<CurriculumResponse> getCurriculums(String track) {
+    public List<CurriculumResponse> getCurriculums(Track track) {
         List<Curriculum> curriculums;
 
         if (track != null) {
-            Curriculum.Track trackEnum;
-            try {
-                trackEnum = Curriculum.Track.valueOf(track.toUpperCase());
-            } catch (IllegalArgumentException e) {
-                throw new CustomException(ErrorCode.CURRICULUM_NOT_FOUND);
-            }
-            curriculums = curriculumRepository.findByTrack(trackEnum)
+            curriculums = curriculumRepository.findByTrack(track)
                     .map(List::of)
                     .orElse(List.of());
         } else {

--- a/src/main/java/com/boaz/backend/domain/faq/dto/FaqResponse.java
+++ b/src/main/java/com/boaz/backend/domain/faq/dto/FaqResponse.java
@@ -17,7 +17,7 @@ public class FaqResponse {
     @Schema(description = "답변", example = "학부생 및 대학원생이라면 누구나 지원 가능합니다. 전공 제한 없이 데이터에 관심 있는 분이라면 환영합니다.")
     private final String answer;
 
-    @Schema(description = "카테고리", example = "지원", allowableValues = {"지원", "활동", "기타"})
+    @Schema(description = "카테고리", example = "지원", allowableValues = {"RECRUITMENT", "ACTIVITY", "ETC"})
     private final String category;
 
     @JsonProperty("order_num")

--- a/src/main/java/com/boaz/backend/domain/faq/entity/Faq.java
+++ b/src/main/java/com/boaz/backend/domain/faq/entity/Faq.java
@@ -27,6 +27,7 @@ public class Faq extends BaseEntity {
     private Integer orderNum;
 
     public enum Category {
-        지원, 활동, 기타
+        // 지원, 활동, 기타
+        RECRUITMENT, ACTIVITY, ETC
     }
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/entity/ApplicationQuestion.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/entity/ApplicationQuestion.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 public class ApplicationQuestion extends BaseEntity {
 
     @Id
-    @Column(length = 10)
+    @Column(length = 20)
     private String id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/boaz/backend/domain/recruitment/entity/MilitaryStatus.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/entity/MilitaryStatus.java
@@ -1,5 +1,6 @@
 package com.boaz.backend.domain.recruitment.entity;
 
 public enum MilitaryStatus {
-    필_또는_면제, 미필
+    // 필_또는_면제, 미필
+    COMPLETED_OR_EXEMPT, NOT_COMPLETED
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/entity/QuestionCategory.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/entity/QuestionCategory.java
@@ -1,5 +1,6 @@
 package com.boaz.backend.domain.recruitment.entity;
 
 public enum QuestionCategory {
-    공통, 시각화, 분석, 엔지니어링
+    //공통, 시각화, 분석, 엔지니어링
+    COMMON, ANALYSIS, VISUALIZATION, ENGINEERING
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -111,7 +111,7 @@ public class RecruitmentService {
 
         // 공통 + 해당 부문 질문 조회
         List<ApplicationQuestion> questions = applicationQuestionRepository
-                .findByRecruitmentIdAndCategories(recruitmentId, QuestionCategory.공통, trackCategory);
+                .findByRecruitmentIdAndCategories(recruitmentId, QuestionCategory.COMMON, trackCategory);
 
         if (questions.isEmpty()) {
             throw new CustomException(ErrorCode.QUESTIONS_NOT_FOUND);
@@ -166,7 +166,7 @@ public class RecruitmentService {
         List<ApplicationQuestion> questions = applicationQuestionRepository
                 .findByRecruitmentIdAndCategories(
                         request.getRecruitmentId(),
-                        QuestionCategory.공통,
+                        QuestionCategory.COMMON,
                         trackCategory
                 );
         if (questions.isEmpty()) {
@@ -326,7 +326,7 @@ public class RecruitmentService {
                 .format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
 
         // 부문별 CSV 생성 및 S3 업로드
-        for (Track track : List.of(Track.시각화, Track.분석, Track.엔지니어링)) {
+        for (Track track : List.of(Track.VISUALIZATION, Track.ANALYSIS, Track.ENGINEERING)) {
 
             // 해당 부문 지원자 조회
             List<Applicant> applicants = applicantRepository
@@ -336,7 +336,7 @@ public class RecruitmentService {
             List<ApplicationQuestion> questions = applicationQuestionRepository
                     .findByRecruitmentIdAndCategories(
                             recruitment.getId(),
-                            QuestionCategory.공통, 
+                            QuestionCategory.COMMON, 
                             QuestionCategory.valueOf(track.name())
                     );
 

--- a/src/main/java/com/boaz/backend/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/boaz/backend/domain/review/controller/ReviewController.java
@@ -3,6 +3,8 @@ package com.boaz.backend.domain.review.controller;
 import com.boaz.backend.domain.review.dto.ReviewResponse;
 import com.boaz.backend.domain.review.service.ReviewService;
 import com.boaz.backend.global.common.ApiResponse;
+import com.boaz.backend.global.common.enums.Track;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +27,7 @@ public class ReviewController {
     @GetMapping
     @Operation(summary = "후기 전체 조회", description = "트랙/기수 필터링 가능. 기본 정렬은 기수 내림차순.")
     public ResponseEntity<ApiResponse<List<ReviewResponse>>> getReviews(
-            @RequestParam(required = false) String track,
+            @RequestParam(required = false) Track track,
             @RequestParam(required = false) Integer term) {
         return ResponseEntity.ok(ApiResponse.ok(reviewService.getReviews(track, term)));
     }

--- a/src/main/java/com/boaz/backend/domain/review/entity/Review.java
+++ b/src/main/java/com/boaz/backend/domain/review/entity/Review.java
@@ -1,6 +1,8 @@
 package com.boaz.backend.domain.review.entity;
 
 import com.boaz.backend.global.common.BaseEntity;
+import com.boaz.backend.global.common.enums.Track;
+
 import jakarta.persistence.*;
 import lombok.Getter;
 
@@ -24,8 +26,4 @@ public class Review extends BaseEntity {
     private String content;
 
     private String imageUrl;
-
-    public enum Track {
-      VISUALIZATION, ANALYSIS, ENGINEERING
-     }
 }

--- a/src/main/java/com/boaz/backend/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/boaz/backend/domain/review/repository/ReviewRepository.java
@@ -1,6 +1,8 @@
 package com.boaz.backend.domain.review.repository;
 
 import com.boaz.backend.domain.review.entity.Review;
+import com.boaz.backend.global.common.enums.Track;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,9 +11,9 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     List<Review> findAllByOrderByTermDesc();
 
-    List<Review> findAllByTrackOrderByTermDesc(Review.Track track);
+    List<Review> findAllByTrackOrderByTermDesc(Track track);
 
     List<Review> findAllByTermOrderByTermDesc(Integer term);
 
-    List<Review> findAllByTrackAndTermOrderByTermDesc(Review.Track track, Integer term);
+    List<Review> findAllByTrackAndTermOrderByTermDesc(Track track, Integer term);
 }

--- a/src/main/java/com/boaz/backend/domain/review/service/ReviewService.java
+++ b/src/main/java/com/boaz/backend/domain/review/service/ReviewService.java
@@ -3,6 +3,8 @@ package com.boaz.backend.domain.review.service;
 import com.boaz.backend.domain.review.dto.ReviewResponse;
 import com.boaz.backend.domain.review.entity.Review;
 import com.boaz.backend.domain.review.repository.ReviewRepository;
+import com.boaz.backend.global.common.enums.Track;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,15 +18,15 @@ public class ReviewService {
 
     private final ReviewRepository reviewRepository;
 
-    public List<ReviewResponse> getReviews(String track, Integer term) {
+    public List<ReviewResponse> getReviews(Track track, Integer term) {
         List<Review> reviews;
 
         if (track != null && term != null) {
             reviews = reviewRepository.findAllByTrackAndTermOrderByTermDesc(
-                    Review.Track.valueOf(track), term);
+                    track, term);
         } else if (track != null) {
             reviews = reviewRepository.findAllByTrackOrderByTermDesc(
-                    Review.Track.valueOf(track));
+                    track);
         } else if (term != null) {
             reviews = reviewRepository.findAllByTermOrderByTermDesc(term);
         } else {

--- a/src/main/java/com/boaz/backend/global/common/enums/Track.java
+++ b/src/main/java/com/boaz/backend/global/common/enums/Track.java
@@ -1,5 +1,6 @@
 package com.boaz.backend.global.common.enums;
 
 public enum Track {
-    전부문, 시각화, 분석, 엔지니어링
+    // 전부문, 분석, 시각화, 엔지니어링
+    ALL, ANALYSIS, VISUALIZATION, ENGINEERING
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -16,7 +16,7 @@ SET FOREIGN_KEY_CHECKS = 1;
 
 -- 임시 데이터
 
--- recruitment 임시 데이터
+recruitment 임시 데이터
 INSERT INTO recruitment (id, term, start_date, end_date, schedule, brochure_url, created_at, updated_at)
 VALUES (1, 26, '2026-03-01 00:00:00', '2026-03-29 23:59:59', 
 '[
@@ -35,228 +35,228 @@ VALUES (2, 27, '2026-07-01 00:00:00', '2026-07-31 23:59:59',
   { "step": "최종 합격 발표", "start": "2026-08-10", "end": "2026-08-10", "sequence": 4 }
 ]', 'https://example.com/brochure.pdf', NOW(), NOW());
 
--- application_question 임시 데이터
+application_question 임시 데이터
 INSERT INTO application_question (id, recruitment_id, category, type, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
-VALUES ('공통1', 1, '공통', 'TEXT', '지원 동기는 무엇인가요? (500자 이내)', null, 500, 1, true, NOW(), NOW());
+VALUES ('COMMON1', 1, 'COMMON', 'TEXT', 'RECRUITMENT 동기는 무엇인가요? (500자 이내)', null, 500, 1, true, NOW(), NOW());
 
 INSERT INTO application_question (id, recruitment_id, category, type, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
-VALUES ('공통2', 1, '공통', 'TEXT', '본인을 나타낼 수 있는 기존의 활동 경험 (500자 이내)', null, 500, 2, true, NOW(), NOW());
+VALUES ('COMMON2', 1, 'COMMON', 'TEXT', '본인을 나타낼 수 있는 기존의 ACTIVITY 경험 (500자 이내)', null, 500, 2, true, NOW(), NOW());
 
 INSERT INTO application_question (id, recruitment_id, category, type, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
-VALUES ('공통5', 1, '공통', 'TEXT', '추가적으로 자신의 활동 중에서 특히 어필하고 싶은 프로젝트가 있다면.. (500자 이내)', null, 500, 99, true, NOW(), NOW());
+VALUES ('COMMON5', 1, 'COMMON', 'TEXT', '추가적으로 자신의 ACTIVITY 중에서 특히 어필하고 싶은 PROJECT가 있다면.. (500자 이내)', null, 500, 99, true, NOW(), NOW());
 
 INSERT INTO application_question (id, recruitment_id, category, type, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
-VALUES ('시각화1', 1, '시각화', 'TABLE', '데이터 시각화 관련 TOOL 활용 경험', '{"rows":["Tableau", "Python"], "columns":["경험 없음", "관련 프로젝트 경험 있음"]}', null, 10, true, NOW(), NOW());
+VALUES ('VISUALIZATION1', 1, 'VISUALIZATION', 'TABLE', '데이터 VISUALIZATION 관련 TOOL 활용 경험', '{"rows":["Tableau", "Python"], "columns":["경험 없음", "관련 PROJECT 경험 있음"]}', null, 10, true, NOW(), NOW());
 
 INSERT INTO application_question (id, recruitment_id, category, type, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
-VALUES ('시각화2', 1, '시각화', 'TEXT', '본인이 진행했던 시각화를 통해 인사이트를 도출한 경험.. (700자 이내)', null, 700, 11, true, NOW(), NOW());
+VALUES ('VISUALIZATION2', 1, 'VISUALIZATION', 'TEXT', '본인이 진행했던 VISUALIZATION를 통해 인사이트를 도출한 경험.. (700자 이내)', null, 700, 11, true, NOW(), NOW());
 
 INSERT INTO application_question (id, recruitment_id, category, type, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
-VALUES ('엔지니어링1', 1, '엔지니어링', 'TABLE', '데이터 엔지니어링 관련 경험', '{"rows":["데이터베이스", "서버 및 클라우드 서비스"], "columns":["경험 없음", "관련 프로젝트 경험 있음"]}', null, 10, true, NOW(), NOW());
+VALUES ('ENGINEERING1', 1, 'ENGINEERING', 'TABLE', '데이터 ENGINEERING 관련 경험', '{"rows":["데이터베이스", "서버 및 클라우드 서비스"], "columns":["경험 없음", "관련 PROJECT 경험 있음"]}', null, 10, true, NOW(), NOW());
 
 INSERT INTO application_question (id, recruitment_id, category, type, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
-VALUES ('엔지니어링2', 1, '엔지니어링', 'TEXT', '데이터 엔지니어링 분야 중 관심있는 세부 분야와 해당 분야와 관련된 경험 및 활동.. (700자 이내)', null, 700, 11, true, NOW(), NOW());
+VALUES ('ENGINEERING2', 1, 'ENGINEERING', 'TEXT', '데이터 ENGINEERING 분야 중 관심있는 세부 분야와 해당 분야와 관련된 경험 및 ACTIVITY.. (700자 이내)', null, 700, 11, true, NOW(), NOW());
 
 INSERT INTO application_question (id, recruitment_id, category, type, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
-VALUES ('분석1', 1, '분석', 'TEXT', '[빅데이터 / 인공지능 / 머신러닝 / 통계 및 수학] 관련 수강 과목 혹은 세미나 경험.. (300자 이내)', null, 300, 10, true, NOW(), NOW());
+VALUES ('ANALYSIS1', 1, 'ANALYSIS', 'TEXT', '[빅데이터 / 인공지능 / 머신러닝 / 통계 및 수학] 관련 수강 과목 혹은 세미나 경험.. (300자 이내)', null, 300, 10, true, NOW(), NOW());
 
 INSERT INTO application_question (id, recruitment_id, category, type, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
-VALUES ('분석2', 1, '분석', 'TEXT', '본인이 진행했던 [머신러닝 / 딥러닝 / 데이터분석] 관련 프로젝트를 소개.. (700자 이내)', null, 700, 11, true, NOW(), NOW());
+VALUES ('ANALYSIS2', 1, 'ANALYSIS', 'TEXT', '본인이 진행했던 [머신러닝 / 딥러닝 / 데이터ANALYSIS] 관련 PROJECT를 소개.. (700자 이내)', null, 700, 11, true, NOW(), NOW());
 
 -- archive 임시 데이터
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (1, 25, '프로젝트', '사용자 맞춤형 뭐뭐뭐뭐 추천시스템 발표', '자료연구팀', '분석', 'https://example.com/conf1.png', '{"slideshare":"https://slideshare.net/example1"}', '2024-08-10', NOW(), NOW());
+VALUES (1, 25, 'PROJECT', '사용자 맞춤형 뭐뭐뭐뭐 추천시스템 발표', '자료연구팀', 'ANALYSIS', 'https://example.com/conf1.png', '{"slideshare":"https://slideshare.net/example1"}', '2024-08-10', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (2, 0, '프로젝트', '누구구구의 뭐뭐뭐뭐 오오오오우 발표', NULL, '분석', 'https://example.com/conf1.png', '{"slideshare":"https://slideshare.net/example1"}', '2024-08-10', NOW(), NOW());
+VALUES (2, 0, 'PROJECT', '누구구구의 뭐뭐뭐뭐 오오오오우 발표', NULL, 'ANALYSIS', 'https://example.com/conf1.png', '{"slideshare":"https://slideshare.net/example1"}', '2024-08-10', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (3, 25, '프로젝트', '무엇무엇 데이터 파이프라인 발표', '자료연구팀', '엔지니어링', 'https://example.com/conf2.png', '{"slideshare":"https://slideshare.net/example2"}', '2024-08-10', NOW(), NOW());
+VALUES (3, 25, 'PROJECT', '무엇무엇 데이터 파이프라인 발표', '자료연구팀', 'ENGINEERING', 'https://example.com/conf2.png', '{"slideshare":"https://slideshare.net/example2"}', '2024-08-10', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (4, 25, '기술블로그', 'Spring Boot 예외 처리 구조 정리', NULL, '엔지니어링', 'https://example.com/blog1.png', '{"medium":"https://medium.com/@boaz/example1"}', '2025-02-14', NOW(), NOW());
+VALUES (4, 25, 'BLOG', 'Spring Boot 예외 처리 구조 정리', NULL, 'ENGINEERING', 'https://example.com/blog1.png', '{"medium":"https://medium.com/@boaz/example1"}', '2025-02-14', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (5, 25, '기술블로그', '데이터 분석 프로젝트 회고', NULL, '분석', 'https://example.com/blog2.png', '{"medium":"https://medium.com/@boaz/example2"}', '2025-01-20', NOW(), NOW());
+VALUES (5, 25, 'BLOG', '데이터 ANALYSIS PROJECT 회고', NULL, 'ANALYSIS', 'https://example.com/blog2.png', '{"medium":"https://medium.com/@boaz/example2"}', '2025-01-20', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (6, 25, '활동사진', '250402 분석 7주차 Base세션', NULL, '분석', 'https://example.com/activity1.png', '{"instagram":"https://instagram.com/p/example1"}', '2025-04-02', NOW(), NOW());
+VALUES (6, 25, 'ACTIVITY', '250402 ANALYSIS 7주차 Base세션', NULL, 'ANALYSIS', 'https://example.com/activity1.png', '{"instagram":"https://instagram.com/p/example1"}', '2025-04-02', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (7, 25, '활동사진', '25기 신입기수 OT', NULL, '전부문', 'https://example.com/activity2.png', '{"instagram":"https://instagram.com/p/example2"}', '2025-03-01', NOW(), NOW());
+VALUES (7, 25, 'ACTIVITY', '25기 신입기수 OT', NULL, 'ALL', 'https://example.com/activity2.png', '{"instagram":"https://instagram.com/p/example2"}', '2025-03-01', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (8, 26, '프로젝트', '추천 시스템 고도화 땡땡 발표', NULL, '엔지니어링', 'https://example.com/conf3.png', '{"slideshare":"https://slideshare.net/example3","github":"https://github.com/boaz/recommendation-system"}', '2025-08-12', NOW(), NOW());
+VALUES (8, 26, 'PROJECT', '추천 시스템 고도화 땡땡 발표', NULL, 'ENGINEERING', 'https://example.com/conf3.png', '{"slideshare":"https://slideshare.net/example3","github":"https://github.com/boaz/recommendation-system"}', '2025-08-12', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (9, 26, '프로젝트', '실시간 데이터 처리 뭐뭐뭐뭐 시스템 발표', '데이터엔지니어링팀', '엔지니어링', 'https://example.com/conf4.png', '{"slideshare":"https://slideshare.net/example4","github":"https://github.com/boaz/stream-processing"}', '2025-08-18', NOW(), NOW());
+VALUES (9, 26, 'PROJECT', '실시간 데이터 처리 뭐뭐뭐뭐 시스템 발표', '데이터ENGINEERING팀', 'ENGINEERING', 'https://example.com/conf4.png', '{"slideshare":"https://slideshare.net/example4","github":"https://github.com/boaz/stream-processing"}', '2025-08-18', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (10, 26, '프로젝트', '데이터 시각화 대시보드 블라블라 발표', '데이터시각화팀', '시각화', 'https://example.com/conf5.png', '{"slideshare":"https://slideshare.net/example5","github":"https://github.com/boaz/dashboard-project"}', '2025-08-25', NOW(), NOW());
+VALUES (10, 26, 'PROJECT', '데이터 VISUALIZATION 대시보드 블라블라 발표', '데이터VISUALIZATION팀', 'VISUALIZATION', 'https://example.com/conf5.png', '{"slideshare":"https://slideshare.net/example5","github":"https://github.com/boaz/dashboard-project"}', '2025-08-25', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (11, 26, '기술블로그', 'Kafka 기반 데이터 스트리밍 아키텍처 정리', NULL, '엔지니어링', 'https://example.com/blog3.png', '{"medium":"https://medium.com/@boaz/kafka-stream","github":"https://github.com/boaz/kafka-stream-example"}', '2025-03-01', NOW(), NOW());
+VALUES (11, 26, 'BLOG', 'Kafka 기반 데이터 스트리밍 아키텍처 정리', NULL, 'ENGINEERING', 'https://example.com/blog3.png', '{"medium":"https://medium.com/@boaz/kafka-stream","github":"https://github.com/boaz/kafka-stream-example"}', '2025-03-01', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (12, 26, '기술블로그', 'Spark 기반 대용량 데이터 처리 경험 정리', NULL, '엔지니어링', 'https://example.com/blog4.png', '{"medium":"https://medium.com/@boaz/spark-processing","github":"https://github.com/boaz/spark-example"}', '2025-03-05', NOW(), NOW());
+VALUES (12, 26, 'BLOG', 'Spark 기반 대용량 데이터 처리 경험 정리', NULL, 'ENGINEERING', 'https://example.com/blog4.png', '{"medium":"https://medium.com/@boaz/spark-processing","github":"https://github.com/boaz/spark-example"}', '2025-03-05', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (13, 26, '기술블로그', '추천 시스템 협업 필터링 구현 과정', NULL, '분석', 'https://example.com/blog5.png', '{"medium":"https://medium.com/@boaz/collaborative-filtering","github":"https://github.com/boaz/cf-recommendation"}', '2025-03-10', NOW(), NOW());
+VALUES (13, 26, 'BLOG', '추천 시스템 협업 필터링 구현 과정', NULL, 'ANALYSIS', 'https://example.com/blog5.png', '{"medium":"https://medium.com/@boaz/collaborative-filtering","github":"https://github.com/boaz/cf-recommendation"}', '2025-03-10', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (14, 26, '활동사진', '26기 데이터 분석 스터디 세션', NULL, '분석', 'https://example.com/activity3.png', '{"instagram":"https://instagram.com/p/example3","youtube":"https://youtube.com/watch?v=analysis-session"}', '2025-04-05', NOW(), NOW());
+VALUES (14, 26, 'ACTIVITY', '26기 데이터 ANALYSIS 스터디 세션', NULL, 'ANALYSIS', 'https://example.com/activity3.png', '{"instagram":"https://instagram.com/p/example3","youtube":"https://youtube.com/watch?v=analysis-session"}', '2025-04-05', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (15, 26, '활동사진', '26기 데이터 엔지니어링 워크샵', NULL, '엔지니어링', 'https://example.com/activity4.png', '{"instagram":"https://instagram.com/p/example4","youtube":"https://youtube.com/watch?v=engineering-workshop"}', '2025-04-10', NOW(), NOW());
+VALUES (15, 26, 'ACTIVITY', '26기 데이터 ENGINEERING 워크샵', NULL, 'ENGINEERING', 'https://example.com/activity4.png', '{"instagram":"https://instagram.com/p/example4","youtube":"https://youtube.com/watch?v=engineering-workshop"}', '2025-04-10', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (16, 26, '활동사진', '26기 데이터 시각화 세션', NULL, '시각화', 'https://example.com/activity5.png', '{"instagram":"https://instagram.com/p/example5","youtube":"https://youtube.com/watch?v=visualization-session"}', '2025-04-15', NOW(), NOW());
+VALUES (16, 26, 'ACTIVITY', '26기 데이터 VISUALIZATION 세션', NULL, 'VISUALIZATION', 'https://example.com/activity5.png', '{"instagram":"https://instagram.com/p/example5","youtube":"https://youtube.com/watch?v=visualization-session"}', '2025-04-15', NOW(), NOW());
 
 -- applicant 임시 데이터
 INSERT INTO applicants (id, recruitment_id, track, name, email, phone, university, major, minor_double_major, last_semester, military_status, birth_date, graduation_date, grad_school_plan, created_at, updated_at)
-VALUES (1, 1, '엔지니어링', '테스트1', 'string@example', '01012345678', 'university', 'major', '["minor_double_major"]', 7, '필_또는_면제', '2002-01-01', '2026-08', false, '2026-03-14 22:19:27', '2026-03-14 22:19:27');
+VALUES (1, 1, 'ENGINEERING', '테스트1', 'string@example', '01012345678', 'university', 'major', '["minor_double_major"]', 7, 'COMPLETED_OR_EXEMPT', '2002-01-01', '2026-08', false, '2026-03-14 22:19:27', '2026-03-14 22:19:27');
 
 INSERT INTO applicants (id, recruitment_id, track, name, email, phone, university, major, minor_double_major, last_semester, military_status, birth_date, graduation_date, grad_school_plan, created_at, updated_at)
-VALUES (2, 1, '엔지니어링', '테스트1', 'string@example', '01012345678', 'university', 'major', '["minor_double_major"]', 7, '필_또는_면제', '2002-01-01', '2026-08', false, '2026-03-14 22:38:15', '2026-03-14 22:38:15');
+VALUES (2, 1, 'ENGINEERING', '테스트1', 'string@example', '01012345678', 'university', 'major', '["minor_double_major"]', 7, 'COMPLETED_OR_EXEMPT', '2002-01-01', '2026-08', false, '2026-03-14 22:38:15', '2026-03-14 22:38:15');
 
 INSERT INTO applicants (id, recruitment_id, track, name, email, phone, university, major, minor_double_major, last_semester, military_status, birth_date, graduation_date, grad_school_plan, created_at, updated_at)
-VALUES (3, 1, '분석', '테스트2', 'string22@example', '01012345688', 'university', 'major', '["minor_double_major"]', 7, '필_또는_면제', '2002-01-01', '2026-08', false, '2026-03-14 22:21:18', '2026-03-14 22:21:18');
+VALUES (3, 1, 'ANALYSIS', '테스트2', 'string22@example', '01012345688', 'university', 'major', '["minor_double_major"]', 7, 'COMPLETED_OR_EXEMPT', '2002-01-01', '2026-08', false, '2026-03-14 22:21:18', '2026-03-14 22:21:18');
 
 INSERT INTO applicants (id, recruitment_id, track, name, email, phone, university, major, minor_double_major, last_semester, military_status, birth_date, graduation_date, grad_school_plan, created_at, updated_at)
-VALUES (4, 1, '시각화', '테스트3', 'string33@example', '01012345622', 'university', 'major', '["minor_double_major"]', 7, '필_또는_면제', '2002-01-01', '2026-08', false, '2026-03-14 22:21:58', '2026-03-14 22:21:58');
+VALUES (4, 1, 'VISUALIZATION', '테스트3', 'string33@example', '01012345622', 'university', 'major', '["minor_double_major"]', 7, 'COMPLETED_OR_EXEMPT', '2002-01-01', '2026-08', false, '2026-03-14 22:21:58', '2026-03-14 22:21:58');
 
 -- applicant_answer 임시 데이터 (테스트1 첫 번째 제출 - id: 1)
 INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (1, '공통1', '공통1답변', null, '2026-03-14 22:19:27', '2026-03-14 22:19:27');
+VALUES (1, 'COMMON1', 'COMMON1답변', null, '2026-03-14 22:19:27', '2026-03-14 22:19:27');
 
 INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (1, '공통2', '공통2답변', null, '2026-03-14 22:19:27', '2026-03-14 22:19:27');
+VALUES (1, 'COMMON2', 'COMMON2답변', null, '2026-03-14 22:19:27', '2026-03-14 22:19:27');
 
 INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (1, '엔지니어링1', null, '{"데이터베이스": "경험 없음", "서버 및 클라우드 서비스": "경험 없음"}', '2026-03-14 22:19:27', '2026-03-14 22:19:27');
+VALUES (1, 'ENGINEERING1', null, '{"데이터베이스": "경험 없음", "서버 및 클라우드 서비스": "경험 없음"}', '2026-03-14 22:19:27', '2026-03-14 22:19:27');
 
 INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (1, '엔지니어링2', '엔지2답변', null, '2026-03-14 22:19:27', '2026-03-14 22:19:27');
+VALUES (1, 'ENGINEERING2', '엔지2답변', null, '2026-03-14 22:19:27', '2026-03-14 22:19:27');
 
 INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (1, '공통5', '공통5답변\nurl', null, '2026-03-14 22:19:27', '2026-03-14 22:19:27');
+VALUES (1, 'COMMON5', 'COMMON5답변\nurl', null, '2026-03-14 22:19:27', '2026-03-14 22:19:27');
 
 -- applicant_answer 임시 데이터 (테스트1 두 번째 제출 - id: 2)
 INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (2, '공통1', '공통1답변11111', null, '2026-03-14 22:38:15', '2026-03-14 22:38:15');
+VALUES (2, 'COMMON1', 'COMMON1답변11111', null, '2026-03-14 22:38:15', '2026-03-14 22:38:15');
 
 INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (2, '공통2', '공통2답변22222', null, '2026-03-14 22:38:15', '2026-03-14 22:38:15');
+VALUES (2, 'COMMON2', 'COMMON2답변22222', null, '2026-03-14 22:38:15', '2026-03-14 22:38:15');
 
 INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (2, '엔지니어링1', null, '{"데이터베이스": "경험 없음", "서버 및 클라우드 서비스": "경험 없음"}', '2026-03-14 22:38:15', '2026-03-14 22:38:15');
+VALUES (2, 'ENGINEERING1', null, '{"데이터베이스": "경험 없음", "서버 및 클라우드 서비스": "경험 없음"}', '2026-03-14 22:38:15', '2026-03-14 22:38:15');
 
 INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (2, '엔지니어링2', '엔지2답변2222', null, '2026-03-14 22:38:15', '2026-03-14 22:38:15');
+VALUES (2, 'ENGINEERING2', '엔지2답변2222', null, '2026-03-14 22:38:15', '2026-03-14 22:38:15');
 
 INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (2, '공통5', '공통5답변5555\nurl', null, '2026-03-14 22:38:15', '2026-03-14 22:38:15');
+VALUES (2, 'COMMON5', 'COMMON5답변5555\nurl', null, '2026-03-14 22:38:15', '2026-03-14 22:38:15');
 
--- applicant_answer 임시 데이터 (테스트2 분석 - id: 3)
+-- applicant_answer 임시 데이터 (테스트2 ANALYSIS - id: 3)
 INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (3, '공통1', '공통1답변', null, NOW(), NOW());
-
-INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (3, '공통2', '공통2답변', null, NOW(), NOW());
+VALUES (3, 'COMMON1', 'COMMON1답변', null, NOW(), NOW());
 
 INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (3, '분석1', '분석1답변', null, NOW(), NOW());
+VALUES (3, 'COMMON2', 'COMMON2답변', null, NOW(), NOW());
 
 INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (3, '분석2', '분석2답변', null, NOW(), NOW());
+VALUES (3, 'ANALYSIS1', 'ANALYSIS1답변', null, NOW(), NOW());
 
 INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (3, '공통5', '공통5답변\nurl', null, NOW(), NOW());
-
--- applicant_answer 임시 데이터 (테스트3 시각화 - id: 4)
-INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (4, '공통1', '공통1답변', null, NOW(), NOW());
+VALUES (3, 'ANALYSIS2', 'ANALYSIS2답변', null, NOW(), NOW());
 
 INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (4, '공통2', '공통2답변', null, NOW(), NOW());
+VALUES (3, 'COMMON5', 'COMMON5답변\nurl', null, NOW(), NOW());
+
+-- applicant_answer 임시 데이터 (테스트3 VISUALIZATION - id: 4)
+INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
+VALUES (4, 'COMMON1', 'COMMON1답변', null, NOW(), NOW());
 
 INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (4, '시각화1', null, '{"Python": "경험 없음", "Tableau": "경험 없음"}', NOW(), NOW());
+VALUES (4, 'COMMON2', 'COMMON2답변', null, NOW(), NOW());
 
 INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (4, '시각화2', '시각화2답변', null, NOW(), NOW());
+VALUES (4, 'VISUALIZATION1', null, '{"Python": "경험 없음", "Tableau": "경험 없음"}', NOW(), NOW());
 
 INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (4, '공통5', '공통5답변\nurl', null, NOW(), NOW());
+VALUES (4, 'VISUALIZATION2', 'VISUALIZATION2답변', null, NOW(), NOW());
+
+INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
+VALUES (4, 'COMMON5', 'COMMON5답변\nurl', null, NOW(), NOW());
 
 -- Curriculum 임시데이터
 INSERT INTO curriculum (track, curriculum_steps, created_at, updated_at) VALUES
 ('ANALYSIS', '[
-  {"step": 1, "title": "데이터 분석 기초", "description": "통계 기초, 파이썬 기초"},
-  {"step": 2, "title": "탐색적 데이터 분석", "description": "Pandas, Numpy 활용"},
+  {"step": 1, "title": "데이터 ANALYSIS 기초", "description": "통계 기초, 파이썬 기초"},
+  {"step": 2, "title": "탐색적 데이터 ANALYSIS", "description": "Pandas, Numpy 활용"},
   {"step": 3, "title": "머신러닝 기초", "description": "Scikit-learn 활용"},
   {"step": 4, "title": "딥러닝 기초", "description": "TensorFlow, PyTorch 기초"},
-  {"step": 5, "title": "프로젝트", "description": "실전 분석 프로젝트 수행"}
+  {"step": 5, "title": "PROJECT", "description": "실전 ANALYSIS PROJECT 수행"}
 ]', NOW(), NOW());
 
 INSERT INTO curriculum (track, curriculum_steps, created_at, updated_at) VALUES
 ('VISUALIZATION', '[
-  {"step": 1, "title": "시각화 기초", "description": "Matplotlib, Seaborn 기초"},
+  {"step": 1, "title": "VISUALIZATION 기초", "description": "Matplotlib, Seaborn 기초"},
   {"step": 2, "title": "대시보드 제작", "description": "Tableau, Power BI 활용"},
-  {"step": 3, "title": "웹 시각화", "description": "D3.js, Plotly 활용"},
+  {"step": 3, "title": "웹 VISUALIZATION", "description": "D3.js, Plotly 활용"},
   {"step": 4, "title": "스토리텔링", "description": "데이터 기반 인사이트 전달"},
-  {"step": 5, "title": "인터랙티브 시각화", "description": "React 기반 차트 제작"},
-  {"step": 6, "title": "프로젝트", "description": "실전 시각화 프로젝트 수행"}
+  {"step": 5, "title": "인터랙티브 VISUALIZATION", "description": "React 기반 차트 제작"},
+  {"step": 6, "title": "PROJECT", "description": "실전 VISUALIZATION PROJECT 수행"}
 ]', NOW(), NOW());
 
 INSERT INTO curriculum (track, curriculum_steps, created_at, updated_at) VALUES
 ('ENGINEERING', '[
-  {"step": 1, "title": "데이터 엔지니어링 기초", "description": "SQL, 데이터베이스 기초"},
+  {"step": 1, "title": "데이터 ENGINEERING 기초", "description": "SQL, 데이터베이스 기초"},
   {"step": 2, "title": "데이터 파이프라인", "description": "Airflow, ETL 구축"},
   {"step": 3, "title": "클라우드 인프라", "description": "AWS, GCP 기초"},
   {"step": 4, "title": "데이터 웨어하우스", "description": "Redshift, BigQuery 활용"},
   {"step": 5, "title": "실시간 처리", "description": "Kafka, Spark Streaming"},
   {"step": 6, "title": "데이터 품질 관리", "description": "데이터 검증 및 모니터링"},
   {"step": 7, "title": "MLOps 기초", "description": "모델 배포 및 파이프라인 자동화"},
-  {"step": 8, "title": "프로젝트", "description": "실전 데이터 파이프라인 구축"}
+  {"step": 8, "title": "PROJECT", "description": "실전 데이터 파이프라인 구축"}
 ]', NOW(), NOW());
 
--- faq 임시데이터 - 지원
+-- faq 임시데이터 - RECRUITMENT
 INSERT INTO faq (question, answer, category, order_num, created_at, updated_at) VALUES
-('BOAZ에 지원하려면 어떤 조건이 필요한가요?', '학부생 및 대학원생이라면 누구나 지원 가능합니다. 전공 제한 없이 데이터에 관심 있는 분이라면 환영합니다.', '지원', 1, NOW(), NOW()),
-('지원서는 어디서 작성할 수 있나요?', '공식 홈페이지의 지원하기 버튼을 통해 작성하실 수 있습니다. 모집 기간에만 접수가 가능합니다.', '지원', 2, NOW(), NOW()),
-('비전공자도 지원할 수 있나요?', '네, 가능합니다. 전공보다는 데이터 분석에 대한 열정과 학습 의지를 더 중요하게 봅니다.', '지원', 3, NOW(), NOW()),
-('서류 합격 후 면접은 어떤 방식으로 진행되나요?', '면접은 개인 면접으로 진행되며, 지원 동기와 간단한 데이터 관련 질문으로 구성됩니다.', '지원', 4, NOW(), NOW()),
-('모집은 1년에 몇 번 진행되나요?', '매 학기 초(3월, 9월)에 신규 기수 모집이 진행됩니다.', '지원', 5, NOW(), NOW());
+('BOAZ에 RECRUITMENT하려면 어떤 조건이 필요한가요?', '학부생 및 대학원생이라면 누구나 RECRUITMENT 가능합니다. 전공 제한 없이 데이터에 관심 있는 분이라면 환영합니다.', 'RECRUITMENT', 1, NOW(), NOW()),
+('RECRUITMENT서는 어디서 작성할 수 있나요?', '공식 홈페이지의 RECRUITMENT하기 버튼을 통해 작성하실 수 있습니다. 모집 기간에만 접수가 가능합니다.', 'RECRUITMENT', 2, NOW(), NOW()),
+('비전공자도 RECRUITMENT할 수 있나요?', '네, 가능합니다. 전공보다는 데이터 ANALYSIS에 대한 열정과 학습 의지를 더 중요하게 봅니다.', 'RECRUITMENT', 3, NOW(), NOW()),
+('서류 합격 후 면접은 어떤 방식으로 진행되나요?', '면접은 개인 면접으로 진행되며, RECRUITMENT 동기와 간단한 데이터 관련 질문으로 구성됩니다.', 'RECRUITMENT', 4, NOW(), NOW()),
+('모집은 1년에 몇 번 진행되나요?', '매 학기 초(3월, 9월)에 신규 기수 모집이 진행됩니다.', 'RECRUITMENT', 5, NOW(), NOW());
 
--- faq 임시데이터 - 활동
+-- faq 임시데이터 - ACTIVITY
 INSERT INTO faq (question, answer, category, order_num, created_at, updated_at) VALUES
-('BOAZ에서는 어떤 활동을 하나요?', '스터디, 세미나, 프로젝트 등 다양한 활동을 진행합니다. 트랙별로 분석, 시각화, 엔지니어링 중 하나를 선택해 심화 학습합니다.', '활동', 1, NOW(), NOW()),
-('활동 기간은 얼마나 되나요?', '한 기수의 활동 기간은 약 6개월(한 학기)입니다.', '활동', 2, NOW(), NOW()),
-('프로젝트는 어떤 방식으로 진행되나요?', '팀을 구성해 실제 데이터를 활용한 프로젝트를 수행하며, 학기 말에 발표회를 통해 결과를 공유합니다.', '활동', 3, NOW(), NOW()),
-('활동비나 지원 혜택이 있나요?', '활동 우수자에게는 소정의 지원금 및 수료증이 제공되며, 외부 대회 참가 시 지원을 받을 수 있습니다.', '활동', 4, NOW(), NOW()),
-('세미나는 얼마나 자주 열리나요?', '격주로 정기 세미나가 진행되며, 외부 연사 초청 특강도 비정기적으로 열립니다.', '활동', 5, NOW(), NOW());
+('BOAZ에서는 어떤 ACTIVITY을 하나요?', '스터디, 세미나, PROJECT 등 다양한 ACTIVITY을 진행합니다. 트랙별로 ANALYSIS, VISUALIZATION, ENGINEERING 중 하나를 선택해 심화 학습합니다.', 'ACTIVITY', 1, NOW(), NOW()),
+('ACTIVITY 기간은 얼마나 되나요?', '한 기수의 ACTIVITY 기간은 약 6개월(한 학기)입니다.', 'ACTIVITY', 2, NOW(), NOW()),
+('PROJECT는 어떤 방식으로 진행되나요?', '팀을 구성해 실제 데이터를 활용한 PROJECT를 수행하며, 학기 말에 발표회를 통해 결과를 공유합니다.', 'ACTIVITY', 3, NOW(), NOW()),
+('ACTIVITY비나 RECRUITMENT 혜택이 있나요?', 'ACTIVITY 우수자에게는 소정의 RECRUITMENT금 및 수료증이 제공되며, 외부 대회 참가 시 RECRUITMENT을 받을 수 있습니다.', 'ACTIVITY', 4, NOW(), NOW()),
+('세미나는 얼마나 자주 열리나요?', '격주로 정기 세미나가 진행되며, 외부 연사 초청 특강도 비정기적으로 열립니다.', 'ACTIVITY', 5, NOW(), NOW());
 
--- faq 임시데이터 - 기타
+-- faq 임시데이터 - ETC
 INSERT INTO faq (question, answer, category, order_num, created_at, updated_at) VALUES
-('BOAZ SNS 채널이 있나요?', '인스타그램과 링크드인을 운영 중입니다. 공식 홈페이지에서 링크를 확인하실 수 있습니다.', '기타', 1, NOW(), NOW()),
-('이전 기수의 프로젝트 결과물을 볼 수 있나요?', '네, 공식 홈페이지 및 GitHub에서 이전 기수의 프로젝트 결과물을 확인하실 수 있습니다.', '기타', 2, NOW(), NOW()),
-('문의는 어디로 하면 되나요?', '공식 이메일 또는 인스타그램 DM으로 문의 주시면 빠르게 답변드리겠습니다.', '기타', 3, NOW(), NOW());
+('BOAZ SNS 채널이 있나요?', '인스타그램과 링크드인을 운영 중입니다. 공식 홈페이지에서 링크를 확인하실 수 있습니다.', 'ETC', 1, NOW(), NOW()),
+('이전 기수의 PROJECT 결과물을 볼 수 있나요?', '네, 공식 홈페이지 및 GitHub에서 이전 기수의 PROJECT 결과물을 확인하실 수 있습니다.', 'ETC', 2, NOW(), NOW()),
+('문의는 어디로 하면 되나요?', '공식 이메일 또는 인스타그램 DM으로 문의 주시면 빠르게 답변드리겠습니다.', 'ETC', 3, NOW(), NOW());
 
 -- review 임시데이터 - ANALYSIS
 INSERT INTO review (name, track, term, content, image_url, created_at, updated_at) VALUES
-('김분석', 'ANALYSIS', 15, 'BOAZ에서 데이터 분석을 공부하며 정말 많이 성장했습니다. 실전 프로젝트를 통해 이론으로만 알던 머신러닝을 직접 적용해볼 수 있어서 좋았어요.', 'https://example.com/images/review1.jpg', NOW(), NOW()),
-('이통계', 'ANALYSIS', 16, '비전공자였지만 BOAZ 덕분에 데이터 분석의 기초부터 차근차근 배울 수 있었습니다. 스터디원들과 함께 성장하는 경험이 값졌어요.', 'https://example.com/images/review2.jpg', NOW(), NOW()),
-('박파이썬', 'ANALYSIS', 17, '분석 트랙에서 Pandas부터 딥러닝까지 폭넓게 배웠습니다. 캐글 대회에도 참가하며 실력을 쌓을 수 있었던 점이 가장 좋았습니다.', null, NOW(), NOW());
+('김ANALYSIS', 'ANALYSIS', 15, 'BOAZ에서 데이터 ANALYSIS을 공부하며 정말 많이 성장했습니다. 실전 PROJECT를 통해 이론으로만 알던 머신러닝을 직접 적용해볼 수 있어서 좋았어요.', 'https://example.com/images/review1.jpg', NOW(), NOW()),
+('이통계', 'ANALYSIS', 16, '비전공자였지만 BOAZ 덕분에 데이터 ANALYSIS의 기초부터 차근차근 배울 수 있었습니다. 스터디원들과 함께 성장하는 경험이 값졌어요.', 'https://example.com/images/review2.jpg', NOW(), NOW()),
+('박파이썬', 'ANALYSIS', 17, 'ANALYSIS 트랙에서 Pandas부터 딥러닝까지 폭넓게 배웠습니다. 캐글 대회에도 참가하며 실력을 쌓을 수 있었던 점이 가장 좋았습니다.', null, NOW(), NOW());
 
 -- review 임시데이터 - VISUALIZATION
 INSERT INTO review (name, track, term, content, image_url, created_at, updated_at) VALUES
-('최시각', 'VISUALIZATION', 15, 'Tableau와 D3.js를 활용한 시각화 프로젝트가 정말 인상 깊었습니다. 데이터를 보기 좋게 표현하는 방법을 배운 것이 현업에서도 큰 도움이 되고 있어요.', 'https://example.com/images/review4.jpg', NOW(), NOW()),
-('정대시', 'VISUALIZATION', 16, '시각화 트랙에서 단순한 차트를 넘어 스토리텔링까지 배울 수 있었습니다. 데이터로 사람들을 설득하는 방법을 익힌 게 큰 수확이었어요.', 'https://example.com/images/review5.jpg', NOW(), NOW()),
+('최시각', 'VISUALIZATION', 15, 'Tableau와 D3.js를 활용한 VISUALIZATION PROJECT가 정말 인상 깊었습니다. 데이터를 보기 좋게 표현하는 방법을 배운 것이 현업에서도 큰 도움이 되고 있어요.', 'https://example.com/images/review4.jpg', NOW(), NOW()),
+('정대시', 'VISUALIZATION', 16, 'VISUALIZATION 트랙에서 단순한 차트를 넘어 스토리텔링까지 배울 수 있었습니다. 데이터로 사람들을 설득하는 방법을 익힌 게 큰 수확이었어요.', 'https://example.com/images/review5.jpg', NOW(), NOW()),
 ('한인터', 'VISUALIZATION', 17, 'React 기반 인터랙티브 대시보드를 만들어보는 경험이 정말 좋았습니다. 프론트엔드와 데이터를 연결하는 시각을 갖게 되었어요.', null, NOW(), NOW());
 
 -- review 임시데이터 - ENGINEERING
 INSERT INTO review (name, track, term, content, image_url, created_at, updated_at) VALUES
-('강파이프', 'ENGINEERING', 15, 'Airflow로 데이터 파이프라인을 구축하고 AWS에 배포하는 경험이 정말 값졌습니다. 엔지니어링 트랙을 통해 백엔드와 데이터를 연결하는 시야가 넓어졌어요.', 'https://example.com/images/review7.jpg', NOW(), NOW()),
+('강파이프', 'ENGINEERING', 15, 'Airflow로 데이터 파이프라인을 구축하고 AWS에 배포하는 경험이 정말 값졌습니다. ENGINEERING 트랙을 통해 백엔드와 데이터를 연결하는 시야가 넓어졌어요.', 'https://example.com/images/review7.jpg', NOW(), NOW()),
 ('윤클라우드', 'ENGINEERING', 16, 'Kafka와 Spark로 실시간 데이터 처리를 경험한 것이 가장 기억에 남습니다. 실제 서비스에 가까운 환경에서 실습할 수 있어서 좋았어요.', 'https://example.com/images/review8.jpg', NOW(), NOW()),
 ('오엠엘', 'ENGINEERING', 17, 'MLOps 파이프라인을 직접 구축해보며 모델 배포의 전 과정을 이해할 수 있었습니다. 취업 준비에도 큰 도움이 된 경험이었어요.', null, NOW(), NOW());


### PR DESCRIPTION
## 💡 개요

* Issue Number: #49 

## 🪐 주요 변경 사항
- ENUM 영어로 통일

## ✅ 상세 내용
- Track, ArchiveCategory, Category, MilitaryStatus, QuestionCategory, QuestionType 영문으로 수정
- 연관된 코드 리팩토링

## 🔔 참고 사항
- X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**변경 목적**: 프로젝트 전체의 ENUM 값을 한국어에서 영어로 일관되게 통일하여 코드의 국제화를 추진하고 유지보수성을 향상시킵니다.

**주요 변경 내용**:

**ENUM 정의 변경**:
- `Track` (전부문→ALL, 시각화→VISUALIZATION, 분석→ANALYSIS, 엔지니어링→ENGINEERING)
- `ArchiveCategory` (프로젝트→PROJECT, 기술블로그→BLOG, 활동사진→ACTIVITY)
- `Faq.Category` (지원→RECRUITMENT, 활동→ACTIVITY, 기타→ETC)
- `MilitaryStatus` (필_또는_면제→COMPLETED_OR_EXEMPT, 미필→NOT_COMPLETED)
- `QuestionCategory` (공통→COMMON, 시각화→VISUALIZATION, 분석→ANALYSIS, 엔지니어링→ENGINEERING)

**컨트롤러 계층**:
- `ArchiveController`: RequestParam 기본값을 "전부문"→"ALL"로 변경, 내부 ENUM 참조 업데이트
- `CurriculumController`: track 파라미터 타입을 String→Track enum으로 변경
- `ReviewController`: track 파라미터 타입을 String→Track enum으로 변경

**엔티티 계층**:
- `Curriculum`, `Review`: 각 클래스의 중첩 Track enum을 제거하고 공통 Track enum 사용
- 중첩 enum 제거로 인한 필드 타입 통일 및 import 추가

**서비스 계층**:
- `CurriculumService`, `ReviewService`: String 기반 ENUM 변환 로직을 제거하고 enum 타입 직접 사용
- `ArchiveService`: Track.ALL을 sentinel 값으로 처리하는 로직 업데이트
- `RecruitmentService`: 한국어 ENUM 상수 참조를 영어로 변경

**데이터베이스**:
- `data.sql`: 모든 seed 데이터의 ENUM 값을 한국어→영어로 일괄 업데이트 (application_question, archive, applicants, curriculum, faq, review 등)

**영향 범위**:
- **API 변경**: 있음 - RequestParam 타입 및 기본값 변경으로 외부 API 호출 시 영어 enum 값 사용 필수
- **DB 스키마 변경**: 없음 - 다만 EnumType.STRING 사용으로 인해 저장되는 enum 문자열 값이 변경되므로 기존 데이터와의 호환성 고려 필요
- **설정 변경**: 있음 - seed 데이터 전면 변경으로 초기 데이터베이스 설정 시 반영 필요

<!-- end of auto-generated comment: release notes by coderabbit.ai -->