### PR TITLE
[Feat] 모집 사전 알림 신청 관리 API 구현

### DIFF
--- a/src/main/java/com/boaz/backend/domain/recruitment/controller/RecruitmentAdminController.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/controller/RecruitmentAdminController.java
@@ -9,6 +9,7 @@ import com.boaz.backend.domain.recruitment.dto.response.QuestionIdsResponse;
 import com.boaz.backend.domain.recruitment.dto.response.QuestionResponse;
 import com.boaz.backend.domain.recruitment.dto.response.RecruitmentIdResponse;
 import com.boaz.backend.domain.recruitment.dto.response.RecruitmentResponse;
+import com.boaz.backend.domain.recruitment.dto.response.SubscriptionResponse;
 import com.boaz.backend.domain.recruitment.service.RecruitmentService;
 import com.boaz.backend.global.common.ApiResponse;
 
@@ -107,6 +108,19 @@ public class RecruitmentAdminController {
     public ResponseEntity<ApiResponse<Void>> deleteQuestion(
             @PathVariable Long questionId) {
         recruitmentService.deleteQuestion(questionId);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    @Operation(summary = "모집 사전 알림 신청 목록 조회", description = "모든 사전 알림 신청 목록을 최신순으로 반환합니다.")
+    @GetMapping("/subscriptions")
+    public ResponseEntity<ApiResponse<List<SubscriptionResponse>>> getAllSubscriptions() {
+        return ResponseEntity.ok(ApiResponse.ok(recruitmentService.getAllSubscriptions()));
+    }
+
+    @Operation(summary = "모집 사전 알림 신청 전체 삭제", description = "모든 사전 알림 신청 데이터를 삭제합니다. 데이터가 없어도 200을 반환합니다.")
+    @DeleteMapping("/subscriptions")
+    public ResponseEntity<ApiResponse<Void>> deleteAllSubscriptions() {
+        recruitmentService.deleteAllSubscriptions();
         return ResponseEntity.ok(ApiResponse.ok(null));
     }
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/response/SubscriptionResponse.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/response/SubscriptionResponse.java
@@ -4,14 +4,24 @@ import com.boaz.backend.domain.recruitment.entity.Subscription;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 public class SubscriptionResponse {
+
+    @Schema(description = "구독 ID", example = "1")
+    private final Long id;
 
     @Schema(description = "구독 이메일", example = "hong@example.com")
     private final String email;
 
+    @Schema(description = "신청 일시")
+    private final LocalDateTime createdAt;
+
     private SubscriptionResponse(Subscription subscription) {
+        this.id = subscription.getId();
         this.email = subscription.getEmail();
+        this.createdAt = subscription.getCreatedAt();
     }
 
     public static SubscriptionResponse from(Subscription subscription) {

--- a/src/main/java/com/boaz/backend/domain/recruitment/repository/SubscriptionRepository.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/repository/SubscriptionRepository.java
@@ -3,7 +3,11 @@ package com.boaz.backend.domain.recruitment.repository;
 import com.boaz.backend.domain.recruitment.entity.Subscription;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
 
     boolean existsByEmail(String email);
+
+    List<Subscription> findAllByOrderByCreatedAtDesc();
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -640,4 +640,18 @@ public class RecruitmentService {
             throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
     }
+
+    // 모집 사전 알림 신청 목록 조회 (어드민 전용)
+    public List<SubscriptionResponse> getAllSubscriptions() {
+        return subscriptionRepository.findAllByOrderByCreatedAtDesc()
+                .stream()
+                .map(SubscriptionResponse::from)
+                .toList();
+    }
+
+    // 모집 사전 알림 신청 전체 삭제 (어드민 전용)
+    @Transactional
+    public void deleteAllSubscriptions() {
+        subscriptionRepository.deleteAll();
+    }
 }


### PR DESCRIPTION
## 💡 개요                                                                                                                                                          
                                                          
* Issue Number: #88                                                                                                                                                 
 
## 🪐 주요 변경 사항                                                                                                                                                
- 모집 사전 알림 신청 관리 어드민 API 2종 구현 (REC-ADMIN-011, 012)

## ✅ 상세 내용
- `GET /api/v1/admin/recruitment/subscriptions` — 전체 목록 조회, `created_at` 내림차순 반환
- `DELETE /api/v1/admin/recruitment/subscriptions` — 전체 삭제, 데이터 0건이어도 200 반환
- `SubscriptionResponse`에 `id`, `createdAt` 필드 추가 (어드민 조회 스펙 대응)

## 🔔 참고 사항
- `SubscriptionResponse` 수정으로 인해 공개 API(`POST /api/v1/recruitment/subscriptions`) 응답에도 `id`, `createdAt`이 함께 노출됨. 기존처럼 `email`만 반환할지 프론트엔드와 협의 필요.
---