### PR TITLE
[Feat] 지원서 전체 삭제 API 구현

### DIFF
--- a/src/main/java/com/boaz/backend/domain/recruitment/controller/RecruitmentAdminController.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/controller/RecruitmentAdminController.java
@@ -71,6 +71,14 @@ public class RecruitmentAdminController {
         return ResponseEntity.ok(ApiResponse.ok(null));
     }
 
+    @Operation(summary = "지원서 전체 삭제", description = "특정 모집 공고의 지원서를 전체 삭제합니다. 모집 진행 중인 경우 삭제 불가.")
+    @DeleteMapping("/{recruitmentId}/applicants")
+    public ResponseEntity<ApiResponse<Void>> deleteApplicants(
+            @PathVariable Long recruitmentId) {
+        recruitmentService.deleteApplicants(recruitmentId);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
     @Operation(summary = "지원서 질문 목록 조회", description = "특정 모집 공고의 질문 목록을 조회합니다. 모집 중 여부와 무관하게 조회 가능.")
     @GetMapping("/{recruitmentId}/questions")
     public ResponseEntity<ApiResponse<List<QuestionResponse>>> getAdminQuestions(

--- a/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantAnswerRepository.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantAnswerRepository.java
@@ -16,4 +16,9 @@ public interface ApplicantAnswerRepository extends JpaRepository<ApplicantAnswer
     // applicant_id 기반 조회
     @Query("SELECT aa FROM ApplicantAnswer aa WHERE aa.applicant.id IN :applicantIds")
     List<ApplicantAnswer> findByApplicantIds(@Param("applicantIds") List<Long> applicantIds);
+
+    // recruitment 내 전체 답변 삭제
+    @Query("DELETE FROM ApplicantAnswer aa WHERE aa.applicant.id IN :applicantIds")
+    @org.springframework.data.jpa.repository.Modifying
+    void deleteByApplicantIds(@Param("applicantIds") List<Long> applicantIds);
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantAnswerRepository.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantAnswerRepository.java
@@ -17,8 +17,8 @@ public interface ApplicantAnswerRepository extends JpaRepository<ApplicantAnswer
     @Query("SELECT aa FROM ApplicantAnswer aa WHERE aa.applicant.id IN :applicantIds")
     List<ApplicantAnswer> findByApplicantIds(@Param("applicantIds") List<Long> applicantIds);
 
-    // recruitment 내 전체 답변 삭제
-    @Query("DELETE FROM ApplicantAnswer aa WHERE aa.applicant.id IN :applicantIds")
+    // recruitment 내 전체 답변 삭제 (서브쿼리로 메모리 적재 없이 벌크 삭제)
     @org.springframework.data.jpa.repository.Modifying
-    void deleteByApplicantIds(@Param("applicantIds") List<Long> applicantIds);
+    @Query("DELETE FROM ApplicantAnswer aa WHERE aa.applicant.id IN (SELECT a.id FROM Applicant a WHERE a.recruitment.id = :recruitmentId)")
+    void deleteByRecruitmentId(@Param("recruitmentId") Long recruitmentId);
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantRepository.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantRepository.java
@@ -14,6 +14,13 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
     // 공고에 연관된 지원자 존재 여부 확인
     boolean existsByRecruitmentId(Long recruitmentId);
 
+    // recruitment_id 기반 지원자 ID 목록 조회
+    @Query("SELECT a.id FROM Applicant a WHERE a.recruitment.id = :recruitmentId")
+    List<Long> findIdsByRecruitmentId(@Param("recruitmentId") Long recruitmentId);
+
+    // recruitment_id 기반 전체 삭제
+    void deleteByRecruitmentId(Long recruitmentId);
+
     // recruitment_id, track 기반 검색 (중복 제거)
     @Query("""
         SELECT a FROM Applicant a

--- a/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantRepository.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantRepository.java
@@ -14,10 +14,6 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
     // 공고에 연관된 지원자 존재 여부 확인
     boolean existsByRecruitmentId(Long recruitmentId);
 
-    // recruitment_id 기반 지원자 ID 목록 조회
-    @Query("SELECT a.id FROM Applicant a WHERE a.recruitment.id = :recruitmentId")
-    List<Long> findIdsByRecruitmentId(@Param("recruitmentId") Long recruitmentId);
-
     // recruitment_id 기반 전체 삭제
     void deleteByRecruitmentId(Long recruitmentId);
 

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -489,11 +489,8 @@ public class RecruitmentService {
             throw new CustomException(ErrorCode.RECRUITMENT_NOT_CLOSED);
         }
 
-        List<Long> applicantIds = applicantRepository.findIdsByRecruitmentId(recruitmentId);
-        if (!applicantIds.isEmpty()) {
-            applicantAnswerRepository.deleteByApplicantIds(applicantIds);
-            applicantRepository.deleteByRecruitmentId(recruitmentId);
-        }
+        applicantAnswerRepository.deleteByRecruitmentId(recruitmentId);
+        applicantRepository.deleteByRecruitmentId(recruitmentId);
     }
 
     // 지원서 질문 목록 조회 (어드민 전용, 모집 중 여부 무관)

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -479,6 +479,23 @@ public class RecruitmentService {
         recruitmentRepository.delete(recruitment);
     }
 
+    // 지원서 전체 삭제 (모집 진행 중이면 거부)
+    @Transactional
+    public void deleteApplicants(Long recruitmentId) {
+        Recruitment recruitment = recruitmentRepository.findById(recruitmentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
+
+        if (recruitment.isActive()) {
+            throw new CustomException(ErrorCode.RECRUITMENT_NOT_CLOSED);
+        }
+
+        List<Long> applicantIds = applicantRepository.findIdsByRecruitmentId(recruitmentId);
+        if (!applicantIds.isEmpty()) {
+            applicantAnswerRepository.deleteByApplicantIds(applicantIds);
+            applicantRepository.deleteByRecruitmentId(recruitmentId);
+        }
+    }
+
     // 지원서 질문 목록 조회 (어드민 전용, 모집 중 여부 무관)
     public List<QuestionResponse> getAdminQuestions(Long recruitmentId) {
         recruitmentRepository.findById(recruitmentId)

--- a/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
     RECRUITMENT_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "RECRUITMENT_NOT_AVAILABLE", "현재 지원 가능한 기간이 아닙니다."),
     QUESTIONS_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTIONS_NOT_FOUND", "등록된 질문이 없습니다."),
     RECRUITMENT_CLOSED(HttpStatus.BAD_REQUEST, "RECRUITMENT_CLOSED", "현재 지원 기간이 아닙니다."),
+    RECRUITMENT_NOT_CLOSED(HttpStatus.BAD_REQUEST, "RECRUITMENT_NOT_CLOSED", "모집이 진행 중인 공고의 지원서는 삭제할 수 없습니다."),
     ANSWER_REQUIRED(HttpStatus.BAD_REQUEST, "ANSWER_REQUIRED", "필수 질문에 답변해주세요."),
     INVALID_TRACK_SELECTION(HttpStatus.BAD_REQUEST, "INVALID_TRACK_SELECTION", "지원 부문을 올바르게 선택해주세요."),
     INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "INVALID_EMAIL_FORMAT", "이메일 형식이 올바르지 않습니다."),


### PR DESCRIPTION
## 💡 개요
* Issue Number: #87                                                            
                                                       
## 🪐 주요 변경 사항
- 지원서 전체 삭제 API 구현 (`DELETE
/api/v1/admin/recruitment/{recruitmentId}/applicants`)

## ✅ 상세 내용
- `ApplicantRepository`에 `findIdsByRecruitmentId()`, `deleteByRecruitmentId()`
 추가
- `ApplicantAnswerRepository`에 `deleteByApplicantIds()` 추가
- `applicant_answer` 삭제 후 `applicant` 삭제 순서 보장 (FK 제약 조건 대응)
- 모집 진행 중(`isActive()`)이면 `RECRUITMENT_NOT_CLOSED` 400 반환
- 지원서가 없는 경우에도 200 반환 (빈 삭제 허용)
- `ErrorCode`에 `RECRUITMENT_NOT_CLOSED` 추가

## 🔔 참고 사항
- 지원서 삭제 후 질문 삭제가 가능해짐 (REC-ADMIN-009 → REC-ADMIN-008 순서)
---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**변경 목적**:
모집 공고 관리자가 해당 공고의 지원서를 일괄 삭제할 수 있는 API를 구현합니다. 외래키 제약을 고려하여 지원 답변 먼저 삭제 후 지원서를 삭제하는 순서를 보장합니다.

**주요 변경 내용**:
- **Controller 레이어**: `DELETE /api/v1/admin/recruitment/{recruitmentId}/applicants` 엔드포인트 추가
- **Repository 레이어**: 
  - `ApplicantRepository`에 `findIdsByRecruitmentId()`, `deleteByRecruitmentId()` 메서드 추가
  - `ApplicantAnswerRepository`에 `deleteByApplicantIds()` 메서드 추가 (JPQL 벌크 DELETE)
- **Service 레이어**: 모집 활성 여부 검증 및 삭제 순서 보장 로직이 포함된 `deleteApplicants()` 메서드 추가
- **Exception 레이어**: 진행 중인 모집의 지원서 삭제 시도 시 반환할 `RECRUITMENT_NOT_CLOSED` 에러 코드 추가

**영향 범위**:
- **API 변경**: 신규 DELETE 엔드포인트 추가
- **비즈니스 로직 변경**: 진행 중 모집(isActive = true)의 경우 지원서 삭제 불가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->