### PR TITLE
[feat] Auth API 구현 (로그인, 토큰 갱신, 로그아웃)

### DIFF
--- a/src/main/java/com/boaz/backend/domain/archive/controller/ArchiveController.java
+++ b/src/main/java/com/boaz/backend/domain/archive/controller/ArchiveController.java
@@ -24,7 +24,7 @@ public class ArchiveController {
 
     private final ArchiveService archiveService;
 
-    @Operation(summary = "프로젝트 아카이빙 목록 조회")
+    @Operation(summary = "프로젝트 아카이빙 목록 조회", description = "트랙, 기수, 제목 기반 필터링. 페이지 단위 반환")
     @GetMapping("/projects")
     public ResponseEntity<ApiResponse<ArchivePageResponse>> getProjects(
         @RequestParam(defaultValue = "ALL") Track track, 
@@ -45,7 +45,7 @@ public class ArchiveController {
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
-    @Operation(summary = "활동 사진 아카이빙 조회")
+    @Operation(summary = "활동 사진 아카이빙 조회", description = "기수, 제목 기반 필터링. 페이지 단위 반환")
     @GetMapping("/activities")
     public ResponseEntity<ApiResponse<ArchivePageResponse>> getActivities(
         @RequestParam(required = false) Integer term, 
@@ -65,7 +65,7 @@ public class ArchiveController {
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
-    @Operation(summary = "기술 블로그 아카이빙 조회")
+    @Operation(summary = "기술 블로그 아카이빙 조회", description = "트랙, 제목 기반 필터링. 페이지 단위 반환")
     @GetMapping("/blogs")
     public ResponseEntity<ApiResponse<ArchivePageResponse>> getBlogs(
         @RequestParam(defaultValue = "ALL") Track track, 

--- a/src/main/java/com/boaz/backend/domain/archive/dto/response/ArchiveItemResponse.java
+++ b/src/main/java/com/boaz/backend/domain/archive/dto/response/ArchiveItemResponse.java
@@ -6,6 +6,7 @@ import com.boaz.backend.global.exception.CustomException;
 import com.boaz.backend.global.exception.ErrorCode;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import lombok.extern.slf4j.Slf4j;
 import lombok.Builder;
@@ -21,13 +22,28 @@ public class ArchiveItemResponse {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
+    @Schema(description = "아카이브 ID", example = "1")
     private Long id;
+
+    @Schema(description = "기수", example = "26")
     private Integer term;
+
+    @Schema(description  = "제목", example = "실시간 추천 시스템 구축 프로젝트")
     private String title;
+
+    @Schema(description = "팀명", example = "팀 보아즈")
     private String teamName;
+
+    @Schema(description = "트랙", example = "ENGINEERING")
     private Track track;
+
+    @Schema(description = "이미지 URL", example = "https://boaz-archiving.s3.ap-northeast-2.amazonaws.com/projects/sample.png")
     private String imageUrl;
+
+    @Schema(description = "관련 링크(JSON)", example = "{\"slideshare\": \"https://www.slideshare.net/example\"}")
     private JsonNode links;
+
+    @Schema(description = "콘텐츠 날짜", example = "2026-04-17")
     private LocalDate contentDate;
 
     // DB에서 가져온 Entity 객체를 API 응답용 DTO 객체로 변환 

--- a/src/main/java/com/boaz/backend/domain/archive/dto/response/ArchivePageResponse.java
+++ b/src/main/java/com/boaz/backend/domain/archive/dto/response/ArchivePageResponse.java
@@ -1,5 +1,6 @@
 package com.boaz.backend.domain.archive.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
@@ -10,13 +11,28 @@ import java.util.List;
 @Builder
 public class ArchivePageResponse {
 
+    @Schema(description = "현재 페이지 번호", example = "5")
     private int currentPage;
+
+    @Schema(description = "전체 페이지 수", example = "5")
     private int totalPages;
+
+    @Schema(description = "페이지당 항목 수", example = "6")
     private int size; 
+
+    @Schema(description = "현재 페이지 항목 수", example ="3")
     private int currentSize;
+
+    @Schema(description = "전체 항목 수", example = "33")
     private long totalSize;
+
+    @Schema(description = "이전 페이지 존재 여부", example = "true")
     private boolean hasPrevious;
+
+    @Schema(description = "다음 페이지 존재 여부", example = "false")
     private boolean hasNext;
+
+    @Schema(description = "아카이브 목록")
     private List<ArchiveItemResponse> posts;
 
     public static ArchivePageResponse from(Page<ArchiveItemResponse> page) {

--- a/src/main/java/com/boaz/backend/domain/archive/entity/Archive.java
+++ b/src/main/java/com/boaz/backend/domain/archive/entity/Archive.java
@@ -9,6 +9,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDate;
 
 @Entity
@@ -17,9 +19,16 @@ import java.time.LocalDate;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Archive extends BaseEntity {
 
-    // 아카이브 카테고리 (프로젝트, 활동사진, 기술블로그)
     public enum Category {
-        PROJECT, ACTIVITY, BLOG
+
+        @Schema(description = "프로젝트")
+        PROJECT, 
+
+        @Schema(description = "활동사진")
+        ACTIVITY, 
+
+        @Schema(description = "기술블로그")
+        BLOG
     }
 
     @Id

--- a/src/main/java/com/boaz/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/boaz/backend/domain/auth/controller/AuthController.java
@@ -36,15 +36,15 @@ public class AuthController {
     @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인. 성공 시 Access Token 반환 및 Refresh Token 쿠키 설정")
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<LoginResponse>> login(
-
         @Valid @RequestBody LoginRequest request, 
         HttpServletResponse response
     ) {
         LoginResponse result = authService.login(request);
 
-        // 쿠키 설정 
+        // 쿠키 설정 (RefreshToken)
         cookieProvider.addRefreshTokenCookie(response, result.getRefreshToken());
 
+        // Body로 (AccessToken)
         return ResponseEntity.ok(ApiResponse.ok(result));
     }
 
@@ -59,8 +59,7 @@ public class AuthController {
         }
         TokenRefreshResponse result = authService.refresh(refreshToken);
 
-        return ResponseEntity
-            .ok(ApiResponse.ok(result));
+        return ResponseEntity.ok(ApiResponse.ok(result));
     }
 
     // AUTH-003 로그아웃
@@ -70,9 +69,10 @@ public class AuthController {
         @CookieValue(name = "refresh_token", required = false) String refreshToken, 
         HttpServletResponse response
     ) {
+        // DB에서 토큰 삭제 (Service에서 처리)
         authService.logout(refreshToken);
 
-        // 쿠키는 Controller에서 처리
+        // 브라우저에 저장된 쿠키 삭제 (Controller에서 처리)
         cookieProvider.expireRefreshTokenCookie(response);
 
         return ResponseEntity.ok(ApiResponse.ok(null));

--- a/src/main/java/com/boaz/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/boaz/backend/domain/auth/controller/AuthController.java
@@ -1,0 +1,75 @@
+package com.boaz.backend.domain.auth.controller;
+
+import org.springframework.http.ResponseEntity;
+
+import com.boaz.backend.domain.auth.dto.request.LoginRequest;
+import com.boaz.backend.domain.auth.dto.response.LoginResponse;
+import com.boaz.backend.domain.auth.dto.response.TokenRefreshResponse;
+import com.boaz.backend.domain.auth.service.AuthService;
+import com.boaz.backend.global.util.CookieProvider;
+import com.boaz.backend.global.common.ApiResponse;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import jakarta.validation.Valid;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+    
+    private final AuthService authService;
+    private final CookieProvider cookieProvider;
+
+    // AUTH-001 로그인
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<LoginResponse>> login(
+
+        @Valid @RequestBody LoginRequest request, 
+        HttpServletResponse response
+    ) {
+        LoginResponse result = authService.login(request);
+
+        // 쿠키 설정 
+        cookieProvider.addRefreshTokenCookie(response, result.getRefreshToken());
+
+        return ResponseEntity.ok(ApiResponse.ok(result));
+    }
+
+    // AUTH-002 토큰 갱신 
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<TokenRefreshResponse>> refresh(
+        @CookieValue(name = "refresh_token", required = false) String refreshToken
+    ) {
+        if (refreshToken == null) {
+            throw new CustomException(ErrorCode.TOKEN_NOT_FOUND);  // 토큰 미포함 
+        }
+        TokenRefreshResponse result = authService.refresh(refreshToken);
+
+        return ResponseEntity
+            .ok(ApiResponse.ok(result));
+    }
+
+    // AUTH-003 로그아웃
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(
+        @CookieValue(name = "refresh_token", required = false) String refreshToken, 
+        HttpServletResponse response
+    ) {
+        authService.logout(refreshToken);
+
+        // 쿠키는 Controller에서 처리
+        cookieProvider.expireRefreshTokenCookie(response);
+
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+}

--- a/src/main/java/com/boaz/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/boaz/backend/domain/auth/controller/AuthController.java
@@ -1,18 +1,20 @@
 package com.boaz.backend.domain.auth.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import com.boaz.backend.global.security.AdminUserDetails;
 
 import com.boaz.backend.domain.auth.dto.request.LoginRequest;
 import com.boaz.backend.domain.auth.dto.response.LoginResponse;
 import com.boaz.backend.domain.auth.dto.response.TokenRefreshResponse;
 import com.boaz.backend.domain.auth.service.AuthService;
 import com.boaz.backend.global.util.CookieProvider;
+
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
 import com.boaz.backend.global.common.ApiResponse;
-import com.boaz.backend.global.exception.CustomException;
-import com.boaz.backend.global.exception.ErrorCode;
 import jakarta.validation.Valid;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -55,9 +57,6 @@ public class AuthController {
     public ResponseEntity<ApiResponse<TokenRefreshResponse>> refresh(
         @CookieValue(name = "refresh_token", required = false) String refreshToken
     ) {
-        if (refreshToken == null) {
-            throw new CustomException(ErrorCode.TOKEN_NOT_FOUND);  // 토큰 미포함 
-        }
         TokenRefreshResponse result = authService.refresh(refreshToken);
 
         return ResponseEntity.ok(ApiResponse.ok(result));
@@ -68,11 +67,14 @@ public class AuthController {
     @SecurityRequirement(name = "bearerAuth")
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
-        @CookieValue(name = "refresh_token", required = false) String refreshToken, 
         HttpServletResponse response
     ) {
+        // SecurityContext에서 adminId 추출
+        AdminUserDetails adminUserDetails = (AdminUserDetails) SecurityContextHolder
+            .getContext().getAuthentication().getPrincipal();
+        Long adminId = adminUserDetails.getAdmin().getId();
         // DB에서 토큰 삭제 (Service에서 처리)
-        authService.logout(refreshToken);
+        authService.logout(adminId);
 
         // 브라우저에 저장된 쿠키 삭제 (Controller에서 처리)
         cookieProvider.expireRefreshTokenCookie(response);

--- a/src/main/java/com/boaz/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/boaz/backend/domain/auth/controller/AuthController.java
@@ -1,7 +1,7 @@
 package com.boaz.backend.domain.auth.controller;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import com.boaz.backend.global.security.AdminUserDetails;
 
 import com.boaz.backend.domain.auth.dto.request.LoginRequest;
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
 
 
 @Tag(name = "Auth", description = "인증 관련 API")
@@ -67,14 +68,12 @@ public class AuthController {
     @SecurityRequirement(name = "bearerAuth")
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
+        @AuthenticationPrincipal AdminUserDetails userDetails,
         HttpServletResponse response
     ) {
-        // SecurityContext에서 adminId 추출
-        AdminUserDetails adminUserDetails = (AdminUserDetails) SecurityContextHolder
-            .getContext().getAuthentication().getPrincipal();
-        Long adminId = adminUserDetails.getAdmin().getId();
+
         // DB에서 토큰 삭제 (Service에서 처리)
-        authService.logout(adminId);
+        authService.logout(userDetails.getAdmin().getId());
 
         // 브라우저에 저장된 쿠키 삭제 (Controller에서 처리)
         cookieProvider.expireRefreshTokenCookie(response);

--- a/src/main/java/com/boaz/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/boaz/backend/domain/auth/controller/AuthController.java
@@ -7,6 +7,8 @@ import com.boaz.backend.domain.auth.dto.response.LoginResponse;
 import com.boaz.backend.domain.auth.dto.response.TokenRefreshResponse;
 import com.boaz.backend.domain.auth.service.AuthService;
 import com.boaz.backend.global.util.CookieProvider;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Operation;
 import com.boaz.backend.global.common.ApiResponse;
 import com.boaz.backend.global.exception.CustomException;
 import com.boaz.backend.global.exception.ErrorCode;
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 
+@Tag(name = "Auth", description = "인증 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
@@ -30,6 +33,7 @@ public class AuthController {
     private final CookieProvider cookieProvider;
 
     // AUTH-001 로그인
+    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인. 성공 시 Access Token 반환 및 Refresh Token 쿠키 설정")
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<LoginResponse>> login(
 
@@ -45,6 +49,7 @@ public class AuthController {
     }
 
     // AUTH-002 토큰 갱신 
+    @Operation(summary = "토큰 갱신", description = "Cookie의 Refresh Token으로 Access Token 재발급")
     @PostMapping("/refresh")
     public ResponseEntity<ApiResponse<TokenRefreshResponse>> refresh(
         @CookieValue(name = "refresh_token", required = false) String refreshToken
@@ -59,6 +64,7 @@ public class AuthController {
     }
 
     // AUTH-003 로그아웃
+    @Operation(summary = "로그아웃", description = "Refresh Token 무효화 및 Cookie 삭제")
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
         @CookieValue(name = "refresh_token", required = false) String refreshToken, 

--- a/src/main/java/com/boaz/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/boaz/backend/domain/auth/controller/AuthController.java
@@ -9,6 +9,7 @@ import com.boaz.backend.domain.auth.service.AuthService;
 import com.boaz.backend.global.util.CookieProvider;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import com.boaz.backend.global.common.ApiResponse;
 import com.boaz.backend.global.exception.CustomException;
 import com.boaz.backend.global.exception.ErrorCode;
@@ -64,6 +65,7 @@ public class AuthController {
 
     // AUTH-003 로그아웃
     @Operation(summary = "로그아웃", description = "Refresh Token 무효화 및 Cookie 삭제")
+    @SecurityRequirement(name = "bearerAuth")
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
         @CookieValue(name = "refresh_token", required = false) String refreshToken, 

--- a/src/main/java/com/boaz/backend/domain/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/boaz/backend/domain/auth/dto/request/LoginRequest.java
@@ -10,10 +10,10 @@ import lombok.NoArgsConstructor;
 public class LoginRequest {
     
     @Schema(description = "로그인 ID", example = "boaz_super")
-    @NotBlank(message = "요청 파라미터가 누락되었습니다.")
+    @NotBlank(message = "username이 누락되었습니다.")
     private String username;
 
     @Schema(description = "비밀번호", example = "Boaz1234!")
-    @NotBlank (message = "요청 파라미터가 누락되었습니다.")
+    @NotBlank (message = "password가 누락되었습니다.")
     private String password;
 }

--- a/src/main/java/com/boaz/backend/domain/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/boaz/backend/domain/auth/dto/request/LoginRequest.java
@@ -1,5 +1,6 @@
 package com.boaz.backend.domain.auth.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,9 +9,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class LoginRequest {
     
+    @Schema(description = "로그인 ID", example = "boaz_super")
     @NotBlank(message = "요청 파라미터가 누락되었습니다.")
     private String username;
 
+    @Schema(description = "비밀번호", example = "Boaz1234!")
     @NotBlank (message = "요청 파라미터가 누락되었습니다.")
     private String password;
 }

--- a/src/main/java/com/boaz/backend/domain/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/boaz/backend/domain/auth/dto/request/LoginRequest.java
@@ -1,0 +1,16 @@
+package com.boaz.backend.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequest {
+    
+    @NotBlank(message = "요청 파라미터가 누락되었습니다.")
+    private String username;
+
+    @NotBlank (message = "요청 파라미터가 누락되었습니다.")
+    private String password;
+}

--- a/src/main/java/com/boaz/backend/domain/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/boaz/backend/domain/auth/dto/response/LoginResponse.java
@@ -1,6 +1,7 @@
 package com.boaz.backend.domain.auth.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -8,6 +9,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class LoginResponse {
 
+    @Schema(description = "Access Token", example = "eyJhbGciOiJIUzI1NiJ9..")
     private String accessToken;
 
     @JsonIgnore

--- a/src/main/java/com/boaz/backend/domain/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/boaz/backend/domain/auth/dto/response/LoginResponse.java
@@ -1,0 +1,16 @@
+package com.boaz.backend.domain.auth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponse {
+
+    private String accessToken;
+
+    @JsonIgnore
+    private String refreshToken;
+    
+}

--- a/src/main/java/com/boaz/backend/domain/auth/dto/response/TokenRefreshResponse.java
+++ b/src/main/java/com/boaz/backend/domain/auth/dto/response/TokenRefreshResponse.java
@@ -1,0 +1,12 @@
+package com.boaz.backend.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// 토큰 갱신 응답 (요청은 Cookie로)
+@Getter
+@AllArgsConstructor
+public class TokenRefreshResponse {
+    
+    private String accessToken;
+}

--- a/src/main/java/com/boaz/backend/domain/auth/dto/response/TokenRefreshResponse.java
+++ b/src/main/java/com/boaz/backend/domain/auth/dto/response/TokenRefreshResponse.java
@@ -1,5 +1,6 @@
 package com.boaz.backend.domain.auth.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -8,5 +9,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class TokenRefreshResponse {
     
+    @Schema(description = "Access Token", example = "eyJhbGciOiJIUzI1NiJ9..")
     private String accessToken;
 }

--- a/src/main/java/com/boaz/backend/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/boaz/backend/domain/auth/entity/RefreshToken.java
@@ -43,7 +43,7 @@ public class RefreshToken {
         return LocalDateTime.now().isAfter(this.expiresAt);
     }
 
-    // 토큰 갱신하는 메서드 
+    // 기존 토큰 덮어쓰기 (token, expiresAt 교체)
     public void rotate(String newToken, LocalDateTime newExpiresAt) {
         this.token = newToken;
         this.expiresAt = newExpiresAt;

--- a/src/main/java/com/boaz/backend/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/boaz/backend/domain/auth/entity/RefreshToken.java
@@ -1,6 +1,5 @@
 package com.boaz.backend.domain.auth.entity;
 
-import com.boaz.backend.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -13,7 +12,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "refresh_token")
-public class RefreshToken extends BaseEntity {
+public class RefreshToken {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,17 +27,23 @@ public class RefreshToken extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime expiresAt;
 
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
     @Builder
     public RefreshToken(Long adminId, String token, LocalDateTime expiresAt) {
         this.adminId = adminId;
         this.token = token;
         this.expiresAt = expiresAt;
+        this.createdAt = LocalDateTime.now();
     }
 
+    // 토큰이 만료되었는지 확인하는 메서드 
     public boolean isExpired() {
         return LocalDateTime.now().isAfter(this.expiresAt);
     }
 
+    // 토큰 갱신하는 메서드 
     public void rotate(String newToken, LocalDateTime newExpiresAt) {
         this.token = newToken;
         this.expiresAt = newExpiresAt;

--- a/src/main/java/com/boaz/backend/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/boaz/backend/domain/auth/repository/RefreshTokenRepository.java
@@ -7,9 +7,12 @@ import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
+    // token 값으로 RefreshToken 조회 (DB 일치 여부 검증)
     Optional<RefreshToken> findByToken(String token);
 
+    // adminId로 RefreshToken 조회 (기존 토큰 존재 여부 확인)
     Optional<RefreshToken> findByAdminId(Long adminId);
 
+    // adminId로 RefreshToken 삭제 (토큰 무효화)
     void deleteByAdminId(Long adminId);
 }

--- a/src/main/java/com/boaz/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/boaz/backend/domain/auth/service/AuthService.java
@@ -1,0 +1,110 @@
+package com.boaz.backend.domain.auth.service;
+
+import com.boaz.backend.domain.admin.entity.Admin;
+import com.boaz.backend.domain.admin.repository.AdminRepository;
+import com.boaz.backend.domain.auth.dto.request.LoginRequest;
+import com.boaz.backend.domain.auth.dto.response.LoginResponse;
+import com.boaz.backend.domain.auth.dto.response.TokenRefreshResponse;
+import com.boaz.backend.domain.auth.entity.RefreshToken;
+import com.boaz.backend.domain.auth.repository.RefreshTokenRepository;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import com.boaz.backend.global.security.JwtProvider;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    
+    private final AdminRepository adminRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtProvider jwtProvider;
+    private final PasswordEncoder passwordEncoder;
+
+    // AUTH-001 로그인
+    @Transactional
+    public LoginResponse login(LoginRequest request) {
+
+        // 아이디 & 비밀번호 검증 (계정 존재 여부 노출 방지를 위해 동일 에러 반환)
+        Admin admin = adminRepository.findByUsernameAndDeletedAtIsNull(request.getUsername())  // 탈퇴 계정 제외 
+            .filter(a -> passwordEncoder.matches(request.getPassword(), a.getPassword()))
+            .orElseThrow(() -> new CustomException(ErrorCode.INVALID_CREDENTIALS));  // 아이디 또는 비밀번호 불일치한 경우 
+
+        // 검증 통과 시 Access Token 발급 
+        String accessToken = jwtProvider.generateAccessToken(
+            admin.getId(), 
+            admin.getUsername(), 
+            admin.getRole().name()
+        );
+
+        // Refresh Token 발급 
+        String newRefreshToken = jwtProvider.generateRefreshToken(admin.getId());
+
+        // 해당 계정의 기존 RefreshToken이 DB에 있는지 조회 (단일 로그인 정책)
+        RefreshToken savedToken = refreshTokenRepository.findByAdminId(admin.getId())
+            .orElse(null);
+        
+        // 기존 토큰 없으면 새로 생성, 있으면 덮어쓰기 
+        if (savedToken == null) {
+
+            // 최초 로그인 (새 row 생성)
+            savedToken = RefreshToken.builder()
+                .adminId(admin.getId())
+                .token(newRefreshToken)
+                .expiresAt(jwtProvider.getRefreshTokenExpiry())
+                .build();
+        } else {
+            // 재로그인 (기존 row의 token, expiresAt 값만 교체)
+            savedToken.rotate(newRefreshToken, jwtProvider.getRefreshTokenExpiry());
+        }
+
+        // DB에 저장
+        refreshTokenRepository.save(savedToken);
+
+        // accessToken은 Body로, refreshToken은 쿠키로 전달하기 위해 같이 반환 
+        return new LoginResponse(accessToken, newRefreshToken);
+    }
+
+    // AUTH-002 토큰 갱신
+    @Transactional(readOnly = true)
+    public TokenRefreshResponse refresh(String refreshToken) {
+
+        // JWT 서명 및 만료 검증
+        jwtProvider.validateToken(refreshToken);
+
+        // 전달 받은 토큰이 DB에 저장된 값과 일치하는지 확인 
+        RefreshToken savedToken = refreshTokenRepository.findByToken(refreshToken)
+            .orElseThrow(() -> new CustomException(ErrorCode.INVALID_TOKEN));  // DB 불일치 시 예외처리
+
+        // AdminId로 관리자 조회 
+        Admin admin = adminRepository.findById(savedToken.getAdminId())
+            .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+        
+        // 검증 통과 시, 새 Access Token 발급 
+        String newAccessToken = jwtProvider.generateAccessToken(
+            admin.getId(), 
+            admin.getUsername(), 
+            admin.getRole().name()
+        );
+
+        return new TokenRefreshResponse(newAccessToken);
+    }
+
+    // AUTH-003 로그아웃
+    @Transactional
+    public void logout(String refreshToken) {
+
+        if (refreshToken != null){ 
+            // 토큰에서 adminId 추출 후 해당 계정의 RefreshToken 삭제 
+            Long adminId = jwtProvider.getAdminIdFromToken(refreshToken);
+            refreshTokenRepository.deleteByAdminId(adminId);
+        }
+
+    }
+
+}

--- a/src/main/java/com/boaz/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/boaz/backend/domain/auth/service/AuthService.java
@@ -31,7 +31,7 @@ public class AuthService {
     public LoginResponse login(LoginRequest request) {
 
         // 아이디 & 비밀번호 검증 (계정 존재 여부 노출 방지를 위해 동일 에러 반환)
-        Admin admin = adminRepository.findByUsernameAndDeletedAtIsNull(request.getUsername())  // 탈퇴 계정 제외 
+        Admin admin = adminRepository.findByUsernameAndDeletedAtIsNull(request.getUsername())
             .filter(a -> passwordEncoder.matches(request.getPassword(), a.getPassword()))
             .orElseThrow(() -> new CustomException(ErrorCode.INVALID_CREDENTIALS));  // 아이디 또는 비밀번호 불일치한 경우 
 
@@ -45,11 +45,10 @@ public class AuthService {
         // Refresh Token 발급 
         String newRefreshToken = jwtProvider.generateRefreshToken(admin.getId());
 
-        // 해당 계정의 기존 RefreshToken이 DB에 있는지 조회 (단일 로그인 정책)
-        RefreshToken savedToken = refreshTokenRepository.findByAdminId(admin.getId())
-            .orElse(null);
+        // 해당 계정의 기존 RefreshToken이 DB에 있는지 조회
+        RefreshToken savedToken = refreshTokenRepository.findByAdminId(admin.getId()).orElse(null);
         
-        // 기존 토큰 없으면 새로 생성, 있으면 덮어쓰기 
+        // 기존 토큰 없으면 새로 생성, 있으면 덮어쓰기 (단일 로그인 정책)
         if (savedToken == null) {
 
             // 최초 로그인 (새 row 생성)
@@ -81,7 +80,7 @@ public class AuthService {
         RefreshToken savedToken = refreshTokenRepository.findByToken(refreshToken)
             .orElseThrow(() -> new CustomException(ErrorCode.INVALID_TOKEN));  // DB 불일치 시 예외처리
 
-        // AdminId로 관리자 조회 
+        // AdminId로 관리자 조회 (Access Token 발급 시 유저 정보 필요)
         Admin admin = adminRepository.findById(savedToken.getAdminId())
             .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
         

--- a/src/main/java/com/boaz/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/boaz/backend/domain/auth/service/AuthService.java
@@ -96,14 +96,10 @@ public class AuthService {
 
     // AUTH-003 로그아웃
     @Transactional
-    public void logout(String refreshToken) {
+    public void logout(Long adminId) {
 
-        if (refreshToken != null){ 
-            // 토큰에서 adminId 추출 후 해당 계정의 RefreshToken 삭제 
-            Long adminId = jwtProvider.getAdminIdFromToken(refreshToken);
-            refreshTokenRepository.deleteByAdminId(adminId);
-        }
+        // RefreshToken 삭제 
+        refreshTokenRepository.deleteByAdminId(adminId);
 
     }
-
 }

--- a/src/main/java/com/boaz/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/boaz/backend/global/config/SecurityConfig.java
@@ -51,6 +51,7 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/admin/**").authenticated()
+                        .requestMatchers("/api/v1/auth/logout").authenticated()
                         .anyRequest().permitAll()
                 )
                 .exceptionHandling(exceptions -> exceptions

--- a/src/main/java/com/boaz/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/boaz/backend/global/config/SecurityConfig.java
@@ -54,8 +54,8 @@ public class SecurityConfig {
                         .anyRequest().permitAll()
                 )
                 .exceptionHandling(exceptions -> exceptions
-                        .authenticationEntryPoint(authenticationEntryPoint)
-                        .accessDeniedHandler(accessDeniedHandler)
+                        .authenticationEntryPoint(authenticationEntryPoint)  // 인증 실패 시
+                        .accessDeniedHandler(accessDeniedHandler)   // 권한 없을 시 
                 )
                 .addFilterBefore(
                         new JwtAuthenticationFilter(jwtProvider, adminUserDetailsService),

--- a/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "TOKEN_NOT_FOUND", "토큰이 존재하지 않습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "EXPIRED_TOKEN", "만료된 토큰입니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "INVALID_CREDENTIALS", "아이디 또는 비밀번호가 올바르지 않습니다."),
 
     // Admin
     ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND, "ADMIN_NOT_FOUND", "해당 계정을 찾을 수 없습니다."),

--- a/src/main/java/com/boaz/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/boaz/backend/global/exception/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.bind.MissingRequestCookieException;
 
 @Slf4j
 @RestControllerAdvice
@@ -51,6 +52,19 @@ public class GlobalExceptionHandler {
                         ErrorCode.MISSING_PARAMETER.getMessage()
                 ));
     }
+    
+    @ExceptionHandler(MissingRequestCookieException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMissingCookie(MissingRequestCookieException e) {
+        log.warn("MissingCookieException: {}", e.getCookieName());
+        return ResponseEntity
+                .status(ErrorCode.TOKEN_NOT_FOUND.getHttpStatus())
+                .body(ApiResponse.error(
+                        ErrorCode.TOKEN_NOT_FOUND.getHttpStatus().value(), 
+                        ErrorCode.TOKEN_NOT_FOUND.getCode(), 
+                        ErrorCode.TOKEN_NOT_FOUND.getMessage()
+                ));
+    }
+
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadable(HttpMessageNotReadableException e) {

--- a/src/main/java/com/boaz/backend/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/boaz/backend/global/security/JwtAuthenticationFilter.java
@@ -36,10 +36,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (StringUtils.hasText(token)) {
             try {
+                // 서명 및 만료 검증 
                 jwtProvider.validateToken(token);
+
+                // 토큰에서 username 추출 후 계정 조회 
                 String username = jwtProvider.getUsernameFromToken(token);
                 UserDetails userDetails = adminUserDetailsService.loadUserByUsername(username);
 
+                // 인증 객체 생성 후 SecurityContext에 저장 (이후 인증된 사용자로 처리)
                 UsernamePasswordAuthenticationToken authentication =
                         new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
                 SecurityContextHolder.getContext().setAuthentication(authentication);
@@ -54,10 +58,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 return;
             }
         }
-
+    
+        // 다음 필터로 전달 
         filterChain.doFilter(request, response);
     }
 
+    // Authorization 헤더에서 "Bearer " 제거 후 토큰 문자열만 반환 (없으면 null 반환)
     private String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
@@ -66,6 +72,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return null;
     }
 
+    // 에러 응답 JSON 작성 후 클라이언트에게 반환 
     private void sendErrorResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
         response.setStatus(errorCode.getHttpStatus().value());
         response.setContentType("application/json;charset=UTF-8");

--- a/src/main/java/com/boaz/backend/global/security/JwtProvider.java
+++ b/src/main/java/com/boaz/backend/global/security/JwtProvider.java
@@ -31,6 +31,7 @@ public class JwtProvider {
         this.refreshTokenExpiration = refreshTokenExpiration;
     }
 
+    // Access Token 생성 
     public String generateAccessToken(Long adminId, String username, String role) {
         return Jwts.builder()
                 .subject(String.valueOf(adminId))
@@ -42,6 +43,7 @@ public class JwtProvider {
                 .compact();
     }
 
+    // Refresh Token 생성 
     public String generateRefreshToken(Long adminId) {
         return Jwts.builder()
                 .subject(String.valueOf(adminId))
@@ -51,6 +53,7 @@ public class JwtProvider {
                 .compact();
     }
 
+    // JWT 토큰을 파싱해서 Claims(내용) 반환 
     public Claims parseClaims(String token) {
         return Jwts.parser()
                 .verifyWith(secretKey)
@@ -59,14 +62,17 @@ public class JwtProvider {
                 .getPayload();
     }
 
+    // 토큰에서 adminId 추출 
     public Long getAdminIdFromToken(String token) {
         return Long.parseLong(parseClaims(token).getSubject());
     }
 
+    // 토큰에서 username 추출 
     public String getUsernameFromToken(String token) {
         return parseClaims(token).get("username", String.class);
     }
 
+    // 토큰 유효성 검사 
     public void validateToken(String token) {
         try {
             Jwts.parser()
@@ -74,12 +80,13 @@ public class JwtProvider {
                     .build()
                     .parseSignedClaims(token);
         } catch (ExpiredJwtException e) {
-            throw new CustomException(ErrorCode.EXPIRED_TOKEN);
+            throw new CustomException(ErrorCode.EXPIRED_TOKEN);  // 토큰 만료
         } catch (JwtException | IllegalArgumentException e) {
-            throw new CustomException(ErrorCode.INVALID_TOKEN);
+            throw new CustomException(ErrorCode.INVALID_TOKEN);  // 위변조 시 
         }
     }
 
+    // Refresh Token 만료 시각 계산 
     public LocalDateTime getRefreshTokenExpiry() {
         return LocalDateTime.now().plusSeconds(refreshTokenExpiration / 1000);
     }

--- a/src/main/java/com/boaz/backend/global/util/CookieProvider.java
+++ b/src/main/java/com/boaz/backend/global/util/CookieProvider.java
@@ -1,0 +1,49 @@
+package com.boaz.backend.global.util;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class CookieProvider {
+
+    @Value("${cookie.same-site}")
+    private String sameSite;
+
+    @Value("${cookie.secure}")
+    private boolean secure;
+
+    @Value("${cookie.domain}")
+    private String domain;
+
+    @Value("${jwt.refresh-token-expiration}")
+    private long refreshTokenExpiration;
+
+    private static final String REFRESH_TOKEN_COOKIE_NAME = "refresh_token";
+
+    // Refresh Token 쿠키 생성 후 응답 헤더에 추가 
+    public void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        String cookie = buildCookieHeader(REFRESH_TOKEN_COOKIE_NAME, refreshToken, (int)(refreshTokenExpiration / 1000));
+        response.addHeader("Set-Cookie", cookie);
+    }
+
+    // Refresh Token 쿠키 만료 (Max-Age=0)
+    public void expireRefreshTokenCookie(HttpServletResponse response) {
+        String cookie = buildCookieHeader(REFRESH_TOKEN_COOKIE_NAME, "", 0);
+        response.addHeader("Set-Cookie", cookie);
+    }
+
+    // Set-Cookie 헤더 문자열 생성 
+    private String buildCookieHeader(String name, String value, int maxAge) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(name).append("=").append(value).append("; ");
+        sb.append("Max-Age=").append(maxAge).append("; ");
+        sb.append("Path=/; ");
+        sb.append("HttpOnly; "); 
+        if (secure) sb.append("Secure; "); 
+        sb.append("SameSite=").append(sameSite);
+        if (domain != null && !domain.isBlank()) sb.append("; Domain=").append(domain);
+        return sb.toString();
+    }  
+}

--- a/src/main/java/com/boaz/backend/global/util/CookieProvider.java
+++ b/src/main/java/com/boaz/backend/global/util/CookieProvider.java
@@ -22,7 +22,7 @@ public class CookieProvider {
 
     private static final String REFRESH_TOKEN_COOKIE_NAME = "refresh_token";
 
-    // Refresh Token 쿠키 생성 후 응답 헤더에 추가 
+    // Refresh Token 쿠키 헤더 문자열 생성 후 응답 헤더에 추가 
     public void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
         String cookie = buildCookieHeader(REFRESH_TOKEN_COOKIE_NAME, refreshToken, (int)(refreshTokenExpiration / 1000));
         response.addHeader("Set-Cookie", cookie);

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -67,4 +67,4 @@ management:
 cookie:
   same-site: Strict
   secure: true
-  domain: boaz.com 
+  domain: dev.bigdataboaz.com 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -52,8 +52,8 @@ cors:
 
 jwt:
   secret: ${JWT_SECRET}
-  access-token-expiration: 1800000     # 30분 (ms)
-  refresh-token-expiration: 1209600000 # 14일 (ms)
+  access-token-expiration: 900000     # 15분 (ms)
+  refresh-token-expiration: 604800000 # 7일 (ms)
 
 management:
   endpoints:
@@ -63,3 +63,8 @@ management:
   endpoint:
     health:
       show-details: never
+
+cookie:
+  same-site: Strict
+  secure: true
+  domain: boaz.com 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -67,4 +67,4 @@ management:
 cookie:
   same-site: Strict
   secure: true
-  domain: dev.bigdataboaz.com 
+  domain: bigdataboaz.com 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -59,6 +59,6 @@ jwt:
   refresh-token-expiration: 604800000 # 7일 (ms)
 
 cookie:
-  same-site: None
+  same-site: Lax
   secure: false
   domain: 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -55,5 +55,10 @@ cors:
 
 jwt:
   secret: ${JWT_SECRET}
-  access-token-expiration: 1800000     # 30분 (ms)
-  refresh-token-expiration: 1209600000 # 14일 (ms)
+  access-token-expiration: 900000     # 15분 (ms)
+  refresh-token-expiration: 604800000 # 7일 (ms)
+
+cookie:
+  same-site: None
+  secure: false
+  domain: 


### PR DESCRIPTION
## 💡 개요

* Issue Number: #66

## 🪐 주요 변경 사항
- 로그인 API 구현 (Access Token 반환 + Refresh Token 쿠키 설정)
- 토큰 갱신 API 구현 (Refresh Token으로 Access Token 재발급)
- 로그아웃 API 구현 (Refresh Token 무효화 + 쿠키 삭제)
- Swagger 문서 추가 (@Tag, @Operation, @Schema)
- CookieProvider 구현 (Set-Cookie 헤더 생성 및 관리)

## ✅ 상세 내용
- 단일 로그인 정책 적용 (재로그인 시 기존 Refresh Token 덮어쓰기)
- Refresh Token DB 저장 및 검증
- Access Token: Response Body / Refresh Token: HttpOnly 쿠키로 분리
- @JsonIgnore로 Refresh Token 응답 바디 노출 방지

## 🔔 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 변경 목적
로그인, 토큰 갱신, 로그아웃을 포함한 인증 API를 도입하고 Access Token은 응답 본문으로, Refresh Token은 HttpOnly 쿠키로 분리하여 안전하게 발급·관리하는 인증 체계를 구현합니다.

## 주요 변경 내용
- Controller/API 레이어
  - `AuthController` 추가: POST /api/v1/auth/login, /refresh, /logout 구현 (로그인 시 Access Token 응답 본문, Refresh Token은 HttpOnly 쿠키로 설정). 로그아웃은 인증된 사용자만 호출하도록 Security 설정 추가.
- Service/비즈니스 로직 레이어
  - `AuthService` 추가: 인증 검증(비밀번호 검사), Access/Refresh 토큰 생성·검증, 단일 로그인 정책(새 로그인 시 기존 Refresh Token 덮어쓰기), 로그아웃 시 저장된 Refresh Token 삭제.
- DTO 레이어
  - `LoginRequest`, `LoginResponse`, `TokenRefreshResponse` 추가. `LoginResponse.refreshToken`에 `@JsonIgnore` 적용하여 응답 본문에서 제외함.
- Entity/데이터 접근 레이어
  - `RefreshToken` 엔티티: `BaseEntity` 상속 제거, `createdAt` 필드 추가(영속화).  
  - `RefreshTokenRepository`: `findByToken()`, `findByAdminId()`, `deleteByAdminId()` 메서드 추가.
- 인프라/유틸리티
  - `CookieProvider` 추가: refresh_token Set-Cookie 생성 및 만료 처리(도메인, SameSite, Secure 지원).
  - `JwtProvider`, `JwtAuthenticationFilter` 검증 흐름·주석 보강.
  - 글로벌 예외처리에 `MissingRequestCookieException` 핸들러 추가(토큰 누락 시 TOKEN_NOT_FOUND 응답).
  - `ErrorCode`에 `INVALID_CREDENTIALS` 추가.
- 설정 및 문서화
  - application-dev.yml / application-local.yml: access-token 만료 30분→15분, refresh-token 만료 14일→7일로 단축; cookie 관련 설정( SameSite, Secure, Domain) 추가/조정.
  - Swagger/OpenAPI 애너테이션(@Tag, @Operation, @Schema) 추가 및 여러 DTO/엔드포인트 문서화 강화.

## 영향 범위
- API 변경: 인증 관련 엔드포인트 3개 추가(POST /api/v1/auth/login, /refresh, /logout) 및 토큰 전달 방식(Access Token: 응답 본문, Refresh Token: HttpOnly 쿠키) 변경. 로그아웃 엔드포인트 인증 요구 추가로 호출 전 인증 필요.
- DB 스키마 변경: `refresh_token` 엔티티에 `createdAt` 필드 추가(마이그레이션 필요 여부 점검).
- 설정 변경: JWT 만료 시간 단축 및 쿠키 보안 관련 설정 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->