### PR TITLE
Feat/#19 archiving

### DIFF
--- a/src/main/java/com/boaz/backend/domain/archive/entity/Archive.java
+++ b/src/main/java/com/boaz/backend/domain/archive/entity/Archive.java
@@ -44,7 +44,7 @@ public class Archive extends BaseEntity {
     @Column(nullable = false, columnDefinition = "json")
     private String links;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private LocalDate contentDate;
 
     @Builder

--- a/src/main/java/com/boaz/backend/domain/archive/repository/ArchiveRepository.java
+++ b/src/main/java/com/boaz/backend/domain/archive/repository/ArchiveRepository.java
@@ -25,7 +25,10 @@ public interface ArchiveRepository extends JpaRepository<Archive, Long> {
                 OR LOWER(REPLACE(a.title, ' ', '')) 
                     LIKE CONCAT('%', LOWER(REPLACE(:keyword, ' ', '')), '%')
             )
-        ORDER BY a.contentDate DESC, a.id DESC 
+        ORDER BY 
+            CASE WHEN a.contentDate IS NULL THEN 1 ELSE 0 END ASC, 
+            a.contentDate DESC, 
+            a.id DESC 
     """)
     Page<Archive> searchArchives(
         @Param("category") ArchiveCategory category, 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -68,7 +68,7 @@ INSERT INTO archive (id, term, category, title, team_name, track, image_url, lin
 VALUES (1, 25, 'PROJECT', '사용자 맞춤형 뭐뭐뭐뭐 추천시스템 발표', '자료연구팀', 'ANALYSIS', 'https://example.com/conf1.png', '{"slideshare":"https://slideshare.net/example1"}', '2024-08-10', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
-VALUES (2, 0, 'PROJECT', '누구구구의 뭐뭐뭐뭐 오오오오우 발표', NULL, 'ANALYSIS', 'https://example.com/conf1.png', '{"slideshare":"https://slideshare.net/example1"}', '2024-08-10', NOW(), NOW());
+VALUES (2, 0, 'PROJECT', '누구구구의 뭐뭐뭐뭐 오오오오우 발표', NULL, 'ANALYSIS', 'https://example.com/conf1.png', '{"slideshare":"https://slideshare.net/example1"}', NULL, NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
 VALUES (3, 25, 'PROJECT', '무엇무엇 데이터 파이프라인 발표', '자료연구팀', 'ENGINEERING', 'https://example.com/conf2.png', '{"slideshare":"https://slideshare.net/example2"}', '2024-08-10', NOW(), NOW());


### PR DESCRIPTION
## 💡 개요
아카이빙 contentDate nullable 및 null last 정렬 적용

* Issue Number: #33

## 🪐 주요 변경 사항
-  Archive 엔티티 contentDate 필드 nullable 허용으로 변경
- contentDate null last 정렬 적용

## ✅ 상세 내용
- contentDate가 null인 경우 CASE WHEN으로 null last 정렬 처리
- Archive 엔티티 contentDate @Column nullable = true 변경

## 🔔 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**변경 목적**: Archive 엔티티의 contentDate 필드를 nullable로 변경하여 더 유연한 아카이브 관리를 지원하고, null 값들을 정렬 결과의 마지막에 배치하는 정렬 로직을 적용합니다.

**주요 변경 내용**:
- **엔티티 계층**: Archive.contentDate 컬럼을 nullable = false에서 nullable = true로 변경
- **저장소 계층**: ArchiveRepository.searchArchives() 쿼리의 ORDER BY 절을 수정하여 CASE WHEN 식으로 null 값을 마지막에 배치 (contentDate IS NULL 조건을 1/0으로 매핑하여 오름차순 정렬)
- **테스트 데이터**: 시드 데이터(id=2)의 content_date 값을 '2024-08-10'에서 NULL로 변경

**영향 범위**: 
- **DB 스키마 변경**: archive 테이블의 content_date 컬럼 NOT NULL 제약조건 제거
- **쿼리 로직 변경**: 정렬 알고리즘 수정으로 인한 검색 결과 순서 변경

<!-- end of auto-generated comment: release notes by coderabbit.ai -->