### PR TITLE
[Chore] Recruitment DTO 및 Enum Swagger 컨벤션 적용

### DIFF
--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/request/AnswerRequest.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/request/AnswerRequest.java
@@ -2,17 +2,19 @@ package com.boaz.backend.domain.recruitment.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
-
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
 public class AnswerRequest {
 
+    @Schema(description = "질문 ID", example = "1")
     @NotNull(message = "question_id를 입력해주세요.")
     @JsonProperty("question_id")
     private Long questionId;
 
+    @Schema(description = "답변")
     @NotNull(message = "답변을 입력해주세요.")
     private JsonNode answer;
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/request/ApplicationRequest.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/request/ApplicationRequest.java
@@ -3,6 +3,7 @@ package com.boaz.backend.domain.recruitment.dto.request;
 import com.boaz.backend.domain.recruitment.entity.Applicant;
 import com.boaz.backend.global.common.enums.Track;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -13,51 +14,65 @@ import java.util.List;
 @Getter
 public class ApplicationRequest {
 
+    @Schema(description = "모집 ID", example = "1")
     @NotNull(message = "recruitment_id를 입력해주세요.")
     @JsonProperty("recruitment_id")
     private Long recruitmentId;
 
+    @Schema(description = "지원 트랙", example = "ENGINEERING", allowableValues = {"ANALYSIS", "VISUALIZATION", "ENGINEERING"})
     @NotNull(message = "지원 부문을 입력해주세요.")
     private Track track;
 
+    @Schema(description = "성명", example = "홍길동")
     @NotBlank(message = "성명을 입력해주세요.")
     private String name;
 
+    @Schema(description = "이메일", example = "hong@example.com")
     @NotBlank(message = "이메일을 입력해주세요.")
     private String email;
 
+    @Schema(description = "전화번호", example = "01012345678")
     @NotBlank(message = "전화번호를 입력해주세요.")
     private String phone;
 
+    @Schema(description = "대학교", example = "한국대학교")
     @NotBlank(message = "대학교를 입력해주세요.")
     private String university;
 
+    @Schema(description = "본전공", example = "컴퓨터공학")
     @NotBlank(message = "본전공을 입력해주세요.")
     private String major;
 
+    @Schema(description = "부전공/복수전공 목록", example = "[\"통계학\"]")
     @JsonProperty("minor_double_major")
     private List<String> minorDoubleMajor;
 
+    @Schema(description = "마지막 재학 학기", example = "4")
     @NotNull(message = "마지막 재학 학기를 입력해주세요.")
     @JsonProperty("last_semester")
     private Integer lastSemester;
 
+    @Schema(description = "병역 상태", example = "COMPLETED_OR_EXEMPT", allowableValues = {"COMPLETED_OR_EXEMPT", "NOT_COMPLETED"})
     @NotNull(message = "병역 상태를 선택해주세요.")
     @JsonProperty("military_status")
     private Applicant.MilitaryStatus militaryStatus;
 
+    @Schema(description = "생년월일", example = "2000-01-01")
     @NotBlank(message = "생년월일을 입력해주세요.")
     @JsonProperty("birth_date")
     private String birthDate;
 
+    @Schema(description = "졸업 예정 시점", example = "2025-02")
     @NotBlank(message = "졸업 예정 시점을 입력해주세요.")
     @JsonProperty("graduation_date")
     private String graduationDate;
 
+    @Schema(description = "대학원 진학 여부", example = "false")
     @NotNull(message = "대학원 진학 여부를 선택해주세요.")
     @JsonProperty("grad_school_plan")
     private Boolean gradSchoolPlan;
 
+    @Schema(description = "지원서 답변 목록")
     @NotNull(message = "답변 목록을 입력해주세요.")
     @Valid
     private List<AnswerRequest> answers;

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/request/SubscriptionRequest.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/request/SubscriptionRequest.java
@@ -1,11 +1,13 @@
 package com.boaz.backend.domain.recruitment.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class SubscriptionRequest {
 
+    @Schema(description = "이메일", example = "hong@example.com")
     @NotBlank(message = "이메일을 입력해주세요.")
     private String email;
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/response/ApplicationResponse.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/response/ApplicationResponse.java
@@ -1,6 +1,7 @@
 package com.boaz.backend.domain.recruitment.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -8,9 +9,11 @@ import java.time.LocalDateTime;
 @Getter
 public class ApplicationResponse {
 
+    @Schema(description = "지원자 ID", example = "1")
     @JsonProperty("applicant_id")
     private final Long applicantId;
 
+    @Schema(description = "제출 일시", example = "2024-03-01T12:00:00")
     @JsonProperty("submitted_at")
     private final LocalDateTime submittedAt;
 

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/response/DeadlineResponse.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/response/DeadlineResponse.java
@@ -3,6 +3,7 @@ package com.boaz.backend.domain.recruitment.dto.response;
 import com.boaz.backend.domain.recruitment.entity.Recruitment;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -10,9 +11,11 @@ import java.time.LocalDateTime;
 @Getter
 public class DeadlineResponse {
 
+    @Schema(description = "모집 ID", example = "1")
     @JsonProperty("recruitment_id")
     private final Long recruitmentId;
 
+    @Schema(description = "마감 일시", example = "2024-03-31T23:59:59")
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private final LocalDateTime deadline;
 

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/response/QuestionResponse.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/response/QuestionResponse.java
@@ -6,7 +6,7 @@ import com.boaz.backend.global.exception.ErrorCode;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
@@ -15,14 +15,31 @@ public class QuestionResponse {
     
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
+    @Schema(description = "질문 ID", example = "1")
     private final Long questionId;
+
+    @Schema(description = "질문 레이블", example = "공통1")
     private final String label;
+
+    @Schema(description = "카테고리", example = "COMMON", allowableValues = {"COMMON", "ANALYSIS", "VISUALIZATION", "ENGINEERING"})
     private final String category;
+
+    @Schema(description = "질문 유형", example = "TEXT", allowableValues = {"TEXT", "TABLE"})
     private final String type;
+
+    @Schema(description = "질문 내용", example = "자신을 소개해주세요.")
     private final String content;
+
+    @Schema(description = "글자 수 제한 (TEXT 유형인 경우)", example = "500", nullable = true)
     private final Integer limitLength;
+
+    @Schema(description = "메타데이터 (TABLE 유형인 경우)", nullable = true)
     private final JsonNode metadata;
+
+    @Schema(description = "질문 순서", example = "1")
     private final Integer orderNum;
+
+    @Schema(description = "필수 여부", example = "true")
     private final Boolean isRequired;
     
     public static QuestionResponse from(ApplicationQuestion question) {

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/response/RecruitmentResponse.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/response/RecruitmentResponse.java
@@ -6,7 +6,7 @@ import com.boaz.backend.global.exception.ErrorCode;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -15,11 +15,22 @@ import java.time.LocalDateTime;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class RecruitmentResponse {
 
+    @Schema(description = "기수", example = "25", nullable = true)
     private final Integer term;
+
+    @Schema(description = "모집 시작 일시", example = "2024-03-01T00:00:00", nullable = true)
     private final LocalDateTime startDate;
+
+    @Schema(description = "모집 마감 일시", example = "2024-03-31T23:59:59", nullable = true)
     private final LocalDateTime endDate;
+
+    @Schema(description = "일정 정보", nullable = true)
     private final JsonNode schedule;
+
+    @Schema(description = "모집 공고 URL", example = "https://example.com/brochure", nullable = true)
     private final String brochureUrl;
+
+    @Schema(description = "모집 중 여부", example = "true")
     private final Boolean isActive;
 
     private static final ObjectMapper objectMapper = new ObjectMapper();

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/response/RecruitmentStatusResponse.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/response/RecruitmentStatusResponse.java
@@ -1,14 +1,17 @@
 package com.boaz.backend.domain.recruitment.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class RecruitmentStatusResponse {
 
+    @Schema(description = "모집 중 여부", example = "true")
     private final Boolean isActive;
+
+    @Schema(description = "현재 모집 기수", example = "25", nullable = true)
     private final Integer term;
 
     private RecruitmentStatusResponse(boolean isActive, Integer term) {

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/response/SubscriptionResponse.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/response/SubscriptionResponse.java
@@ -1,11 +1,13 @@
 package com.boaz.backend.domain.recruitment.dto.response;
 
 import com.boaz.backend.domain.recruitment.entity.Subscription;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
 public class SubscriptionResponse {
 
+    @Schema(description = "구독 이메일", example = "hong@example.com")
     private final String email;
 
     private SubscriptionResponse(Subscription subscription) {

--- a/src/main/java/com/boaz/backend/domain/recruitment/entity/Applicant.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/entity/Applicant.java
@@ -1,5 +1,6 @@
 package com.boaz.backend.domain.recruitment.entity;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -20,9 +21,11 @@ import java.time.LocalDate;
 @EntityListeners(AuditingEntityListener.class)
 public class Applicant extends BaseEntity  {
     
-    // 필_또는_면제, 미필
     public enum MilitaryStatus {
-        COMPLETED_OR_EXEMPT, NOT_COMPLETED
+        @Schema(description = "필 또는 면제")
+        COMPLETED_OR_EXEMPT,
+        @Schema(description = "미필")
+        NOT_COMPLETED
     }
 
     @Id

--- a/src/main/java/com/boaz/backend/domain/recruitment/entity/ApplicationQuestion.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/entity/ApplicationQuestion.java
@@ -1,7 +1,7 @@
 package com.boaz.backend.domain.recruitment.entity;
 
 import com.boaz.backend.global.common.BaseEntity;
-
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.Getter;
 
@@ -10,13 +10,22 @@ import lombok.Getter;
 @Table(name = "application_question")
 public class ApplicationQuestion extends BaseEntity {
 
-    //공통, 시각화, 분석, 엔지니어링
     public enum Category {
-        COMMON, ANALYSIS, VISUALIZATION, ENGINEERING
+        @Schema(description = "공통")
+        COMMON,
+        @Schema(description = "분석")
+        ANALYSIS,
+        @Schema(description = "시각화")
+        VISUALIZATION,
+        @Schema(description = "엔지니어링")
+        ENGINEERING
     }
 
     public enum Type {
-        TEXT, TABLE
+        @Schema(description = "텍스트")
+        TEXT,
+        @Schema(description = "표")
+        TABLE
     }
 
     @Id


### PR DESCRIPTION
## 💡 개요

* Issue Number: #63

## 🪐 주요 변경 사항
- recruitment 도메인 DTO 및 Enum에 Swagger `@Schema` 어노테이션 추가

## ✅ 상세 내용
- RequestDTO 필드 `@Schema` 추가
- ResponseDTO 필드 `@Schema` 추가
- 내부 Enum 값 `@Schema` 추가
- nullable 필드에 `nullable = true` 적용 (RecruitmentResponse, RecruitmentStatusResponse)
- enum 값 한글 주석 제거 후 `@Schema(description = ...)` 으로 대체

## 🔔 참고 사항
- Controller는 기존에 컨벤션에 맞게 작성되어 있어 수정하지 않음
---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 변경 요약

**변경 목적:**
모집(recruitment) 도메인의 DTO와 Enum에 OpenAPI/Swagger `@Schema` 어노테이션을 적용하여 API 문서화 컨벤션을 통일합니다. 기존의 한국어 인라인 주석을 제거하고 표준화된 메타데이터로 대체합니다.

**주요 변경 내용:**

Request DTO 계층:
- `AnswerRequest`: questionId, answer 필드에 @Schema 추가
- `ApplicationRequest`: recruitmentId, track, name, email 등 모든 필드에 @Schema 및 allowableValues 추가
- `SubscriptionRequest`: email 필드에 @Schema 추가

Response DTO 계층:
- `ApplicationResponse`: applicantId, submittedAt 필드에 @Schema 추가
- `DeadlineResponse`: recruitmentId, deadline 필드에 @Schema 추가
- `QuestionResponse`: questionId, label, category, type, content, limitLength, metadata, orderNum, isRequired 필드에 @Schema 및 nullable 속성 추가
- `RecruitmentResponse`: term, startDate, endDate, schedule, brochureUrl, isActive 필드에 @Schema 추가
- `RecruitmentStatusResponse`: isActive, term 필드에 @Schema 및 nullable 속성 추가
- `SubscriptionResponse`: email 필드에 @Schema 추가

Enum 계층:
- `Applicant.MilitaryStatus`: COMPLETED_OR_EXEMPT("필 또는 면제"), NOT_COMPLETED("미필")에 @Schema 추가
- `ApplicationQuestion.Category`: COMMON, ANALYSIS, VISUALIZATION, ENGINEERING에 @Schema 추가
- `ApplicationQuestion.Type`: TEXT, TABLE에 @Schema 추가

**영향 범위:**
- API 문서화 개선만 (Swagger/OpenAPI 메타데이터 추가)
- DB 스키마 변경 없음
- 비즈니스 로직 및 설정 변경 없음
- 필드 타입, 검증 규칙, JSON 직렬화 동작 변경 없음

<!-- end of auto-generated comment: release notes by coderabbit.ai -->