### PR TITLE
[Feat] Admin 계정 관리 API 전체 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
     // env
     implementation 'io.github.cdimascio:dotenv-java:3.1.0'
 
+    // JsonNullable
+    implementation 'org.openapitools:jackson-databind-nullable:0.2.6'
+
     // S3
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1'
 

--- a/src/main/java/com/boaz/backend/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/boaz/backend/domain/admin/controller/AdminController.java
@@ -1,6 +1,7 @@
 package com.boaz.backend.domain.admin.controller;
 
 import com.boaz.backend.domain.admin.dto.request.AdminCreateRequest;
+import com.boaz.backend.domain.admin.dto.request.AdminUpdateRequest;
 import com.boaz.backend.domain.admin.dto.response.AdminAccountResponse;
 import com.boaz.backend.domain.admin.dto.response.AdminIdResponse;
 import com.boaz.backend.domain.admin.service.AdminService;
@@ -15,6 +16,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -58,6 +60,17 @@ public class AdminController {
             @AuthenticationPrincipal AdminUserDetails userDetails
     ) {
         AdminAccountResponse response = adminService.getAccount(id, userDetails.getAdmin());
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @Operation(summary = "id별 계정 수정 (SUPER: role 포함 전체 / TEAM: 본인 프로필만)")
+    @PatchMapping("/accounts/{id}")
+    public ResponseEntity<ApiResponse<AdminIdResponse>> updateAccount(
+            @PathVariable Long id,
+            @RequestBody AdminUpdateRequest request,
+            @AuthenticationPrincipal AdminUserDetails userDetails
+    ) {
+        AdminIdResponse response = adminService.updateAccount(id, request, userDetails.getAdmin());
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 }

--- a/src/main/java/com/boaz/backend/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/boaz/backend/domain/admin/controller/AdminController.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -73,6 +74,16 @@ public class AdminController {
     ) {
         AdminIdResponse response = adminService.updateAccount(id, request, userDetails.getAdmin());
         return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @Operation(summary = "id별 계정 삭제 (SUPER: 전체 / TEAM: 본인만)")
+    @DeleteMapping("/accounts/{id}")
+    public ResponseEntity<ApiResponse<Void>> deleteAccount(
+            @PathVariable Long id,
+            @AuthenticationPrincipal AdminUserDetails userDetails
+    ) {
+        adminService.deleteAccount(id, userDetails.getAdmin());
+        return ResponseEntity.ok(ApiResponse.ok(null));
     }
 
     @Operation(summary = "비밀번호 초기화 (SUPER: 전체 / TEAM: 본인만)")

--- a/src/main/java/com/boaz/backend/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/boaz/backend/domain/admin/controller/AdminController.java
@@ -1,15 +1,47 @@
 package com.boaz.backend.domain.admin.controller;
 
+import com.boaz.backend.domain.admin.dto.response.AdminAccountResponse;
+import com.boaz.backend.domain.admin.service.AdminService;
+import com.boaz.backend.global.common.ApiResponse;
+import com.boaz.backend.global.security.AdminUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
 
 @Tag(name = "Admin", description = "관리자 API")
+@SecurityRequirement(name = "bearerAuth")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin")
 public class AdminController {
 
+    private final AdminService adminService;
+
+    @Operation(summary = "모든 계정 조회 (SUPER only)")
+    @GetMapping("/accounts")
+    public ResponseEntity<ApiResponse<List<AdminAccountResponse>>> getAccounts(
+            @AuthenticationPrincipal AdminUserDetails userDetails
+    ) {
+        List<AdminAccountResponse> response = adminService.getAccounts(userDetails.getAdmin());
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @Operation(summary = "id별 계정 조회 (SUPER: 전체 / TEAM: 본인만)")
+    @GetMapping("/accounts/{id}")
+    public ResponseEntity<ApiResponse<AdminAccountResponse>> getAccount(
+            @PathVariable Long id,
+            @AuthenticationPrincipal AdminUserDetails userDetails
+    ) {
+        AdminAccountResponse response = adminService.getAccount(id, userDetails.getAdmin());
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
 }

--- a/src/main/java/com/boaz/backend/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/boaz/backend/domain/admin/controller/AdminController.java
@@ -1,6 +1,7 @@
 package com.boaz.backend.domain.admin.controller;
 
 import com.boaz.backend.domain.admin.dto.request.AdminCreateRequest;
+import com.boaz.backend.domain.admin.dto.request.AdminPasswordResetRequest;
 import com.boaz.backend.domain.admin.dto.request.AdminUpdateRequest;
 import com.boaz.backend.domain.admin.dto.response.AdminAccountResponse;
 import com.boaz.backend.domain.admin.dto.response.AdminIdResponse;
@@ -72,5 +73,16 @@ public class AdminController {
     ) {
         AdminIdResponse response = adminService.updateAccount(id, request, userDetails.getAdmin());
         return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @Operation(summary = "비밀번호 초기화 (SUPER: 전체 / TEAM: 본인만)")
+    @PatchMapping("/accounts/{id}/password")
+    public ResponseEntity<ApiResponse<Void>> resetPassword(
+            @PathVariable Long id,
+            @RequestBody @Valid AdminPasswordResetRequest request,
+            @AuthenticationPrincipal AdminUserDetails userDetails
+    ) {
+        adminService.resetPassword(id, request, userDetails.getAdmin());
+        return ResponseEntity.ok(ApiResponse.ok(null));
     }
 }

--- a/src/main/java/com/boaz/backend/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/boaz/backend/domain/admin/controller/AdminController.java
@@ -89,8 +89,8 @@ public class AdminController {
         return ResponseEntity.ok(ApiResponse.ok(null));
     }
 
-    @Operation(summary = "비밀번호 초기화 (SUPER: 전체 / TEAM: 본인만)",
-            description = "비밀번호 변경 후 해당 계정의 RefreshToken 삭제(재로그인 강제).")
+    @Operation(summary = "비밀번호 변경 (SUPER: 전체 초기화 / TEAM: 본인만)",
+            description = "본인 비밀번호 변경 시 currentPassword 필수 (역할 무관). SUPER의 타인 초기화 시 currentPassword 불필요. 변경 후 해당 계정의 RefreshToken 삭제(재로그인 강제).")
     @PatchMapping("/accounts/{id}/password")
     public ResponseEntity<ApiResponse<Void>> resetPassword(
             @PathVariable Long id,

--- a/src/main/java/com/boaz/backend/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/boaz/backend/domain/admin/controller/AdminController.java
@@ -36,7 +36,8 @@ public class AdminController {
 
     private final AdminService adminService;
 
-    @Operation(summary = "계정 생성 (SUPER only)")
+    @Operation(summary = "계정 생성 (SUPER only)",
+            description = "SUPER 권한만 호출 가능. track은 ALL 제외 ANALYSIS·VISUALIZATION·ENGINEERING만 허용.")
     @PostMapping("/accounts")
     public ResponseEntity<ApiResponse<AdminIdResponse>> createAccount(
             @RequestBody @Valid AdminCreateRequest request,
@@ -65,7 +66,8 @@ public class AdminController {
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
-    @Operation(summary = "id별 계정 수정 (SUPER: role 포함 전체 / TEAM: 본인 프로필만)")
+    @Operation(summary = "id별 계정 수정 (SUPER: role 포함 전체 / TEAM: 본인 프로필만)",
+            description = "모든 필드 선택적. role 변경 시 해당 계정의 RefreshToken 삭제(재로그인 강제). 본인 role 변경 불가.")
     @PatchMapping("/accounts/{id}")
     public ResponseEntity<ApiResponse<AdminIdResponse>> updateAccount(
             @PathVariable Long id,
@@ -76,7 +78,8 @@ public class AdminController {
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
-    @Operation(summary = "id별 계정 삭제 (SUPER: 전체 / TEAM: 본인만)")
+    @Operation(summary = "id별 계정 삭제 (SUPER: 전체 / TEAM: 본인만)",
+            description = "soft delete. 마지막 SUPER 계정은 삭제 불가. 삭제 시 RefreshToken도 함께 삭제.")
     @DeleteMapping("/accounts/{id}")
     public ResponseEntity<ApiResponse<Void>> deleteAccount(
             @PathVariable Long id,
@@ -86,7 +89,8 @@ public class AdminController {
         return ResponseEntity.ok(ApiResponse.ok(null));
     }
 
-    @Operation(summary = "비밀번호 초기화 (SUPER: 전체 / TEAM: 본인만)")
+    @Operation(summary = "비밀번호 초기화 (SUPER: 전체 / TEAM: 본인만)",
+            description = "비밀번호 변경 후 해당 계정의 RefreshToken 삭제(재로그인 강제).")
     @PatchMapping("/accounts/{id}/password")
     public ResponseEntity<ApiResponse<Void>> resetPassword(
             @PathVariable Long id,

--- a/src/main/java/com/boaz/backend/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/boaz/backend/domain/admin/controller/AdminController.java
@@ -1,17 +1,23 @@
 package com.boaz.backend.domain.admin.controller;
 
+import com.boaz.backend.domain.admin.dto.request.AdminCreateRequest;
 import com.boaz.backend.domain.admin.dto.response.AdminAccountResponse;
+import com.boaz.backend.domain.admin.dto.response.AdminIdResponse;
 import com.boaz.backend.domain.admin.service.AdminService;
 import com.boaz.backend.global.common.ApiResponse;
 import com.boaz.backend.global.security.AdminUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,6 +31,16 @@ import java.util.List;
 public class AdminController {
 
     private final AdminService adminService;
+
+    @Operation(summary = "계정 생성 (SUPER only)")
+    @PostMapping("/accounts")
+    public ResponseEntity<ApiResponse<AdminIdResponse>> createAccount(
+            @RequestBody @Valid AdminCreateRequest request,
+            @AuthenticationPrincipal AdminUserDetails userDetails
+    ) {
+        AdminIdResponse response = adminService.createAccount(request, userDetails.getAdmin());
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created(response));
+    }
 
     @Operation(summary = "모든 계정 조회 (SUPER only)")
     @GetMapping("/accounts")

--- a/src/main/java/com/boaz/backend/domain/admin/dto/request/AdminCreateRequest.java
+++ b/src/main/java/com/boaz/backend/domain/admin/dto/request/AdminCreateRequest.java
@@ -3,6 +3,7 @@ package com.boaz.backend.domain.admin.dto.request;
 import com.boaz.backend.domain.admin.entity.Admin;
 import com.boaz.backend.global.common.enums.Track;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -37,6 +38,7 @@ public class AdminCreateRequest {
     private Track track;
 
     @NotNull
+    @Min(0)
     @Schema(description = "기수", example = "25")
     private Integer term;
 

--- a/src/main/java/com/boaz/backend/domain/admin/dto/request/AdminCreateRequest.java
+++ b/src/main/java/com/boaz/backend/domain/admin/dto/request/AdminCreateRequest.java
@@ -2,6 +2,7 @@ package com.boaz.backend.domain.admin.dto.request;
 
 import com.boaz.backend.domain.admin.entity.Admin;
 import com.boaz.backend.global.common.enums.Track;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -11,6 +12,7 @@ import lombok.Getter;
 public class AdminCreateRequest {
 
     @NotBlank
+    @Schema(description = "로그인 ID", example = "boaz_team2")
     private String username;
 
     @NotBlank
@@ -18,20 +20,28 @@ public class AdminCreateRequest {
             regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*]).{8,}$",
             message = "비밀번호는 최소 8자 이상, 영문+숫자+특수문자(!@#$%^&*)를 포함해야 합니다."
     )
+    @Schema(description = "비밀번호 (8자 이상, 영문+숫자+특수문자 포함)", example = "Boaz1234!")
     private String password;
 
     @NotNull
+    @Schema(description = "역할", example = "TEAM", allowableValues = {"SUPER", "TEAM"})
     private Admin.Role role;
 
     @NotBlank
+    @Schema(description = "이름", example = "김보아즈")
     private String name;
 
     @NotNull
+    @Schema(description = "부문 (ALL 제외)", example = "ANALYSIS",
+            allowableValues = {"ANALYSIS", "VISUALIZATION", "ENGINEERING"})
     private Track track;
 
     @NotNull
+    @Schema(description = "기수", example = "25")
     private Integer term;
 
     @NotNull
+    @Schema(description = "직책/소속", example = "서비스운영팀",
+            allowableValues = {"대표진", "디자인팀", "자료연구팀", "운영지원팀", "기획팀", "대외협력팀", "서비스운영팀"})
     private Admin.TeamName teamName;
 }

--- a/src/main/java/com/boaz/backend/domain/admin/dto/request/AdminCreateRequest.java
+++ b/src/main/java/com/boaz/backend/domain/admin/dto/request/AdminCreateRequest.java
@@ -1,0 +1,37 @@
+package com.boaz.backend.domain.admin.dto.request;
+
+import com.boaz.backend.domain.admin.entity.Admin;
+import com.boaz.backend.global.common.enums.Track;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class AdminCreateRequest {
+
+    @NotBlank
+    private String username;
+
+    @NotBlank
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*]).{8,}$",
+            message = "비밀번호는 최소 8자 이상, 영문+숫자+특수문자(!@#$%^&*)를 포함해야 합니다."
+    )
+    private String password;
+
+    @NotNull
+    private Admin.Role role;
+
+    @NotBlank
+    private String name;
+
+    @NotNull
+    private Track track;
+
+    @NotNull
+    private Integer term;
+
+    @NotNull
+    private Admin.TeamName teamName;
+}

--- a/src/main/java/com/boaz/backend/domain/admin/dto/request/AdminPasswordResetRequest.java
+++ b/src/main/java/com/boaz/backend/domain/admin/dto/request/AdminPasswordResetRequest.java
@@ -1,5 +1,6 @@
 package com.boaz.backend.domain.admin.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
@@ -12,5 +13,6 @@ public class AdminPasswordResetRequest {
             regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*]).{8,}$",
             message = "비밀번호는 8자 이상이며 영문, 숫자, 특수문자(!@#$%^&*)를 각 1개 이상 포함해야 합니다."
     )
+    @Schema(description = "새 비밀번호 (8자 이상, 영문+숫자+특수문자 포함)", example = "NewBoaz1234!")
     private String newPassword;
 }

--- a/src/main/java/com/boaz/backend/domain/admin/dto/request/AdminPasswordResetRequest.java
+++ b/src/main/java/com/boaz/backend/domain/admin/dto/request/AdminPasswordResetRequest.java
@@ -8,6 +8,9 @@ import lombok.Getter;
 @Getter
 public class AdminPasswordResetRequest {
 
+    @Schema(description = "현재 비밀번호 (본인 변경 시 필수, SUPER의 타인 초기화 시 불필요)", example = "Boaz1234!")
+    private String currentPassword;
+
     @NotBlank
     @Pattern(
             regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*]).{8,}$",

--- a/src/main/java/com/boaz/backend/domain/admin/dto/request/AdminPasswordResetRequest.java
+++ b/src/main/java/com/boaz/backend/domain/admin/dto/request/AdminPasswordResetRequest.java
@@ -1,0 +1,16 @@
+package com.boaz.backend.domain.admin.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class AdminPasswordResetRequest {
+
+    @NotBlank
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*]).{8,}$",
+            message = "비밀번호는 8자 이상이며 영문, 숫자, 특수문자(!@#$%^&*)를 각 1개 이상 포함해야 합니다."
+    )
+    private String newPassword;
+}

--- a/src/main/java/com/boaz/backend/domain/admin/dto/request/AdminUpdateRequest.java
+++ b/src/main/java/com/boaz/backend/domain/admin/dto/request/AdminUpdateRequest.java
@@ -2,15 +2,28 @@ package com.boaz.backend.domain.admin.dto.request;
 
 import com.boaz.backend.domain.admin.entity.Admin;
 import com.boaz.backend.global.common.enums.Track;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import org.openapitools.jackson.nullable.JsonNullable;
 
 @Getter
 public class AdminUpdateRequest {
 
+    @Schema(description = "역할 (SUPER only, 본인 변경 불가)", example = "TEAM",
+            allowableValues = {"SUPER", "TEAM"})
     private JsonNullable<Admin.Role> role = JsonNullable.undefined();
+
+    @Schema(description = "이름", example = "김보아즈")
     private JsonNullable<String> name = JsonNullable.undefined();
+
+    @Schema(description = "부문 (ALL 제외)", example = "ANALYSIS",
+            allowableValues = {"ANALYSIS", "VISUALIZATION", "ENGINEERING"})
     private JsonNullable<Track> track = JsonNullable.undefined();
+
+    @Schema(description = "기수", example = "25")
     private JsonNullable<Integer> term = JsonNullable.undefined();
+
+    @Schema(description = "직책/소속", example = "서비스운영팀",
+            allowableValues = {"대표진", "디자인팀", "자료연구팀", "운영지원팀", "기획팀", "대외협력팀", "서비스운영팀"})
     private JsonNullable<Admin.TeamName> teamName = JsonNullable.undefined();
 }

--- a/src/main/java/com/boaz/backend/domain/admin/dto/request/AdminUpdateRequest.java
+++ b/src/main/java/com/boaz/backend/domain/admin/dto/request/AdminUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.boaz.backend.domain.admin.dto.request;
+
+import com.boaz.backend.domain.admin.entity.Admin;
+import com.boaz.backend.global.common.enums.Track;
+import lombok.Getter;
+import org.openapitools.jackson.nullable.JsonNullable;
+
+@Getter
+public class AdminUpdateRequest {
+
+    private JsonNullable<Admin.Role> role = JsonNullable.undefined();
+    private JsonNullable<String> name = JsonNullable.undefined();
+    private JsonNullable<Track> track = JsonNullable.undefined();
+    private JsonNullable<Integer> term = JsonNullable.undefined();
+    private JsonNullable<Admin.TeamName> teamName = JsonNullable.undefined();
+}

--- a/src/main/java/com/boaz/backend/domain/admin/dto/response/AdminAccountResponse.java
+++ b/src/main/java/com/boaz/backend/domain/admin/dto/response/AdminAccountResponse.java
@@ -2,6 +2,7 @@ package com.boaz.backend.domain.admin.dto.response;
 
 import com.boaz.backend.domain.admin.entity.Admin;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,19 +12,38 @@ import java.time.LocalDateTime;
 @Builder
 public class AdminAccountResponse {
 
+    @Schema(description = "계정 ID", example = "1")
     private Long id;
+
+    @Schema(description = "로그인 ID", example = "boaz_team2")
     private String username;
+
+    @Schema(description = "역할", example = "TEAM", allowableValues = {"SUPER", "TEAM"})
     private String role;
+
+    @Schema(description = "이름", example = "김보아즈")
     private String name;
+
+    @Schema(description = "부문", example = "ANALYSIS",
+            allowableValues = {"ANALYSIS", "VISUALIZATION", "ENGINEERING"})
     private String track;
+
+    @Schema(description = "기수", example = "25")
     private Integer term;
+
+    @Schema(description = "직책/소속", example = "서비스운영팀",
+            allowableValues = {"대표진", "디자인팀", "자료연구팀", "운영지원팀", "기획팀", "대외협력팀", "서비스운영팀"})
     private String teamName;
+
+    @Schema(description = "생성한 SUPER 계정 ID", example = "1", nullable = true)
     private Long createdBy;
 
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    @Schema(description = "생성 일시", example = "2025-01-01T00:00:00")
     private LocalDateTime createdAt;
 
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    @Schema(description = "수정 일시", example = "2025-01-01T00:00:00")
     private LocalDateTime updatedAt;
 
     public static AdminAccountResponse from(Admin admin) {

--- a/src/main/java/com/boaz/backend/domain/admin/dto/response/AdminAccountResponse.java
+++ b/src/main/java/com/boaz/backend/domain/admin/dto/response/AdminAccountResponse.java
@@ -1,0 +1,43 @@
+package com.boaz.backend.domain.admin.dto.response;
+
+import com.boaz.backend.domain.admin.entity.Admin;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class AdminAccountResponse {
+
+    private Long id;
+    private String username;
+    private String role;
+    private String name;
+    private String track;
+    private Integer term;
+    private String teamName;
+    private Long createdBy;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime createdAt;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime updatedAt;
+
+    public static AdminAccountResponse from(Admin admin) {
+        return AdminAccountResponse.builder()
+                .id(admin.getId())
+                .username(admin.getUsername())
+                .role(admin.getRole().name())
+                .name(admin.getName())
+                .track(admin.getTrack().name())
+                .term(admin.getTerm())
+                .teamName(admin.getTeamName().name())
+                .createdBy(admin.getCreatedBy())
+                .createdAt(admin.getCreatedAt())
+                .updatedAt(admin.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/boaz/backend/domain/admin/dto/response/AdminIdResponse.java
+++ b/src/main/java/com/boaz/backend/domain/admin/dto/response/AdminIdResponse.java
@@ -1,0 +1,11 @@
+package com.boaz.backend.domain.admin.dto.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class AdminIdResponse {
+
+    private final Long id;
+}

--- a/src/main/java/com/boaz/backend/domain/admin/dto/response/AdminIdResponse.java
+++ b/src/main/java/com/boaz/backend/domain/admin/dto/response/AdminIdResponse.java
@@ -1,5 +1,6 @@
 package com.boaz.backend.domain.admin.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -7,5 +8,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AdminIdResponse {
 
+    @Schema(description = "계정 ID", example = "1")
     private final Long id;
 }

--- a/src/main/java/com/boaz/backend/domain/admin/entity/Admin.java
+++ b/src/main/java/com/boaz/backend/domain/admin/entity/Admin.java
@@ -37,7 +37,7 @@ public class Admin extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true, updatable = false)
+    @Column(nullable = false, updatable = false)
     private String username;
 
     @Column(nullable = false)

--- a/src/main/java/com/boaz/backend/domain/admin/entity/Admin.java
+++ b/src/main/java/com/boaz/backend/domain/admin/entity/Admin.java
@@ -2,6 +2,7 @@ package com.boaz.backend.domain.admin.entity;
 
 import com.boaz.backend.global.common.BaseEntity;
 import com.boaz.backend.global.common.enums.Track;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -18,11 +19,18 @@ import java.time.LocalDateTime;
 public class Admin extends BaseEntity {
 
     public enum Role {
-        SUPER, TEAM
+        @Schema(description = "슈퍼 관리자") SUPER,
+        @Schema(description = "팀 관리자") TEAM
     }
-    
+
     public enum TeamName {
-        대표진, 운영지원팀, 대외협력팀, 서비스운영팀, 자료연구팀
+        @Schema(description = "대표진") 대표진,
+        @Schema(description = "디자인팀") 디자인팀,
+        @Schema(description = "자료연구팀") 자료연구팀,
+        @Schema(description = "운영지원팀") 운영지원팀,
+        @Schema(description = "기획팀") 기획팀,
+        @Schema(description = "대외협력팀") 대외협력팀,
+        @Schema(description = "서비스운영팀") 서비스운영팀,
     }
 
     @Id

--- a/src/main/java/com/boaz/backend/domain/admin/entity/Admin.java
+++ b/src/main/java/com/boaz/backend/domain/admin/entity/Admin.java
@@ -70,6 +70,26 @@ public class Admin extends BaseEntity {
         this.createdBy = createdBy;
     }
 
+    public void updateRole(Role role) {
+        this.role = role;
+    }
+
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    public void updateTrack(Track track) {
+        this.track = track;
+    }
+
+    public void updateTerm(Integer term) {
+        this.term = term;
+    }
+
+    public void updateTeamName(TeamName teamName) {
+        this.teamName = teamName;
+    }
+
     public void resetPassword(String encodedPassword) {
         this.password = encodedPassword;
     }

--- a/src/main/java/com/boaz/backend/domain/admin/repository/AdminRepository.java
+++ b/src/main/java/com/boaz/backend/domain/admin/repository/AdminRepository.java
@@ -3,6 +3,7 @@ package com.boaz.backend.domain.admin.repository;
 import com.boaz.backend.domain.admin.entity.Admin;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface AdminRepository extends JpaRepository<Admin, Long> {
@@ -10,4 +11,8 @@ public interface AdminRepository extends JpaRepository<Admin, Long> {
     Optional<Admin> findByUsernameAndDeletedAtIsNull(String username);
 
     boolean existsByUsernameAndDeletedAtIsNull(String username);
+
+    List<Admin> findAllByDeletedAtIsNullOrderByCreatedAtAsc();
+
+    Optional<Admin> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/com/boaz/backend/domain/admin/repository/AdminRepository.java
+++ b/src/main/java/com/boaz/backend/domain/admin/repository/AdminRepository.java
@@ -15,4 +15,6 @@ public interface AdminRepository extends JpaRepository<Admin, Long> {
     List<Admin> findAllByDeletedAtIsNullOrderByCreatedAtAsc();
 
     Optional<Admin> findByIdAndDeletedAtIsNull(Long id);
+
+    long countByRoleAndDeletedAtIsNull(Admin.Role role);
 }

--- a/src/main/java/com/boaz/backend/domain/admin/service/AdminService.java
+++ b/src/main/java/com/boaz/backend/domain/admin/service/AdminService.java
@@ -1,0 +1,42 @@
+package com.boaz.backend.domain.admin.service;
+
+import com.boaz.backend.domain.admin.dto.response.AdminAccountResponse;
+import com.boaz.backend.domain.admin.entity.Admin;
+import com.boaz.backend.domain.admin.repository.AdminRepository;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminService {
+
+    private final AdminRepository adminRepository;
+
+    public List<AdminAccountResponse> getAccounts(Admin currentAdmin) {
+        if (currentAdmin.getRole() != Admin.Role.SUPER) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        return adminRepository.findAllByDeletedAtIsNullOrderByCreatedAtAsc()
+                .stream()
+                .map(AdminAccountResponse::from)
+                .toList();
+    }
+
+    public AdminAccountResponse getAccount(Long id, Admin currentAdmin) {
+        if (currentAdmin.getRole() == Admin.Role.TEAM && !currentAdmin.getId().equals(id)) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        Admin admin = adminRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+
+        return AdminAccountResponse.from(admin);
+    }
+}

--- a/src/main/java/com/boaz/backend/domain/admin/service/AdminService.java
+++ b/src/main/java/com/boaz/backend/domain/admin/service/AdminService.java
@@ -112,6 +112,24 @@ public class AdminService {
     }
 
     @Transactional
+    public void deleteAccount(Long id, Admin currentAdmin) {
+        if (currentAdmin.getRole() == Admin.Role.TEAM && !currentAdmin.getId().equals(id)) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        Admin admin = adminRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+
+        if (admin.getRole() == Admin.Role.SUPER
+                && adminRepository.countByRoleAndDeletedAtIsNull(Admin.Role.SUPER) <= 1) {
+            throw new CustomException(ErrorCode.LAST_SUPER_ACCOUNT);
+        }
+
+        admin.softDelete();
+        refreshTokenRepository.deleteByAdminId(id);
+    }
+
+    @Transactional
     public void resetPassword(Long id, AdminPasswordResetRequest request, Admin currentAdmin) {
         if (currentAdmin.getRole() == Admin.Role.TEAM && !currentAdmin.getId().equals(id)) {
             throw new CustomException(ErrorCode.UNAUTHORIZED);

--- a/src/main/java/com/boaz/backend/domain/admin/service/AdminService.java
+++ b/src/main/java/com/boaz/backend/domain/admin/service/AdminService.java
@@ -1,11 +1,15 @@
 package com.boaz.backend.domain.admin.service;
 
+import com.boaz.backend.domain.admin.dto.request.AdminCreateRequest;
 import com.boaz.backend.domain.admin.dto.response.AdminAccountResponse;
+import com.boaz.backend.domain.admin.dto.response.AdminIdResponse;
 import com.boaz.backend.domain.admin.entity.Admin;
 import com.boaz.backend.domain.admin.repository.AdminRepository;
+import com.boaz.backend.global.common.enums.Track;
 import com.boaz.backend.global.exception.CustomException;
 import com.boaz.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +21,7 @@ import java.util.List;
 public class AdminService {
 
     private final AdminRepository adminRepository;
+    private final PasswordEncoder passwordEncoder;
 
     public List<AdminAccountResponse> getAccounts(Admin currentAdmin) {
         if (currentAdmin.getRole() != Admin.Role.SUPER) {
@@ -27,6 +32,35 @@ public class AdminService {
                 .stream()
                 .map(AdminAccountResponse::from)
                 .toList();
+    }
+
+    @Transactional
+    public AdminIdResponse createAccount(AdminCreateRequest request, Admin currentAdmin) {
+        if (currentAdmin.getRole() != Admin.Role.SUPER) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        if (request.getTrack() == Track.ALL) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        if (adminRepository.existsByUsernameAndDeletedAtIsNull(request.getUsername())) {
+            throw new CustomException(ErrorCode.DUPLICATE_USERNAME);
+        }
+
+        Admin admin = Admin.builder()
+                .username(request.getUsername())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .role(request.getRole())
+                .name(request.getName())
+                .track(request.getTrack())
+                .term(request.getTerm())
+                .teamName(request.getTeamName())
+                .createdBy(currentAdmin.getId())
+                .build();
+
+        adminRepository.save(admin);
+        return new AdminIdResponse(admin.getId());
     }
 
     public AdminAccountResponse getAccount(Long id, Admin currentAdmin) {

--- a/src/main/java/com/boaz/backend/domain/admin/service/AdminService.java
+++ b/src/main/java/com/boaz/backend/domain/admin/service/AdminService.java
@@ -141,6 +141,16 @@ public class AdminService {
         Admin admin = adminRepository.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
 
+        boolean isSelf = currentAdmin.getId().equals(id);
+        if (isSelf) {
+            if (request.getCurrentPassword() == null || request.getCurrentPassword().isBlank()) {
+                throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+            }
+            if (!passwordEncoder.matches(request.getCurrentPassword(), admin.getPassword())) {
+                throw new CustomException(ErrorCode.INVALID_CURRENT_PASSWORD);
+            }
+        }
+
         admin.resetPassword(passwordEncoder.encode(request.getNewPassword()));
         refreshTokenRepository.deleteByAdminId(id);
     }

--- a/src/main/java/com/boaz/backend/domain/admin/service/AdminService.java
+++ b/src/main/java/com/boaz/backend/domain/admin/service/AdminService.java
@@ -66,7 +66,9 @@ public class AdminService {
     }
 
     public AdminAccountResponse getAccount(Long id, Admin currentAdmin) {
-        if (currentAdmin.getRole() == Admin.Role.TEAM && !currentAdmin.getId().equals(id)) {
+        boolean isSelf = currentAdmin.getId().equals(id);
+        boolean isTeam = currentAdmin.getRole() == Admin.Role.TEAM;
+        if (isTeam && !isSelf) {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
 
@@ -78,18 +80,16 @@ public class AdminService {
 
     @Transactional
     public AdminIdResponse updateAccount(Long id, AdminUpdateRequest request, Admin currentAdmin) {
-        // TEAM은 본인 계정만 수정 가능
-        if (currentAdmin.getRole() == Admin.Role.TEAM && !currentAdmin.getId().equals(id)) {
+        boolean isSelf = currentAdmin.getId().equals(id);
+        boolean isTeam = currentAdmin.getRole() == Admin.Role.TEAM;
+
+        if (isTeam && !isSelf) {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
-
-        // TEAM은 role 변경 불가
-        if (currentAdmin.getRole() == Admin.Role.TEAM && request.getRole().isPresent()) {
+        if (isTeam && request.getRole().isPresent()) {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
-
-        // 본인 role 변경 불가
-        if (request.getRole().isPresent() && currentAdmin.getId().equals(id)) {
+        if (isSelf && request.getRole().isPresent()) {
             throw new CustomException(ErrorCode.CANNOT_MODIFY_OWN_ROLE);
         }
 
@@ -116,7 +116,9 @@ public class AdminService {
 
     @Transactional
     public void deleteAccount(Long id, Admin currentAdmin) {
-        if (currentAdmin.getRole() == Admin.Role.TEAM && !currentAdmin.getId().equals(id)) {
+        boolean isSelf = currentAdmin.getId().equals(id);
+        boolean isTeam = currentAdmin.getRole() == Admin.Role.TEAM;
+        if (isTeam && !isSelf) {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
 
@@ -134,14 +136,14 @@ public class AdminService {
 
     @Transactional
     public void resetPassword(Long id, AdminPasswordResetRequest request, Admin currentAdmin) {
-        if (currentAdmin.getRole() == Admin.Role.TEAM && !currentAdmin.getId().equals(id)) {
+        boolean isSelf = currentAdmin.getId().equals(id);
+        boolean isTeam = currentAdmin.getRole() == Admin.Role.TEAM;
+        if (isTeam && !isSelf) {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
 
         Admin admin = adminRepository.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
-
-        boolean isSelf = currentAdmin.getId().equals(id);
         if (isSelf) {
             if (request.getCurrentPassword() == null || request.getCurrentPassword().isBlank()) {
                 throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);

--- a/src/main/java/com/boaz/backend/domain/admin/service/AdminService.java
+++ b/src/main/java/com/boaz/backend/domain/admin/service/AdminService.java
@@ -1,10 +1,12 @@
 package com.boaz.backend.domain.admin.service;
 
 import com.boaz.backend.domain.admin.dto.request.AdminCreateRequest;
+import com.boaz.backend.domain.admin.dto.request.AdminUpdateRequest;
 import com.boaz.backend.domain.admin.dto.response.AdminAccountResponse;
 import com.boaz.backend.domain.admin.dto.response.AdminIdResponse;
 import com.boaz.backend.domain.admin.entity.Admin;
 import com.boaz.backend.domain.admin.repository.AdminRepository;
+import com.boaz.backend.domain.auth.repository.RefreshTokenRepository;
 import com.boaz.backend.global.common.enums.Track;
 import com.boaz.backend.global.exception.CustomException;
 import com.boaz.backend.global.exception.ErrorCode;
@@ -22,6 +24,7 @@ public class AdminService {
 
     private final AdminRepository adminRepository;
     private final PasswordEncoder passwordEncoder;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     public List<AdminAccountResponse> getAccounts(Admin currentAdmin) {
         if (currentAdmin.getRole() != Admin.Role.SUPER) {
@@ -70,5 +73,40 @@ public class AdminService {
                 .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
 
         return AdminAccountResponse.from(admin);
+    }
+
+    @Transactional
+    public AdminIdResponse updateAccount(Long id, AdminUpdateRequest request, Admin currentAdmin) {
+        // TEAM은 본인 계정만 수정 가능
+        if (currentAdmin.getRole() == Admin.Role.TEAM && !currentAdmin.getId().equals(id)) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // TEAM은 role 변경 불가
+        if (currentAdmin.getRole() == Admin.Role.TEAM && request.getRole().isPresent()) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // 본인 role 변경 불가
+        if (request.getRole().isPresent() && currentAdmin.getId().equals(id)) {
+            throw new CustomException(ErrorCode.CANNOT_MODIFY_OWN_ROLE);
+        }
+
+        Admin admin = adminRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+
+        request.getTrack().ifPresent(Track::validateNotAll);
+
+        request.getRole().ifPresent(role -> {
+            admin.updateRole(role);
+            refreshTokenRepository.deleteByAdminId(id);
+        });
+
+        request.getName().ifPresent(admin::updateName);
+        request.getTrack().ifPresent(admin::updateTrack);
+        request.getTerm().ifPresent(admin::updateTerm);
+        request.getTeamName().ifPresent(admin::updateTeamName);
+
+        return new AdminIdResponse(admin.getId());
     }
 }

--- a/src/main/java/com/boaz/backend/domain/admin/service/AdminService.java
+++ b/src/main/java/com/boaz/backend/domain/admin/service/AdminService.java
@@ -1,6 +1,7 @@
 package com.boaz.backend.domain.admin.service;
 
 import com.boaz.backend.domain.admin.dto.request.AdminCreateRequest;
+import com.boaz.backend.domain.admin.dto.request.AdminPasswordResetRequest;
 import com.boaz.backend.domain.admin.dto.request.AdminUpdateRequest;
 import com.boaz.backend.domain.admin.dto.response.AdminAccountResponse;
 import com.boaz.backend.domain.admin.dto.response.AdminIdResponse;
@@ -108,5 +109,18 @@ public class AdminService {
         request.getTeamName().ifPresent(admin::updateTeamName);
 
         return new AdminIdResponse(admin.getId());
+    }
+
+    @Transactional
+    public void resetPassword(Long id, AdminPasswordResetRequest request, Admin currentAdmin) {
+        if (currentAdmin.getRole() == Admin.Role.TEAM && !currentAdmin.getId().equals(id)) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        Admin admin = adminRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+
+        admin.resetPassword(passwordEncoder.encode(request.getNewPassword()));
+        refreshTokenRepository.deleteByAdminId(id);
     }
 }

--- a/src/main/java/com/boaz/backend/domain/admin/service/AdminService.java
+++ b/src/main/java/com/boaz/backend/domain/admin/service/AdminService.java
@@ -105,7 +105,10 @@ public class AdminService {
 
         request.getName().ifPresent(admin::updateName);
         request.getTrack().ifPresent(admin::updateTrack);
-        request.getTerm().ifPresent(admin::updateTerm);
+        request.getTerm().ifPresent(t -> {
+            if (t < 0) throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+            admin.updateTerm(t);
+        });
         request.getTeamName().ifPresent(admin::updateTeamName);
 
         return new AdminIdResponse(admin.getId());

--- a/src/main/java/com/boaz/backend/domain/admin/service/AdminService.java
+++ b/src/main/java/com/boaz/backend/domain/admin/service/AdminService.java
@@ -40,9 +40,7 @@ public class AdminService {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
 
-        if (request.getTrack() == Track.ALL) {
-            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
-        }
+        request.getTrack().validateNotAll();
 
         if (adminRepository.existsByUsernameAndDeletedAtIsNull(request.getUsername())) {
             throw new CustomException(ErrorCode.DUPLICATE_USERNAME);

--- a/src/main/java/com/boaz/backend/domain/curriculum/service/CurriculumService.java
+++ b/src/main/java/com/boaz/backend/domain/curriculum/service/CurriculumService.java
@@ -27,6 +27,8 @@ public class CurriculumService {
         List<Curriculum> curriculums;
 
         if (track != null) {
+            track.validateNotAll();
+            
             curriculums = curriculumRepository.findByTrack(track)
                     .map(List::of)
                     .orElse(List.of());

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -104,6 +104,9 @@ public class RecruitmentService {
         if (!isActive) {
             throw new CustomException(ErrorCode.RECRUITMENT_NOT_AVAILABLE);
         }
+        
+        // 부문 검증
+        track.validateNotAll();
 
         // Track → ApplicationQuestion.Category 변환
         ApplicationQuestion.Category trackCategory = toQuestionCategory(track);
@@ -141,6 +144,9 @@ public class RecruitmentService {
         if (!isActive) {
             throw new CustomException(ErrorCode.RECRUITMENT_CLOSED);
         }
+
+        // 부문 검증
+        request.getTrack().validateNotAll();
 
         // 이메일 형식 검증
         if (!request.getEmail().matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$")) {

--- a/src/main/java/com/boaz/backend/domain/review/service/ReviewService.java
+++ b/src/main/java/com/boaz/backend/domain/review/service/ReviewService.java
@@ -19,6 +19,10 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
 
     public List<ReviewResponse> getReviews(Track track, Integer term) {
+        if (track != null) {
+            track.validateNotAll();
+        }
+
         List<Review> reviews;
 
         if (track != null && term != null) {

--- a/src/main/java/com/boaz/backend/global/common/enums/Track.java
+++ b/src/main/java/com/boaz/backend/global/common/enums/Track.java
@@ -1,6 +1,15 @@
 package com.boaz.backend.global.common.enums;
 
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+
 public enum Track {
     // 전부문, 분석, 시각화, 엔지니어링
-    ALL, ANALYSIS, VISUALIZATION, ENGINEERING
+    ALL, ANALYSIS, VISUALIZATION, ENGINEERING;
+
+    public void validateNotAll() {
+        if (this == ALL) {
+            throw new CustomException(ErrorCode.INVALID_TRACK_SELECTION);
+        }
+    }
 }

--- a/src/main/java/com/boaz/backend/global/config/JacksonConfig.java
+++ b/src/main/java/com/boaz/backend/global/config/JacksonConfig.java
@@ -1,0 +1,14 @@
+package com.boaz.backend.global.config;
+
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public JsonNullableModule jsonNullableModule() {
+        return new JsonNullableModule();
+    }
+}

--- a/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     DUPLICATE_USERNAME(HttpStatus.CONFLICT, "DUPLICATE_USERNAME", "이미 존재하는 아이디입니다."),
     CANNOT_MODIFY_OWN_ROLE(HttpStatus.FORBIDDEN, "CANNOT_MODIFY_OWN_ROLE", "본인 계정의 역할은 변경할 수 없습니다."),
     LAST_SUPER_ACCOUNT(HttpStatus.BAD_REQUEST, "LAST_SUPER_ACCOUNT", "마지막 SUPER 계정은 삭제할 수 없습니다."),
+    INVALID_CURRENT_PASSWORD(HttpStatus.UNAUTHORIZED, "INVALID_CURRENT_PASSWORD", "현재 비밀번호가 올바르지 않습니다."),
 
     // Recruitment
     RECRUITMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "RECRUITMENT_NOT_FOUND", "해당 모집 공고를 찾을 수 없습니다."),

--- a/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
@@ -11,14 +11,18 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다."),
     MISSING_PARAMETER(HttpStatus.BAD_REQUEST, "MISSING_PARAMETER", "요청 파라미터가 누락되었습니다."),
     INVALID_PARAMETER_TYPE(HttpStatus.BAD_REQUEST, "INVALID_PARAMETER_TYPE", "파라미터 타입이 올바르지 않습니다."),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "접근 권한이 없습니다."),
+    UNAUTHORIZED(HttpStatus.FORBIDDEN, "UNAUTHORIZED", "접근 권한이 없습니다."),
 
     // Auth / Token
+    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "TOKEN_NOT_FOUND", "토큰이 존재하지 않습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "EXPIRED_TOKEN", "만료된 토큰입니다."),
 
     // Admin
     ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND, "ADMIN_NOT_FOUND", "해당 계정을 찾을 수 없습니다."),
+    DUPLICATE_USERNAME(HttpStatus.CONFLICT, "DUPLICATE_USERNAME", "이미 존재하는 아이디입니다."),
+    CANNOT_MODIFY_OWN_ROLE(HttpStatus.FORBIDDEN, "CANNOT_MODIFY_OWN_ROLE", "본인 계정의 역할은 변경할 수 없습니다."),
+    LAST_SUPER_ACCOUNT(HttpStatus.BAD_REQUEST, "LAST_SUPER_ACCOUNT", "마지막 SUPER 계정은 삭제할 수 없습니다."),
 
     // Recruitment
     RECRUITMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "RECRUITMENT_NOT_FOUND", "해당 모집 공고를 찾을 수 없습니다."),

--- a/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     QUESTIONS_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTIONS_NOT_FOUND", "등록된 질문이 없습니다."),
     RECRUITMENT_CLOSED(HttpStatus.BAD_REQUEST, "RECRUITMENT_CLOSED", "현재 지원 기간이 아닙니다."),
     ANSWER_REQUIRED(HttpStatus.BAD_REQUEST, "ANSWER_REQUIRED", "필수 질문에 답변해주세요."),
+    INVALID_TRACK_SELECTION(HttpStatus.BAD_REQUEST, "INVALID_TRACK_SELECTION", "지원 부문을 올바르게 선택해주세요."),
     INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "INVALID_EMAIL_FORMAT", "이메일 형식이 올바르지 않습니다."),
     INVALID_PHONE_FORMAT(HttpStatus.BAD_REQUEST, "INVALID_PHONE_FORMAT", "전화번호 형식이 올바르지 않습니다."),
     INVALID_ANSWER_TYPE(HttpStatus.BAD_REQUEST, "INVALID_ANSWER_TYPE", "답변 형식이 올바르지 않습니다."),

--- a/src/main/java/com/boaz/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/boaz/backend/global/exception/GlobalExceptionHandler.java
@@ -1,8 +1,11 @@
 package com.boaz.backend.global.exception;
 
 import com.boaz.backend.global.common.ApiResponse;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -46,6 +49,29 @@ public class GlobalExceptionHandler {
                         400,
                         ErrorCode.MISSING_PARAMETER.getCode(),
                         ErrorCode.MISSING_PARAMETER.getMessage()
+                ));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadable(HttpMessageNotReadableException e) {
+        String message = ErrorCode.INVALID_INPUT_VALUE.getMessage();
+        
+        if (e.getCause() instanceof InvalidFormatException ife) {
+                if (!ife.getPath().isEmpty()) {
+                String fieldName = ife.getPath().get(0).getFieldName();
+                message = String.format("'%s' 필드의 값이 유효하지 않습니다. (입력값: %s)", 
+                                        fieldName, ife.getValue());
+                }
+        }
+
+        log.warn("Payload Error: {}", e.getMostSpecificCause().getMessage());
+        
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.error(
+                        400, 
+                        ErrorCode.INVALID_INPUT_VALUE.getCode(), 
+                        message
                 ));
     }
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -2,6 +2,7 @@
 SET FOREIGN_KEY_CHECKS = 0;
 
 -- 모든 테이블 초기화
+TRUNCATE admin;
 TRUNCATE recruitment;
 TRUNCATE application_question;
 TRUNCATE archive;
@@ -15,6 +16,13 @@ TRUNCATE review;
 SET FOREIGN_KEY_CHECKS = 1;
 
 -- 임시 데이터
+
+-- admin 임시 데이터 (비밀번호: Boaz1234!)
+INSERT INTO admin (username, password, role, name, track, term, team_name, created_by, created_at, updated_at)
+VALUES ('boaz_super', '$2a$10$7GogA3bv05pd830JHPishOFHtneEqmpZgE2s9fZuoARQxDZGg6N.y', 'SUPER', '김보아즈', 'ENGINEERING', 27, '대표진', NULL, NOW(), NOW());
+
+INSERT INTO admin (username, password, role, name, track, term, team_name, created_by, created_at, updated_at)
+VALUES ('boaz_team', '$2a$10$7GogA3bv05pd830JHPishOFHtneEqmpZgE2s9fZuoARQxDZGg6N.y', 'TEAM', '이보아즈', 'ANALYSIS', 27, '서비스운영팀', 1, NOW(), NOW());
 
 -- recruitment 임시 데이터
 INSERT INTO recruitment (id, term, start_date, end_date, schedule, brochure_url, created_at, updated_at)


### PR DESCRIPTION
## 💡 개요

* Issue Number: #65 

## 🪐 주요 변경 사항
- Admin 계정 관리 API 전체 구현 (CRUD + 비밀번호 초기화)
- Soft delete 방식 적용 및 RefreshToken 연동

## ✅ 상세 내용
- GET /api/v1/admin/accounts — 전체 계정 조회 (SUPER only)
- GET /api/v1/admin/accounts/{id} — 단건 계정 조회 (TEAM: 본인만)
- POST /api/v1/admin/accounts — 계정 생성 (SUPER only)
- PATCH /api/v1/admin/accounts/{id} — 계정 수정 (SUPER: role 포함 전체 / TEAM: 본인 프로필만)
- DELETE /api/v1/admin/accounts/{id} — 계정 삭제, soft delete 적용 (SUPER: 전체 / TEAM: 본인만, 마지막 SUPER 삭제 불가)
- PATCH /api/v1/admin/accounts/{id}/password — 비밀번호 초기화
- role 변경 및 비밀번호 변경 시 해당 계정의 RefreshToken 삭제 (재로그인 강제)
- PATCH 요청에 JsonNullable 적용 — undefined / null / 값 세 가지 상태 구분
- Admin 도메인 Swagger 문서화 (Controller, DTO, Enum)
- username DB 레벨 UNIQUE 제약 제거 (soft delete와의 충돌 해소, 애플리케이션 레벨 중복 검증 유지)

## 🔔 참고 사항
- X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Admin 계정 관리 API 전체 구현

**변경 목적:**
Issue #65와 관련하여 Admin 계정 관리 API를 전체 구현하고, Soft delete와 RefreshToken 연동, JsonNullable을 통한 부분 업데이트 지원을 포함하여 관리자 계정의 CRUD 및 보안 기능을 완성합니다.

**주요 변경 내용:**

*Controller & API 엔드포인트*
- AdminController: 6개 엔드포인트 추가
  - POST /api/v1/admin/accounts (계정 생성)
  - GET /api/v1/admin/accounts (전체 계정 조회, SUPER 전용)
  - GET /api/v1/admin/accounts/{id} (단건 조회, TEAM은 본인만)
  - PATCH /api/v1/admin/accounts/{id} (계정 수정)
  - DELETE /api/v1/admin/accounts/{id} (소프트 삭제)
  - PATCH /api/v1/admin/accounts/{id}/password (비밀번호 초기화)

*DTO 추가*
- AdminCreateRequest: 계정 생성 요청 (username, password, role, name, track, term, teamName)
- AdminUpdateRequest: 계정 수정 요청 (JsonNullable 타입으로 undefined/null/값 구분)
- AdminPasswordResetRequest: 비밀번호 리셋 요청
- AdminAccountResponse: 계정 조회 응답
- AdminIdResponse: ID 반환 응답

*서비스 & 비즈니스 로직*
- AdminService: 역할 기반 접근 제어 구현
  - SUPER: 전체 계정 관리, role 변경 가능
  - TEAM: 본인 계정만 관리 가능, role 변경 불가
  - Role/비밀번호 변경 시 RefreshToken 삭제하여 재로그인 강제
  - 마지막 SUPER 계정 삭제 방지
  - Track "ALL" 선택 불가 유효성 검사

*엔티티 & 저장소*
- Admin 엔티티: username 컬럼 unique 제약 제거, 업데이트 메서드 추가 (updateRole, updateName, updateTrack, updateTerm, updateTeamName)
- AdminRepository: 3개 쿼리 메서드 추가 (findAllByDeletedAtIsNullOrderByCreatedAtAsc, findByIdAndDeletedAtIsNull, countByRoleAndDeletedAtIsNull)

*설정 & 예외 처리*
- JacksonConfig: JsonNullableModule bean 등록
- Track enum: validateNotAll() 메서드 추가 (INVALID_TRACK_SELECTION 예외 발생)
- ErrorCode: 4개 새로운 에러코드 추가 (DUPLICATE_USERNAME, CANNOT_MODIFY_OWN_ROLE, LAST_SUPER_ACCOUNT, INVALID_TRACK_SELECTION)
- GlobalExceptionHandler: HttpMessageNotReadableException 핸들러 추가

*기타*
- CurriculumService, RecruitmentService, ReviewService: Track validation 호출 추가
- data.sql: admin 테이블 초기 데이터(2개 계정) 추가

**영향 범위:**
- **API 변경**: 6개 새로운 엔드포인트 추가, Bearer Token 기반 인증 요구
- **DB 스키마 변경**: Admin 엔티티의 username 컬럼 unique 제약 제거 (soft delete와의 호환성), Swagger 문서화 추가
- **설정 변경**: Jackson JsonNullable 모듈 의존성 추가 및 bean 등록, 새로운 에러코드 정의
<!-- end of auto-generated comment: release notes by coderabbit.ai -->