### PR TITLE
[Refactor] Admin 엔티티 필드별 update 메서드를 단일 update()로 통합

### DIFF
--- a/src/main/java/com/boaz/backend/domain/admin/entity/Admin.java
+++ b/src/main/java/com/boaz/backend/domain/admin/entity/Admin.java
@@ -78,24 +78,12 @@ public class Admin extends BaseEntity {
         this.createdBy = createdBy;
     }
 
-    public void updateRole(Role role) {
-        this.role = role;
-    }
-
-    public void updateName(String name) {
-        this.name = name;
-    }
-
-    public void updateTrack(Track track) {
-        this.track = track;
-    }
-
-    public void updateTerm(Integer term) {
-        this.term = term;
-    }
-
-    public void updateTeamName(TeamName teamName) {
-        this.teamName = teamName;
+    public void update(Role role, String name, Track track, Integer term, TeamName teamName) {
+        if (role != null) this.role = role;
+        if (name != null) this.name = name;
+        if (track != null) this.track = track;
+        if (term != null) this.term = term;
+        if (teamName != null) this.teamName = teamName;
     }
 
     public void resetPassword(String encodedPassword) {

--- a/src/main/java/com/boaz/backend/domain/admin/service/AdminService.java
+++ b/src/main/java/com/boaz/backend/domain/admin/service/AdminService.java
@@ -97,19 +97,21 @@ public class AdminService {
                 .orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
 
         request.getTrack().ifPresent(Track::validateNotAll);
-
-        request.getRole().ifPresent(role -> {
-            admin.updateRole(role);
-            refreshTokenRepository.deleteByAdminId(id);
-        });
-
-        request.getName().ifPresent(admin::updateName);
-        request.getTrack().ifPresent(admin::updateTrack);
         request.getTerm().ifPresent(t -> {
             if (t < 0) throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
-            admin.updateTerm(t);
         });
-        request.getTeamName().ifPresent(admin::updateTeamName);
+
+        if (request.getRole().isPresent()) {
+            refreshTokenRepository.deleteByAdminId(id);
+        }
+
+        admin.update(
+                request.getRole().orElse(null),
+                request.getName().orElse(null),
+                request.getTrack().orElse(null),
+                request.getTerm().orElse(null),
+                request.getTeamName().orElse(null)
+        );
 
         return new AdminIdResponse(admin.getId());
     }


### PR DESCRIPTION
## 💡 개요

* Issue Number: #65 

## 🪐 주요 변경 사항
- 다른 도메인과 구현 방식을 통일하기 위해, Admin 엔티티 필드별 update 메서드를 단일 update()로 통합

## ✅ 상세 내용
- Admin 엔티티 필드별 update 메서드를 단일 update()로 통합

## 🔔 참고 사항
- X
---