### PR TITLE
[Feat] JSON 예외 처리 강화 및 Track 검증 로직 추가

### DIFF
--- a/src/main/java/com/boaz/backend/domain/curriculum/service/CurriculumService.java
+++ b/src/main/java/com/boaz/backend/domain/curriculum/service/CurriculumService.java
@@ -27,6 +27,8 @@ public class CurriculumService {
         List<Curriculum> curriculums;
 
         if (track != null) {
+            track.validateNotAll();
+            
             curriculums = curriculumRepository.findByTrack(track)
                     .map(List::of)
                     .orElse(List.of());

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -104,6 +104,9 @@ public class RecruitmentService {
         if (!isActive) {
             throw new CustomException(ErrorCode.RECRUITMENT_NOT_AVAILABLE);
         }
+        
+        // 부문 검증
+        track.validateNotAll();
 
         // Track → ApplicationQuestion.Category 변환
         ApplicationQuestion.Category trackCategory = toQuestionCategory(track);
@@ -141,6 +144,9 @@ public class RecruitmentService {
         if (!isActive) {
             throw new CustomException(ErrorCode.RECRUITMENT_CLOSED);
         }
+
+        // 부문 검증
+        request.getTrack().validateNotAll();
 
         // 이메일 형식 검증
         if (!request.getEmail().matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$")) {

--- a/src/main/java/com/boaz/backend/domain/review/service/ReviewService.java
+++ b/src/main/java/com/boaz/backend/domain/review/service/ReviewService.java
@@ -19,6 +19,10 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
 
     public List<ReviewResponse> getReviews(Track track, Integer term) {
+        if (track != null) {
+            track.validateNotAll();
+        }
+
         List<Review> reviews;
 
         if (track != null && term != null) {

--- a/src/main/java/com/boaz/backend/global/common/enums/Track.java
+++ b/src/main/java/com/boaz/backend/global/common/enums/Track.java
@@ -1,6 +1,15 @@
 package com.boaz.backend.global.common.enums;
 
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+
 public enum Track {
     // 전부문, 분석, 시각화, 엔지니어링
-    ALL, ANALYSIS, VISUALIZATION, ENGINEERING
+    ALL, ANALYSIS, VISUALIZATION, ENGINEERING;
+
+    public void validateNotAll() {
+        if (this == ALL) {
+            throw new CustomException(ErrorCode.INVALID_TRACK_SELECTION);
+        }
+    }
 }

--- a/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     QUESTIONS_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTIONS_NOT_FOUND", "등록된 질문이 없습니다."),
     RECRUITMENT_CLOSED(HttpStatus.BAD_REQUEST, "RECRUITMENT_CLOSED", "현재 지원 기간이 아닙니다."),
     ANSWER_REQUIRED(HttpStatus.BAD_REQUEST, "ANSWER_REQUIRED", "필수 질문에 답변해주세요."),
+    INVALID_TRACK_SELECTION(HttpStatus.BAD_REQUEST, "INVALID_TRACK_SELECTION", "지원 부문을 올바르게 선택해주세요."),
     INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "INVALID_EMAIL_FORMAT", "이메일 형식이 올바르지 않습니다."),
     INVALID_PHONE_FORMAT(HttpStatus.BAD_REQUEST, "INVALID_PHONE_FORMAT", "전화번호 형식이 올바르지 않습니다."),
     INVALID_ANSWER_TYPE(HttpStatus.BAD_REQUEST, "INVALID_ANSWER_TYPE", "답변 형식이 올바르지 않습니다."),

--- a/src/main/java/com/boaz/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/boaz/backend/global/exception/GlobalExceptionHandler.java
@@ -1,8 +1,11 @@
 package com.boaz.backend.global.exception;
 
 import com.boaz.backend.global.common.ApiResponse;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -46,6 +49,29 @@ public class GlobalExceptionHandler {
                         400,
                         ErrorCode.MISSING_PARAMETER.getCode(),
                         ErrorCode.MISSING_PARAMETER.getMessage()
+                ));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadable(HttpMessageNotReadableException e) {
+        String message = ErrorCode.INVALID_INPUT_VALUE.getMessage();
+        
+        if (e.getCause() instanceof InvalidFormatException ife) {
+                if (!ife.getPath().isEmpty()) {
+                String fieldName = ife.getPath().get(0).getFieldName();
+                message = String.format("'%s' 필드의 값이 유효하지 않습니다. (입력값: %s)", 
+                                        fieldName, ife.getValue());
+                }
+        }
+
+        log.warn("Payload Error: {}", e.getMostSpecificCause().getMessage());
+        
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.error(
+                        400, 
+                        ErrorCode.INVALID_INPUT_VALUE.getCode(), 
+                        message
                 ));
     }
 


### PR DESCRIPTION
## 💡 개요

* Issue Number: #69

## 🪐 주요 변경 사항
- GlobalExceptionHandler 내 상세 핸들러 추가: HttpMessageNotReadableException 발생 시 구체적 에러 메시지 반환 로직 구현
- Track Enum 내 공통 검증 메서드 도입: validateNotAll() 메서드를 통한 부문 검증 로직 적용

## ✅ 상세 내용
- GlobalExceptionHandler 내 HttpMessageNotReadableException 발생 시, 파라미터명도 추출해서 에러 메시지로 반환하도록 구현
- Track을 파라미터로 사용하는 API 중, Track의 필드인 ALL이 request로 들어오면 안되는 경우에 대해 validateNotAll()를 활용한 검증 로직 적용

## 🔔 참고 사항
-
---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**변경 목적**
- JSON 파싱 예외 처리를 강화하여 사용자에게 보다 구체적인 에러 응답 제공
- Track 파라미터 검증 로직을 도입하여 ALL 값이 부적절한 API 요청 차단

**주요 변경 내용**
- **Global Exception Handling**
  - `GlobalExceptionHandler`에 `HttpMessageNotReadableException` 핸들러 추가
  - JSON 파싱 실패 시 필드명과 입력값을 포함한 상세 에러 메시지 반환
  
- **Track Enum 검증**
  - `Track` enum에 `validateNotAll()` 메서드 추가 (Track.ALL 값 검증)
  - `INVALID_TRACK_SELECTION` ErrorCode 추가
  
- **Service 계층 검증 적용**
  - `CurriculumService.getCurriculums()`: Track 파라미터 검증 추가
  - `RecruitmentService.getQuestions()`, `submitApplication()`: Track 파라미터 검증 추가
  - `ReviewService.getReviews()`: Track 파라미터 검증 추가

**영향 범위**
- **API 변경**: 기존 API 시그니처 변경 없음, 유효성 검증 강화로 특정 요청에 대해 400 에러 응답 추가
- **DB 스키마 변경**: 없음
- **설정 변경**: 없음

<!-- end of auto-generated comment: release notes by coderabbit.ai -->