### PR TITLE
[Feat] 인증 실패 시 공통 에러 응답 형식 적용

### DIFF
--- a/src/main/java/com/boaz/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/boaz/backend/global/config/SecurityConfig.java
@@ -1,16 +1,21 @@
 package com.boaz.backend.global.config;
 
+import com.boaz.backend.global.exception.ErrorCode;
 import com.boaz.backend.global.security.AdminUserDetailsService;
 import com.boaz.backend.global.security.JwtAuthenticationFilter;
 import com.boaz.backend.global.security.JwtProvider;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -18,6 +23,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.io.IOException;
 
 import java.util.Arrays;
 import java.util.List;
@@ -49,12 +56,35 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/admin/**").authenticated()
                         .anyRequest().permitAll()
                 )
+                .exceptionHandling(exceptions -> exceptions
+                        .authenticationEntryPoint((request, response, e) ->
+                                sendSecurityError(response, ErrorCode.TOKEN_NOT_FOUND))
+                        .accessDeniedHandler((request, response, e) -> {
+                            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+                            ErrorCode errorCode = (auth == null || auth instanceof AnonymousAuthenticationToken)
+                                    ? ErrorCode.TOKEN_NOT_FOUND
+                                    : ErrorCode.UNAUTHORIZED;
+                            sendSecurityError(response, errorCode);
+                        })
+                )
                 .addFilterBefore(
                         new JwtAuthenticationFilter(jwtProvider, adminUserDetailsService),
                         UsernamePasswordAuthenticationFilter.class
                 );
 
         return http.build();
+    }
+
+    private void sendSecurityError(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+        String body = String.format(
+                "{\"status\":%d,\"error_code\":\"%s\",\"message\":\"%s\"}",
+                errorCode.getHttpStatus().value(),
+                errorCode.getCode(),
+                errorCode.getMessage()
+        );
+        response.getWriter().write(body);
     }
 
     @Bean

--- a/src/main/java/com/boaz/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/boaz/backend/global/config/SecurityConfig.java
@@ -1,21 +1,18 @@
 package com.boaz.backend.global.config;
 
-import com.boaz.backend.global.exception.ErrorCode;
 import com.boaz.backend.global.security.AdminUserDetailsService;
+import com.boaz.backend.global.security.CustomAccessDeniedHandler;
+import com.boaz.backend.global.security.CustomAuthenticationEntryPoint;
 import com.boaz.backend.global.security.JwtAuthenticationFilter;
 import com.boaz.backend.global.security.JwtProvider;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -23,8 +20,6 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
-import java.io.IOException;
 
 import java.util.Arrays;
 import java.util.List;
@@ -36,6 +31,8 @@ public class SecurityConfig {
 
     private final JwtProvider jwtProvider;
     private final AdminUserDetailsService adminUserDetailsService;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
 
     @Value("${cors.allowed-origins}")
     private String allowedOrigins;
@@ -57,15 +54,8 @@ public class SecurityConfig {
                         .anyRequest().permitAll()
                 )
                 .exceptionHandling(exceptions -> exceptions
-                        .authenticationEntryPoint((request, response, e) ->
-                                sendSecurityError(response, ErrorCode.TOKEN_NOT_FOUND))
-                        .accessDeniedHandler((request, response, e) -> {
-                            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-                            ErrorCode errorCode = (auth == null || auth instanceof AnonymousAuthenticationToken)
-                                    ? ErrorCode.TOKEN_NOT_FOUND
-                                    : ErrorCode.UNAUTHORIZED;
-                            sendSecurityError(response, errorCode);
-                        })
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler)
                 )
                 .addFilterBefore(
                         new JwtAuthenticationFilter(jwtProvider, adminUserDetailsService),
@@ -73,18 +63,6 @@ public class SecurityConfig {
                 );
 
         return http.build();
-    }
-
-    private void sendSecurityError(HttpServletResponse response, ErrorCode errorCode) throws IOException {
-        response.setStatus(errorCode.getHttpStatus().value());
-        response.setContentType("application/json;charset=UTF-8");
-        String body = String.format(
-                "{\"status\":%d,\"error_code\":\"%s\",\"message\":\"%s\"}",
-                errorCode.getHttpStatus().value(),
-                errorCode.getCode(),
-                errorCode.getMessage()
-        );
-        response.getWriter().write(body);
     }
 
     @Bean

--- a/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
@@ -12,8 +12,10 @@ public enum ErrorCode {
     MISSING_PARAMETER(HttpStatus.BAD_REQUEST, "MISSING_PARAMETER", "요청 파라미터가 누락되었습니다."),
     INVALID_PARAMETER_TYPE(HttpStatus.BAD_REQUEST, "INVALID_PARAMETER_TYPE", "파라미터 타입이 올바르지 않습니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "접근 권한이 없습니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "ACCESS_DENIED", "해당 리소스에 접근할 권한이 없습니다."),
 
     // Auth / Token
+    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "TOKEN_NOT_FOUND", "토큰이 존재하지 않습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "EXPIRED_TOKEN", "만료된 토큰입니다."),
 

--- a/src/main/java/com/boaz/backend/global/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/boaz/backend/global/security/CustomAccessDeniedHandler.java
@@ -4,9 +4,6 @@ import com.boaz.backend.global.exception.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
@@ -18,11 +15,7 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response,
                        AccessDeniedException accessDeniedException) throws IOException {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        ErrorCode errorCode = (auth == null || auth instanceof AnonymousAuthenticationToken)
-                ? ErrorCode.TOKEN_NOT_FOUND
-                : ErrorCode.UNAUTHORIZED;
-        sendError(response, errorCode);
+        sendError(response, ErrorCode.TOKEN_NOT_FOUND);
     }
 
     private void sendError(HttpServletResponse response, ErrorCode errorCode) throws IOException {

--- a/src/main/java/com/boaz/backend/global/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/boaz/backend/global/security/CustomAccessDeniedHandler.java
@@ -15,7 +15,7 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response,
                        AccessDeniedException accessDeniedException) throws IOException {
-        sendError(response, ErrorCode.TOKEN_NOT_FOUND);
+        sendError(response, ErrorCode.ACCESS_DENIED);
     }
 
     private void sendError(HttpServletResponse response, ErrorCode errorCode) throws IOException {

--- a/src/main/java/com/boaz/backend/global/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/boaz/backend/global/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,39 @@
+package com.boaz.backend.global.security;
+
+import com.boaz.backend.global.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        ErrorCode errorCode = (auth == null || auth instanceof AnonymousAuthenticationToken)
+                ? ErrorCode.TOKEN_NOT_FOUND
+                : ErrorCode.UNAUTHORIZED;
+        sendError(response, errorCode);
+    }
+
+    private void sendError(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+        String body = String.format(
+                "{\"status\":%d,\"error_code\":\"%s\",\"message\":\"%s\"}",
+                errorCode.getHttpStatus().value(),
+                errorCode.getCode(),
+                errorCode.getMessage()
+        );
+        response.getWriter().write(body);
+    }
+}

--- a/src/main/java/com/boaz/backend/global/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/boaz/backend/global/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,32 @@
+package com.boaz.backend.global.security;
+
+import com.boaz.backend.global.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        sendError(response, ErrorCode.TOKEN_NOT_FOUND);
+    }
+
+    private void sendError(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+        String body = String.format(
+                "{\"status\":%d,\"error_code\":\"%s\",\"message\":\"%s\"}",
+                errorCode.getHttpStatus().value(),
+                errorCode.getCode(),
+                errorCode.getMessage()
+        );
+        response.getWriter().write(body);
+    }
+}


### PR DESCRIPTION
## 💡 개요

* Issue Number: #58 

## 🪐 주요 변경 사항
- 인증/인가 실패 시 공통 에러 응답 형식 적용

## ✅ 상세 내용
- 인증/인가 예외 핸들러를 SecurityConfig 인라인에서 별도 클래스로 분리
  - CustomAuthenticationEntryPoint: 인증 실패 시 TOKEN_NOT_FOUND (401) 반환
  - CustomAccessDeniedHandler: 토큰 미포함 요청 시 TOKEN_NOT_FOUND (401) 반환
- SecurityConfig에서 핸들러 로직 및 sendSecurityError 제거, 빈 주입으로 대체
- CustomAccessDeniedHandler 불필요한 role 분기 제거 (role 체크는 Service 레벨에서 처리)

## 🔔 참고 사항
- 기존: Spring Security 기본 형식 { timestamp, status, error, path } 반환
- 변경: 공통 에러 형식 { status, error_code, message } 반환

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 변경 사항 요약

**변경 목적:**  
Spring Security의 인증/인가 실패 시 응답을 기존 기본 형식에서 공통 에러 응답 형식(`{ status, error_code, message }`)으로 통일하여 API 응답 일관성을 확보합니다.

**주요 변경 내용:**
- **CustomAuthenticationEntryPoint** 신규 클래스 추가
  - `AuthenticationEntryPoint` 구현으로 인증 실패(401 TOKEN_NOT_FOUND) 처리
  - JSON 형식의 공통 에러 응답 반환

- **CustomAccessDeniedHandler** 신규 클래스 추가
  - `AccessDeniedHandler` 구현으로 인가 실패(401 TOKEN_NOT_FOUND) 처리
  - 토큰 미포함 요청에 대한 일관된 JSON 응답 반환

- **SecurityConfig** 수정
  - 두 핸들러 빈 의존성 주입 추가
  - `.exceptionHandling()` 설정에서 커스텀 핸들러들 등록

**영향 범위:**  
API 응답 변경 — 인증/인가 실패 시 응답 형식이 `{ status, error_code, message }` 구조로 통일됨

<!-- end of auto-generated comment: release notes by coderabbit.ai -->