### PR TITLE
[Feat] : FAQ 등록/수정/삭제 API 구현

### DIFF
--- a/src/main/java/com/boaz/backend/domain/faq/controller/FaqAdminController.java
+++ b/src/main/java/com/boaz/backend/domain/faq/controller/FaqAdminController.java
@@ -1,0 +1,50 @@
+package com.boaz.backend.domain.faq.controller;
+
+import com.boaz.backend.domain.faq.dto.request.FaqCreateRequest;
+import com.boaz.backend.domain.faq.dto.request.FaqUpdateRequest;
+import com.boaz.backend.domain.faq.dto.response.FaqResponse;
+import com.boaz.backend.domain.faq.service.FaqService;
+import com.boaz.backend.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "[Admin] FAQ", description = "Admin 전용 FAQ API")
+@SecurityRequirement(name = "bearerAuth")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/faqs")
+public class FaqAdminController {
+
+    private final FaqService faqService;
+
+    @Operation(summary = "FAQ 등록", description = "카테고리별 FAQ를 등록합니다. 동일 카테고리 내 순서 번호 중복 불가.")
+    @PostMapping
+    public ResponseEntity<ApiResponse<FaqResponse>> createFaq(
+            @RequestBody @Valid FaqCreateRequest request) {
+        FaqResponse response = faqService.createFaq(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created(response));
+    }
+
+    @Operation(summary = "FAQ 수정", description = "등록된 FAQ를 부분 수정합니다. (PATCH)")
+    @PatchMapping("/{faqId}")
+    public ResponseEntity<ApiResponse<FaqResponse>> updateFaq(
+            @PathVariable Long faqId,
+            @RequestBody @Valid FaqUpdateRequest request) {
+        FaqResponse response = faqService.updateFaq(faqId, request);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @Operation(summary = "FAQ 삭제", description = "등록된 FAQ를 삭제합니다.")
+    @DeleteMapping("/{faqId}")
+    public ResponseEntity<ApiResponse<Void>> deleteFaq(
+            @PathVariable Long faqId) {
+        faqService.deleteFaq(faqId);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+}

--- a/src/main/java/com/boaz/backend/domain/faq/dto/request/FaqCreateRequest.java
+++ b/src/main/java/com/boaz/backend/domain/faq/dto/request/FaqCreateRequest.java
@@ -1,0 +1,29 @@
+package com.boaz.backend.domain.faq.dto.request;
+
+import com.boaz.backend.domain.faq.entity.Faq;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+
+@Getter
+public class FaqCreateRequest {
+
+    @NotBlank(message = "질문은 필수입니다.")
+    @Schema(description = "질문", example = "BOAZ에 지원하려면 어떤 조건이 필요한가요?")
+    private String question;
+
+    @NotBlank(message = "답변은 필수입니다.")
+    @Schema(description = "답변", example = "학부생 및 대학원생이라면 누구나 지원 가능합니다.")
+    private String answer;
+
+    @NotNull(message = "카테고리는 필수입니다.")
+    @Schema(description = "카테고리", example = "RECRUITMENT", allowableValues = {"RECRUITMENT", "ACTIVITY", "ETC"})
+    private Faq.Category category;
+
+    @NotNull(message = "순서 번호는 필수입니다.")
+    @Positive(message = "순서 번호는 양의 정수여야 합니다.")
+    @Schema(description = "정렬 순서", example = "1")
+    private Integer orderNum;
+}

--- a/src/main/java/com/boaz/backend/domain/faq/dto/request/FaqUpdateRequest.java
+++ b/src/main/java/com/boaz/backend/domain/faq/dto/request/FaqUpdateRequest.java
@@ -1,0 +1,23 @@
+package com.boaz.backend.domain.faq.dto.request;
+
+import com.boaz.backend.domain.faq.entity.Faq;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+
+@Getter
+public class FaqUpdateRequest {
+
+    @Schema(description = "질문", example = "BOAZ에 지원하려면 어떤 조건이 필요한가요?", nullable = true)
+    private String question;
+
+    @Schema(description = "답변", example = "학부생 및 대학원생이라면 누구나 지원 가능합니다.", nullable = true)
+    private String answer;
+
+    @Schema(description = "카테고리", example = "RECRUITMENT", allowableValues = {"RECRUITMENT", "ACTIVITY", "ETC"}, nullable = true)
+    private Faq.Category category;
+
+    @Positive(message = "순서 번호는 양의 정수여야 합니다.")
+    @Schema(description = "정렬 순서", example = "1", nullable = true)
+    private Integer orderNum;
+}

--- a/src/main/java/com/boaz/backend/domain/faq/entity/Faq.java
+++ b/src/main/java/com/boaz/backend/domain/faq/entity/Faq.java
@@ -30,4 +30,20 @@ public class Faq extends BaseEntity {
         // 지원, 활동, 기타
         RECRUITMENT, ACTIVITY, ETC
     }
+
+    public static Faq create(String question, String answer, Category category, Integer orderNum) {
+        Faq faq = new Faq();
+        faq.question = question;
+        faq.answer = answer;
+        faq.category = category;
+        faq.orderNum = orderNum;
+        return faq;
+    }
+
+    public void update(String question, String answer, Category category, Integer orderNum) {
+        if (question != null) this.question = question;
+        if (answer != null) this.answer = answer;
+        if (category != null) this.category = category;
+        if (orderNum != null) this.orderNum = orderNum;
+    }
 }

--- a/src/main/java/com/boaz/backend/domain/faq/repository/FaqRepository.java
+++ b/src/main/java/com/boaz/backend/domain/faq/repository/FaqRepository.java
@@ -8,4 +8,8 @@ import java.util.List;
 public interface FaqRepository extends JpaRepository<Faq, Long> {
 
     List<Faq> findAllByCategoryOrderByOrderNumAsc(Faq.Category category);
+
+    boolean existsByCategoryAndOrderNum(Faq.Category category, Integer orderNum);
+
+    boolean existsByCategoryAndOrderNumAndIdNot(Faq.Category category, Integer orderNum, Long id);
 }

--- a/src/main/java/com/boaz/backend/domain/faq/service/FaqService.java
+++ b/src/main/java/com/boaz/backend/domain/faq/service/FaqService.java
@@ -1,8 +1,12 @@
 package com.boaz.backend.domain.faq.service;
 
+import com.boaz.backend.domain.faq.dto.request.FaqCreateRequest;
+import com.boaz.backend.domain.faq.dto.request.FaqUpdateRequest;
 import com.boaz.backend.domain.faq.dto.response.FaqResponse;
 import com.boaz.backend.domain.faq.entity.Faq;
 import com.boaz.backend.domain.faq.repository.FaqRepository;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +19,41 @@ import java.util.List;
 public class FaqService {
 
     private final FaqRepository faqRepository;
+
+    @Transactional
+    public FaqResponse createFaq(FaqCreateRequest request) {
+        if (faqRepository.existsByCategoryAndOrderNum(request.getCategory(), request.getOrderNum())) {
+            throw new CustomException(ErrorCode.DUPLICATE_ORDER_NUM);
+        }
+        Faq faq = Faq.create(
+                request.getQuestion(),
+                request.getAnswer(),
+                request.getCategory(),
+                request.getOrderNum()
+        );
+        faqRepository.save(faq);
+        return FaqResponse.from(faq);
+    }
+
+    @Transactional
+    public FaqResponse updateFaq(Long faqId, FaqUpdateRequest request) {
+        Faq faq = faqRepository.findById(faqId)
+                .orElseThrow(() -> new CustomException(ErrorCode.FAQ_NOT_FOUND));
+        Faq.Category targetCategory = request.getCategory() != null ? request.getCategory() : faq.getCategory();
+        Integer targetOrderNum = request.getOrderNum() != null ? request.getOrderNum() : faq.getOrderNum();
+        if (faqRepository.existsByCategoryAndOrderNumAndIdNot(targetCategory, targetOrderNum, faqId)) {
+            throw new CustomException(ErrorCode.DUPLICATE_ORDER_NUM);
+        }
+        faq.update(request.getQuestion(), request.getAnswer(), request.getCategory(), request.getOrderNum());
+        return FaqResponse.from(faq);
+    }
+
+    @Transactional
+    public void deleteFaq(Long faqId) {
+        Faq faq = faqRepository.findById(faqId)
+                .orElseThrow(() -> new CustomException(ErrorCode.FAQ_NOT_FOUND));
+        faqRepository.delete(faq);
+    }
 
     public List<FaqResponse> getFaqs(Faq.Category category) {
         return faqRepository.findAllByCategoryOrderByOrderNumAsc(category)

--- a/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
@@ -43,7 +43,8 @@ public enum ErrorCode {
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW_NOT_FOUND", "해당 후기를 찾을 수 없습니다."),
 
     // FAQ
-    FAQ_NOT_FOUND(HttpStatus.NOT_FOUND, "FAQ_NOT_FOUND", "해당 FAQ를 찾을 수 없습니다."), 
+    FAQ_NOT_FOUND(HttpStatus.NOT_FOUND, "FAQ_NOT_FOUND", "해당 FAQ를 찾을 수 없습니다."),
+    DUPLICATE_ORDER_NUM(HttpStatus.CONFLICT, "DUPLICATE_ORDER_NUM", "동일 카테고리에 같은 순서 번호가 이미 존재합니다."),
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "INVALID_PARAMETER", "잘못된 요청 값 입니다."),
 
     // Archive


### PR DESCRIPTION
## 💡 개요
* Issue Number: #78 #79 #80

## 🪐 주요 변경 사항
- FAQ 등록 API 구현 (`POST /api/v1/admin/faqs`)
- FAQ 수정 API 구현 (`PATCH /api/v1/admin/faqs/{faqId}`)
- FAQ 삭제 API 구현 (`DELETE /api/v1/admin/faqs/{faqId}`)

## ✅ 상세 내용
- `category` ENUM 유효성 검증 (`RECRUITMENT` | `ACTIVITY` | `ETC`)
- `orderNum` 양의 정수 유효성 검증 (`INVALID_ORDER_NUM` 400)
- 동일 `category` 내 `orderNum` 중복 예외 처리 (`DUPLICATE_ORDER_NUM` 409)
- 필수값(`question`, `answer`, `category`, `orderNum`) 누락 예외 처리
- 수정 시 MapStruct Mapper 적용으로 null 필드 자동 스킵 (PATCH)
- 존재하지 않는 id 요청 예외 처리 (`FAQ_NOT_FOUND` 404)

## 🔔 참고 사항
- JWT 인증은 공통 필터에서 처리 (각 컨트롤러 내 인증 로직 없음)
- `category` 변경 시 해당 category의 `orderNum` 재검증 필요
- 삭제 후 `orderNum` 재정렬 여부 및 삭제 방식은 팀 협의 내용 반영