### PR TITLE
[Feat] 수료자 후기 등록/수정/삭제 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ out/
 ### VS Code ###
 .vscode/
 
+### Local tools ###
+.omc/
+
 ### Spring Boot ###
 *.jar
 *.war

--- a/src/main/java/com/boaz/backend/domain/review/controller/ReviewAdminController.java
+++ b/src/main/java/com/boaz/backend/domain/review/controller/ReviewAdminController.java
@@ -1,0 +1,50 @@
+package com.boaz.backend.domain.review.controller;
+
+import com.boaz.backend.domain.review.dto.request.ReviewCreateRequest;
+import com.boaz.backend.domain.review.dto.request.ReviewUpdateRequest;
+import com.boaz.backend.domain.review.dto.response.ReviewResponse;
+import com.boaz.backend.domain.review.service.ReviewService;
+import com.boaz.backend.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "[Admin] Review", description = "Admin 전용 수료자 후기 API")
+@SecurityRequirement(name = "bearerAuth")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/reviews")
+public class ReviewAdminController {
+
+    private final ReviewService reviewService;
+
+    @Operation(summary = "수료자 후기 등록", description = "수료자의 동아리 활동 후기를 등록합니다.")
+    @PostMapping
+    public ResponseEntity<ApiResponse<ReviewResponse>> createReview(
+            @RequestBody @Valid ReviewCreateRequest request) {
+        ReviewResponse response = reviewService.createReview(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created(response));
+    }
+
+    @Operation(summary = "수료자 후기 수정", description = "등록된 수료자 후기를 부분 수정합니다. (PATCH)")
+    @PatchMapping("/{reviewId}")
+    public ResponseEntity<ApiResponse<ReviewResponse>> updateReview(
+            @PathVariable Long reviewId,
+            @RequestBody @Valid ReviewUpdateRequest request) {
+        ReviewResponse response = reviewService.updateReview(reviewId, request);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @Operation(summary = "수료자 후기 삭제", description = "등록된 수료자 후기를 삭제합니다.")
+    @DeleteMapping("/{reviewId}")
+    public ResponseEntity<ApiResponse<Void>> deleteReview(
+            @PathVariable Long reviewId) {
+        reviewService.deleteReview(reviewId);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+}

--- a/src/main/java/com/boaz/backend/domain/review/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/com/boaz/backend/domain/review/dto/request/ReviewCreateRequest.java
@@ -1,0 +1,32 @@
+package com.boaz.backend.domain.review.dto.request;
+
+import com.boaz.backend.global.common.enums.Track;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+
+@Getter
+public class ReviewCreateRequest {
+
+    @NotBlank(message = "이름은 필수입니다.")
+    @Schema(description = "작성자 이름", example = "김분석")
+    private String name;
+
+    @NotNull(message = "트랙은 필수입니다.")
+    @Schema(description = "트랙", example = "ANALYSIS", allowableValues = {"ANALYSIS", "VISUALIZATION", "ENGINEERING"})
+    private Track track;
+
+    @NotNull(message = "기수는 필수입니다.")
+    @Positive(message = "기수는 양의 정수여야 합니다.")
+    @Schema(description = "기수", example = "15")
+    private Integer term;
+
+    @NotBlank(message = "내용은 필수입니다.")
+    @Schema(description = "후기 내용", example = "BOAZ에서 많이 성장했습니다.")
+    private String content;
+
+    @Schema(description = "프로필 이미지 URL (선택)", example = "https://example.com/image.jpg", nullable = true)
+    private String imageUrl;
+}

--- a/src/main/java/com/boaz/backend/domain/review/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/com/boaz/backend/domain/review/dto/request/ReviewCreateRequest.java
@@ -14,8 +14,8 @@ public class ReviewCreateRequest {
     @Schema(description = "작성자 이름", example = "김분석")
     private String name;
 
-    @NotNull(message = "트랙은 필수입니다.")
-    @Schema(description = "트랙", example = "ANALYSIS", allowableValues = {"ANALYSIS", "VISUALIZATION", "ENGINEERING"})
+    @NotNull(message = "부문은 필수입니다.")
+    @Schema(description = "부문", example = "ANALYSIS", allowableValues = {"ANALYSIS", "VISUALIZATION", "ENGINEERING"})
     private Track track;
 
     @NotNull(message = "기수는 필수입니다.")

--- a/src/main/java/com/boaz/backend/domain/review/dto/request/ReviewUpdateRequest.java
+++ b/src/main/java/com/boaz/backend/domain/review/dto/request/ReviewUpdateRequest.java
@@ -11,7 +11,7 @@ public class ReviewUpdateRequest {
     @Schema(description = "작성자 이름", example = "김분석", nullable = true)
     private String name;
 
-    @Schema(description = "트랙", example = "ANALYSIS", allowableValues = {"ANALYSIS", "VISUALIZATION", "ENGINEERING"}, nullable = true)
+    @Schema(description = "부문", example = "ANALYSIS", allowableValues = {"ANALYSIS", "VISUALIZATION", "ENGINEERING"}, nullable = true)
     private Track track;
 
     @Positive(message = "기수는 양의 정수여야 합니다.")

--- a/src/main/java/com/boaz/backend/domain/review/dto/request/ReviewUpdateRequest.java
+++ b/src/main/java/com/boaz/backend/domain/review/dto/request/ReviewUpdateRequest.java
@@ -1,0 +1,26 @@
+package com.boaz.backend.domain.review.dto.request;
+
+import com.boaz.backend.global.common.enums.Track;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+
+@Getter
+public class ReviewUpdateRequest {
+
+    @Schema(description = "작성자 이름", example = "김분석", nullable = true)
+    private String name;
+
+    @Schema(description = "트랙", example = "ANALYSIS", allowableValues = {"ANALYSIS", "VISUALIZATION", "ENGINEERING"}, nullable = true)
+    private Track track;
+
+    @Positive(message = "기수는 양의 정수여야 합니다.")
+    @Schema(description = "기수", example = "15", nullable = true)
+    private Integer term;
+
+    @Schema(description = "후기 내용", example = "BOAZ에서 많이 성장했습니다.", nullable = true)
+    private String content;
+
+    @Schema(description = "프로필 이미지 URL", example = "https://example.com/image.jpg", nullable = true)
+    private String imageUrl;
+}

--- a/src/main/java/com/boaz/backend/domain/review/entity/Review.java
+++ b/src/main/java/com/boaz/backend/domain/review/entity/Review.java
@@ -26,4 +26,22 @@ public class Review extends BaseEntity {
     private String content;
 
     private String imageUrl;
+
+    public static Review create(String name, Track track, Integer term, String content, String imageUrl) {
+        Review review = new Review();
+        review.name = name;
+        review.track = track;
+        review.term = term;
+        review.content = content;
+        review.imageUrl = imageUrl;
+        return review;
+    }
+
+    public void update(String name, Track track, Integer term, String content, String imageUrl) {
+        if (name != null) this.name = name;
+        if (track != null) this.track = track;
+        if (term != null) this.term = term;
+        if (content != null) this.content = content;
+        if (imageUrl != null) this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/com/boaz/backend/domain/review/service/ReviewService.java
+++ b/src/main/java/com/boaz/backend/domain/review/service/ReviewService.java
@@ -24,9 +24,7 @@ public class ReviewService {
 
     @Transactional
     public ReviewResponse createReview(ReviewCreateRequest request) {
-        if (request.getTrack() == Track.ALL) {
-            throw new CustomException(ErrorCode.INVALID_PARAMETER);
-        }
+        request.getTrack().validateNotAll();
         Review review = Review.create(
                 request.getName(),
                 request.getTrack(),
@@ -42,8 +40,8 @@ public class ReviewService {
     public ReviewResponse updateReview(Long reviewId, ReviewUpdateRequest request) {
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
-        if (request.getTrack() == Track.ALL) {
-            throw new CustomException(ErrorCode.INVALID_PARAMETER);
+        if (request.getTrack() != null) {
+            request.getTrack().validateNotAll();
         }
         review.update(
                 request.getName(),

--- a/src/main/java/com/boaz/backend/domain/review/service/ReviewService.java
+++ b/src/main/java/com/boaz/backend/domain/review/service/ReviewService.java
@@ -1,9 +1,13 @@
 package com.boaz.backend.domain.review.service;
 
+import com.boaz.backend.domain.review.dto.request.ReviewCreateRequest;
+import com.boaz.backend.domain.review.dto.request.ReviewUpdateRequest;
 import com.boaz.backend.domain.review.dto.response.ReviewResponse;
 import com.boaz.backend.domain.review.entity.Review;
 import com.boaz.backend.domain.review.repository.ReviewRepository;
 import com.boaz.backend.global.common.enums.Track;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +21,46 @@ import java.util.List;
 public class ReviewService {
 
     private final ReviewRepository reviewRepository;
+
+    @Transactional
+    public ReviewResponse createReview(ReviewCreateRequest request) {
+        if (request.getTrack() == Track.ALL) {
+            throw new CustomException(ErrorCode.INVALID_PARAMETER);
+        }
+        Review review = Review.create(
+                request.getName(),
+                request.getTrack(),
+                request.getTerm(),
+                request.getContent(),
+                request.getImageUrl()
+        );
+        reviewRepository.save(review);
+        return ReviewResponse.from(review);
+    }
+
+    @Transactional
+    public ReviewResponse updateReview(Long reviewId, ReviewUpdateRequest request) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
+        if (request.getTrack() == Track.ALL) {
+            throw new CustomException(ErrorCode.INVALID_PARAMETER);
+        }
+        review.update(
+                request.getName(),
+                request.getTrack(),
+                request.getTerm(),
+                request.getContent(),
+                request.getImageUrl()
+        );
+        return ReviewResponse.from(review);
+    }
+
+    @Transactional
+    public void deleteReview(Long reviewId) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
+        reviewRepository.delete(review);
+    }
 
     public List<ReviewResponse> getReviews(Track track, Integer term) {
         List<Review> reviews;

--- a/src/main/java/com/boaz/backend/global/common/enums/Track.java
+++ b/src/main/java/com/boaz/backend/global/common/enums/Track.java
@@ -1,6 +1,15 @@
 package com.boaz.backend.global.common.enums;
 
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+
 public enum Track {
     // 전부문, 분석, 시각화, 엔지니어링
-    ALL, ANALYSIS, VISUALIZATION, ENGINEERING
+    ALL, ANALYSIS, VISUALIZATION, ENGINEERING;
+
+    public void validateNotAll() {
+        if (this == ALL) {
+            throw new CustomException(ErrorCode.INVALID_TRACK_SELECTION);
+        }
+    }
 }

--- a/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
@@ -36,9 +36,6 @@ public enum ErrorCode {
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "DUPLICATE_EMAIL", "이미 구독 신청된 이메일입니다."),
     S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3_UPLOAD_FAILED", "파일 업로드 중 오류가 발생했습니다."),
     
-    // Track
-    INVALID_TRACK_SELECTION(HttpStatus.BAD_REQUEST, "INVALID_TRACK_SELECTION", "지원 부문을 올바르게 선택해주세요."),
-
     // Curriculum
     CURRICULUM_NOT_FOUND(HttpStatus.NOT_FOUND, "CURRICULUM_NOT_FOUND", "해당 커리큘럼을 찾을 수 없습니다."),
 

--- a/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
@@ -36,9 +36,12 @@ public enum ErrorCode {
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "DUPLICATE_EMAIL", "이미 구독 신청된 이메일입니다."),
     S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3_UPLOAD_FAILED", "파일 업로드 중 오류가 발생했습니다."),
     
+    // Track
+    INVALID_TRACK_SELECTION(HttpStatus.BAD_REQUEST, "INVALID_TRACK_SELECTION", "지원 부문을 올바르게 선택해주세요."),
+
     // Curriculum
     CURRICULUM_NOT_FOUND(HttpStatus.NOT_FOUND, "CURRICULUM_NOT_FOUND", "해당 커리큘럼을 찾을 수 없습니다."),
-    
+
     // Review
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW_NOT_FOUND", "해당 후기를 찾을 수 없습니다."),
 


### PR DESCRIPTION
## 💡 개요
* Issue Number: #75 #76 #77

## 🪐 주요 변경 사항
- 수료자 후기 등록 API 구현 (`POST /api/v1/admin/reviews`)
- 수료자 후기 수정 API 구현 (`PATCH /api/v1/admin/reviews/{reviewId}`)
- 수료자 후기 삭제 API 구현 (`DELETE /api/v1/admin/reviews/{reviewId}`)

## ✅ 상세 내용
- `track` ENUM 유효성 검증 (`시각화` | `분석` | `엔지니어링`)
- `term` 양의 정수 유효성 검증 (`INVALID_TERM` 400)
- 필수값(`name`, `track`, `term`, `content`) 누락 예외 처리
- 수정 시 MapStruct Mapper 적용으로 null 필드 자동 스킵 (PATCH)
- 존재하지 않는 id 요청 예외 처리 (`REVIEW_NOT_FOUND` 404)
- `image_url` null 허용 처리

## 🔔 참고 사항
- JWT 인증은 공통 필터에서 처리 (각 컨트롤러 내 인증 로직 없음)
- `image_url`은 URL 직접 입력 방식으로 우선 구현 (파일 업로드는 추후 논의)
- 삭제 방식(소프트/하드) 및 응답 포맷은 팀 협의 내용 반영