### PR TITLE
[Fix] Swagger 스키마 snake_case 불일치 수정

### DIFF
--- a/src/main/java/com/boaz/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/boaz/backend/global/config/SwaggerConfig.java
@@ -7,6 +7,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.core.jackson.ModelResolver;
+
+
 @Configuration
 public class SwaggerConfig {
 
@@ -21,5 +25,10 @@ public class SwaggerConfig {
                         .title("BOAZ 웹사이트 백엔드 API")
                         .description("BOAZ 웹사이트 백엔드 API 문서")
                         .version("v1.0.0"));
+    }
+
+    @Bean
+    public ModelResolver modelResolver(ObjectMapper objectMapper) {
+        return new ModelResolver(objectMapper);
     }
 }


### PR DESCRIPTION
## 💡 개요

* Issue Number: #53 

## 🪐 주요 변경 사항
- SwaggerConfig에 ModelResolver Bean 등록

## ✅ 상세 내용
- SpringDoc은 기본적으로 자체 ModelResolver를 사용하기 때문에 Jackson의 SNAKE_CASE 설정이 Swagger 스키마에 반영되지 않음
- ObjectMapper를 주입받는 ModelResolver Bean을 등록하여 Swagger 스키마도 snake_case로 표시되도록 수정

## 🔔 참고 사항
- 소스코드 변경 없이 SwaggerConfig.java 단일 파일만 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## PR 요약

**변경 목적**: SpringDoc이 기본 ModelResolver를 사용하면서 Jackson의 SNAKE_CASE 설정이 Swagger 스키마에 반영되지 않는 문제를 해결하고자, ObjectMapper를 기반으로 한 ModelResolver Bean을 등록하여 API 문서의 필드명이 snake_case로 올바르게 표시되도록 수정.

**주요 변경 내용**:
- **SwaggerConfig.java**: `ModelResolver` Bean 추가
  - `modelResolver(ObjectMapper objectMapper)` 메소드 신규 추가
  - 애플리케이션의 ObjectMapper를 주입받아 Jackson 기반 모델 해석 활성화
  - 임포트 추가: `ObjectMapper`, `ModelResolver`

**영향 범위**: 설정 변경 (Swagger/OpenAPI 스키마 표시 방식 개선, API 스펙 문서의 필드명 표기)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->