### PR TITLE
[Feat] 리크루팅 지원서 제출/임시저장/조회 User 인증 적용

### DIFF
--- a/src/main/java/com/boaz/backend/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/controller/RecruitmentController.java
@@ -17,6 +17,7 @@ import com.boaz.backend.global.common.enums.Track;
 import com.boaz.backend.global.security.UserPrincipal;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -63,6 +64,7 @@ public class RecruitmentController {
     }
 
     @Operation(summary = "지원서 제출")
+    @SecurityRequirement(name = "bearerAuth")
     @PostMapping("/{recruitmentId}/applications")
     public ResponseEntity<ApiResponse<ApplicationResponse>> submitApplication(
             @PathVariable Long recruitmentId,
@@ -75,6 +77,7 @@ public class RecruitmentController {
     }
 
     @Operation(summary = "지원서 임시저장")
+    @SecurityRequirement(name = "bearerAuth")
     @PutMapping("/{recruitmentId}/applications/draft")
     public ResponseEntity<ApiResponse<DraftApplicationResponse>> saveDraft(
             @PathVariable Long recruitmentId,
@@ -85,6 +88,7 @@ public class RecruitmentController {
     }
 
     @Operation(summary = "내 지원서 조회")
+    @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/{recruitmentId}/applications/me")
     public ResponseEntity<ApiResponse<MyApplicationResponse>> getMyApplication(
             @PathVariable Long recruitmentId,

--- a/src/main/java/com/boaz/backend/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/controller/RecruitmentController.java
@@ -1,9 +1,12 @@
 package com.boaz.backend.domain.recruitment.controller;
 
 import com.boaz.backend.domain.recruitment.dto.request.ApplicationRequest;
+import com.boaz.backend.domain.recruitment.dto.request.DraftApplicationRequest;
 import com.boaz.backend.domain.recruitment.dto.request.SubscriptionRequest;
 import com.boaz.backend.domain.recruitment.dto.response.ApplicationResponse;
 import com.boaz.backend.domain.recruitment.dto.response.DeadlineResponse;
+import com.boaz.backend.domain.recruitment.dto.response.DraftApplicationResponse;
+import com.boaz.backend.domain.recruitment.dto.response.MyApplicationResponse;
 import com.boaz.backend.domain.recruitment.dto.response.QuestionResponse;
 import com.boaz.backend.domain.recruitment.dto.response.RecruitmentResponse;
 import com.boaz.backend.domain.recruitment.dto.response.RecruitmentStatusResponse;
@@ -11,6 +14,7 @@ import com.boaz.backend.domain.recruitment.dto.response.SubscriptionResponse;
 import com.boaz.backend.domain.recruitment.service.RecruitmentService;
 import com.boaz.backend.global.common.ApiResponse;
 import com.boaz.backend.global.common.enums.Track;
+import com.boaz.backend.global.security.UserPrincipal;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -21,6 +25,7 @@ import java.util.List;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Recruitment", description = "모집 공고 API")
@@ -30,7 +35,7 @@ import org.springframework.web.bind.annotation.*;
 public class RecruitmentController {
 
     private final RecruitmentService recruitmentService;
-    
+
     @Operation(summary = "모집 중 여부 조회")
     @GetMapping("/status")
     public ResponseEntity<ApiResponse<RecruitmentStatusResponse>> getRecruitmentStatus() {
@@ -58,12 +63,34 @@ public class RecruitmentController {
     }
 
     @Operation(summary = "지원서 제출")
-    @PostMapping("/applications")
+    @PostMapping("/{recruitmentId}/applications")
     public ResponseEntity<ApiResponse<ApplicationResponse>> submitApplication(
+            @PathVariable Long recruitmentId,
+            @AuthenticationPrincipal UserPrincipal principal,
             @RequestBody @Valid ApplicationRequest request) {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(ApiResponse.created(recruitmentService.submitApplication(request)));
+                .body(ApiResponse.created(
+                        recruitmentService.submitApplication(principal.userId(), recruitmentId, request)));
+    }
+
+    @Operation(summary = "지원서 임시저장")
+    @PutMapping("/{recruitmentId}/applications/draft")
+    public ResponseEntity<ApiResponse<DraftApplicationResponse>> saveDraft(
+            @PathVariable Long recruitmentId,
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestBody DraftApplicationRequest request) {
+        return ResponseEntity.ok(ApiResponse.ok(
+                recruitmentService.saveDraft(principal.userId(), recruitmentId, request)));
+    }
+
+    @Operation(summary = "내 지원서 조회")
+    @GetMapping("/{recruitmentId}/applications/me")
+    public ResponseEntity<ApiResponse<MyApplicationResponse>> getMyApplication(
+            @PathVariable Long recruitmentId,
+            @AuthenticationPrincipal UserPrincipal principal) {
+        return ResponseEntity.ok(ApiResponse.ok(
+                recruitmentService.getMyApplication(principal.userId(), recruitmentId)));
     }
 
     @Operation(summary = "모집 사전 알림 구독")

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/request/DraftApplicationRequest.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/request/DraftApplicationRequest.java
@@ -5,38 +5,29 @@ import com.boaz.backend.global.common.enums.Track;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 import java.util.List;
 
-
 @Getter
-public class ApplicationRequest {
+public class DraftApplicationRequest {
 
     @Schema(description = "지원 부문", example = "ENGINEERING", allowableValues = {"ANALYSIS", "VISUALIZATION", "ENGINEERING"})
-    @NotNull(message = "지원 부문을 입력해주세요.")
     private Track track;
 
     @Schema(description = "성명", example = "홍길동")
-    @NotBlank(message = "성명을 입력해주세요.")
     private String name;
 
     @Schema(description = "이메일", example = "hong@example.com")
-    @NotBlank(message = "이메일을 입력해주세요.")
     private String email;
 
-    @Schema(description = "전화번호", example = "01012345678")
-    @NotBlank(message = "전화번호를 입력해주세요.")
+    @Schema(description = "전화번호 (하이픈 없이 숫자만, 10~11자리)", example = "01012345678")
     private String phone;
 
     @Schema(description = "대학교", example = "한국대학교")
-    @NotBlank(message = "대학교를 입력해주세요.")
     private String university;
 
     @Schema(description = "본전공", example = "컴퓨터공학")
-    @NotBlank(message = "본전공을 입력해주세요.")
     private String major;
 
     @Schema(description = "부전공/복수전공 목록", example = "[\"통계학\"]")
@@ -44,32 +35,26 @@ public class ApplicationRequest {
     private List<String> minorDoubleMajor;
 
     @Schema(description = "마지막 재학 학기", example = "4")
-    @NotNull(message = "마지막 재학 학기를 입력해주세요.")
     @JsonProperty("last_semester")
     private Integer lastSemester;
 
-    @Schema(description = "병역 상태", example = "COMPLETED_OR_EXEMPT", allowableValues = {"COMPLETED_OR_EXEMPT", "NOT_COMPLETED"})
-    @NotNull(message = "병역 상태를 선택해주세요.")
+    @Schema(description = "병역 상태", allowableValues = {"COMPLETED_OR_EXEMPT", "NOT_COMPLETED"})
     @JsonProperty("military_status")
     private Applicant.MilitaryStatus militaryStatus;
 
-    @Schema(description = "생년월일", example = "2000-01-01")
-    @NotBlank(message = "생년월일을 입력해주세요.")
+    @Schema(description = "생년월일 (YYYY-MM-DD)", example = "2000-01-01")
     @JsonProperty("birth_date")
     private String birthDate;
 
-    @Schema(description = "졸업 예정 시점", example = "2025-02")
-    @NotBlank(message = "졸업 예정 시점을 입력해주세요.")
+    @Schema(description = "졸업 예정 시점", example = "2026-02")
     @JsonProperty("graduation_date")
     private String graduationDate;
 
     @Schema(description = "대학원 진학 여부", example = "false")
-    @NotNull(message = "대학원 진학 여부를 선택해주세요.")
     @JsonProperty("grad_school_plan")
     private Boolean gradSchoolPlan;
 
-    @Schema(description = "지원서 답변 목록")
-    @NotNull(message = "답변 목록을 입력해주세요.")
+    @Schema(description = "답변 목록. null이면 기존 answers 유지, 빈 배열이면 전체 삭제")
     @Valid
     private List<AnswerRequest> answers;
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/response/DraftApplicationResponse.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/response/DraftApplicationResponse.java
@@ -1,0 +1,21 @@
+package com.boaz.backend.domain.recruitment.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class DraftApplicationResponse {
+
+    @Schema(description = "지원자 ID", example = "42")
+    @JsonProperty("applicant_id")
+    private final Long applicantId;
+
+    private DraftApplicationResponse(Long applicantId) {
+        this.applicantId = applicantId;
+    }
+
+    public static DraftApplicationResponse of(Long applicantId) {
+        return new DraftApplicationResponse(applicantId);
+    }
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/response/MyApplicationResponse.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/response/MyApplicationResponse.java
@@ -1,0 +1,141 @@
+package com.boaz.backend.domain.recruitment.dto.response;
+
+import com.boaz.backend.domain.recruitment.entity.Applicant;
+import com.boaz.backend.global.common.enums.Track;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+public class MyApplicationResponse {
+
+    @Schema(description = "지원자 ID", example = "42")
+    @JsonProperty("applicant_id")
+    private final Long applicantId;
+
+    @Schema(description = "지원서 상태", example = "DRAFT")
+    private final Applicant.ApplicantStatus status;
+
+    @Schema(description = "지원 부문", example = "ENGINEERING")
+    private final Track track;
+
+    @Schema(description = "성명", example = "홍길동")
+    private final String name;
+
+    @Schema(description = "이메일", example = "hong@example.com")
+    private final String email;
+
+    @Schema(description = "전화번호", example = "01012345678")
+    private final String phone;
+
+    @Schema(description = "대학교", example = "한국대학교")
+    private final String university;
+
+    @Schema(description = "본전공", example = "컴퓨터공학")
+    private final String major;
+
+    @Schema(description = "부전공/복수전공 목록")
+    @JsonProperty("minor_double_major")
+    private final List<String> minorDoubleMajor;
+
+    @Schema(description = "마지막 재학 학기", example = "6")
+    @JsonProperty("last_semester")
+    private final Integer lastSemester;
+
+    @Schema(description = "병역 상태", example = "COMPLETED_OR_EXEMPT")
+    @JsonProperty("military_status")
+    private final Applicant.MilitaryStatus militaryStatus;
+
+    @Schema(description = "생년월일", example = "2000-01-01")
+    @JsonProperty("birth_date")
+    private final LocalDate birthDate;
+
+    @Schema(description = "졸업 예정 시점", example = "2026-02")
+    @JsonProperty("graduation_date")
+    private final String graduationDate;
+
+    @Schema(description = "대학원 진학 여부", example = "false")
+    @JsonProperty("grad_school_plan")
+    private final Boolean gradSchoolPlan;
+
+    @Schema(description = "지원서 답변 목록")
+    private final List<AnswerItemResponse> answers;
+
+    @Schema(description = "최초 생성 일시")
+    @JsonProperty("created_at")
+    private final LocalDateTime createdAt;
+
+    @Schema(description = "마지막 수정 일시")
+    @JsonProperty("updated_at")
+    private final LocalDateTime updatedAt;
+
+    private MyApplicationResponse(Long applicantId, Applicant.ApplicantStatus status, Track track,
+                                   String name, String email, String phone, String university, String major,
+                                   List<String> minorDoubleMajor, Integer lastSemester,
+                                   Applicant.MilitaryStatus militaryStatus, LocalDate birthDate,
+                                   String graduationDate, Boolean gradSchoolPlan,
+                                   List<AnswerItemResponse> answers,
+                                   LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.applicantId = applicantId;
+        this.status = status;
+        this.track = track;
+        this.name = name;
+        this.email = email;
+        this.phone = phone;
+        this.university = university;
+        this.major = major;
+        this.minorDoubleMajor = minorDoubleMajor;
+        this.lastSemester = lastSemester;
+        this.militaryStatus = militaryStatus;
+        this.birthDate = birthDate;
+        this.graduationDate = graduationDate;
+        this.gradSchoolPlan = gradSchoolPlan;
+        this.answers = answers;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public static MyApplicationResponse of(Applicant applicant, List<String> minorDoubleMajor,
+                                            List<AnswerItemResponse> answers) {
+        return new MyApplicationResponse(
+                applicant.getId(),
+                applicant.getStatus(),
+                applicant.getTrack(),
+                applicant.getName(),
+                applicant.getEmail(),
+                applicant.getPhone(),
+                applicant.getUniversity(),
+                applicant.getMajor(),
+                minorDoubleMajor,
+                applicant.getLastSemester(),
+                applicant.getMilitaryStatus(),
+                applicant.getBirthDate(),
+                applicant.getGraduationDate(),
+                applicant.getGradSchoolPlan(),
+                answers,
+                applicant.getCreatedAt(),
+                applicant.getUpdatedAt()
+        );
+    }
+
+    @Getter
+    public static class AnswerItemResponse {
+
+        @Schema(description = "질문 ID", example = "1")
+        @JsonProperty("question_id")
+        private final Long questionId;
+
+        @Schema(description = "답변 (TEXT: 문자열, TABLE: 객체)")
+        private final JsonNode answer;
+
+        public AnswerItemResponse(Long questionId, JsonNode answer) {
+            this.questionId = questionId;
+            this.answer = answer;
+        }
+    }
+}

--- a/src/main/java/com/boaz/backend/domain/recruitment/entity/Applicant.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/entity/Applicant.java
@@ -9,23 +9,30 @@ import lombok.NoArgsConstructor;
 
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import com.boaz.backend.domain.user.entity.User;
 import com.boaz.backend.global.common.BaseEntity;
 import com.boaz.backend.global.common.enums.Track;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "applicants")
 @EntityListeners(AuditingEntityListener.class)
-public class Applicant extends BaseEntity  {
-    
+public class Applicant extends BaseEntity {
+
     public enum MilitaryStatus {
         @Schema(description = "필 또는 면제")
         COMPLETED_OR_EXEMPT,
         @Schema(description = "미필")
         NOT_COMPLETED
+    }
+
+    public enum ApplicantStatus {
+        DRAFT,
+        SUBMITTED
     }
 
     @Id
@@ -36,14 +43,22 @@ public class Applicant extends BaseEntity  {
     @JoinColumn(name = "recruitment_id", nullable = false)
     private Recruitment recruitment;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ApplicantStatus status;
+
     @Column(length = 50)
     @Enumerated(EnumType.STRING)
     private Track track;
 
-    @Column(length = 100, nullable = false)
+    @Column(length = 100)
     private String name;
 
-    @Column(length = 255, nullable = false)
+    @Column(length = 255)
     private String email;
 
     @Column(length = 20)
@@ -71,12 +86,16 @@ public class Applicant extends BaseEntity  {
 
     private Boolean gradSchoolPlan;
 
+    private LocalDateTime submittedAt;
+
     @Builder
-    public Applicant(Recruitment recruitment, Track track, String name, String email,
-                    String phone, String university, String major, String minorDoubleMajor,
-                    Integer lastSemester, MilitaryStatus militaryStatus, LocalDate birthDate,
-                    String graduationDate, Boolean gradSchoolPlan) {
+    public Applicant(Recruitment recruitment, User user, ApplicantStatus status, Track track,
+                     String name, String email, String phone, String university, String major,
+                     String minorDoubleMajor, Integer lastSemester, MilitaryStatus militaryStatus,
+                     LocalDate birthDate, String graduationDate, Boolean gradSchoolPlan) {
         this.recruitment = recruitment;
+        this.user = user;
+        this.status = status != null ? status : ApplicantStatus.DRAFT;
         this.track = track;
         this.name = name;
         this.email = email;
@@ -89,5 +108,51 @@ public class Applicant extends BaseEntity  {
         this.birthDate = birthDate;
         this.graduationDate = graduationDate;
         this.gradSchoolPlan = gradSchoolPlan;
+    }
+
+    // 임시저장 부분 업데이트 (null이면 기존값 유지)
+    public void update(Track track, String name, String email, String phone,
+                       String university, String major, String minorDoubleMajor,
+                       Integer lastSemester, MilitaryStatus militaryStatus,
+                       LocalDate birthDate, String graduationDate, Boolean gradSchoolPlan) {
+        if (track != null) this.track = track;
+        if (name != null) this.name = name;
+        if (email != null) this.email = email;
+        if (phone != null) this.phone = phone;
+        if (university != null) this.university = university;
+        if (major != null) this.major = major;
+        if (minorDoubleMajor != null) this.minorDoubleMajor = minorDoubleMajor;
+        if (lastSemester != null) this.lastSemester = lastSemester;
+        if (militaryStatus != null) this.militaryStatus = militaryStatus;
+        if (birthDate != null) this.birthDate = birthDate;
+        if (graduationDate != null) this.graduationDate = graduationDate;
+        if (gradSchoolPlan != null) this.gradSchoolPlan = gradSchoolPlan;
+    }
+
+    // 신규 제출 시 submittedAt 설정 (DRAFT 없이 바로 제출하는 경우)
+    public void markSubmitted() {
+        this.status = ApplicantStatus.SUBMITTED;
+        this.submittedAt = LocalDateTime.now();
+    }
+
+    // 제출 시 전체 덮어쓰기 + SUBMITTED 전환
+    public void overwrite(Track track, String name, String email, String phone,
+                          String university, String major, String minorDoubleMajor,
+                          Integer lastSemester, MilitaryStatus militaryStatus,
+                          LocalDate birthDate, String graduationDate, Boolean gradSchoolPlan) {
+        this.track = track;
+        this.name = name;
+        this.email = email;
+        this.phone = phone;
+        this.university = university;
+        this.major = major;
+        this.minorDoubleMajor = minorDoubleMajor;
+        this.lastSemester = lastSemester;
+        this.militaryStatus = militaryStatus;
+        this.birthDate = birthDate;
+        this.graduationDate = graduationDate;
+        this.gradSchoolPlan = gradSchoolPlan;
+        this.status = ApplicantStatus.SUBMITTED;
+        this.submittedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantAnswerRepository.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantAnswerRepository.java
@@ -17,6 +17,11 @@ public interface ApplicantAnswerRepository extends JpaRepository<ApplicantAnswer
     @Query("SELECT aa FROM ApplicantAnswer aa WHERE aa.applicant.id IN :applicantIds")
     List<ApplicantAnswer> findByApplicantIds(@Param("applicantIds") List<Long> applicantIds);
 
+    // 지원자 단건 답변 전체 삭제 (임시저장 덮어쓰기, 제출 시 DRAFT 답변 교체)
+    @org.springframework.data.jpa.repository.Modifying
+    @Query("DELETE FROM ApplicantAnswer aa WHERE aa.applicant.id = :applicantId")
+    void deleteByApplicantId(@Param("applicantId") Long applicantId);
+
     // recruitment 내 전체 답변 삭제 (서브쿼리로 메모리 적재 없이 벌크 삭제)
     @org.springframework.data.jpa.repository.Modifying
     @Query("DELETE FROM ApplicantAnswer aa WHERE aa.applicant.id IN (SELECT a.id FROM Applicant a WHERE a.recruitment.id = :recruitmentId)")

--- a/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantRepository.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantRepository.java
@@ -1,10 +1,9 @@
 package com.boaz.backend.domain.recruitment.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import com.boaz.backend.domain.recruitment.entity.Applicant;
 import com.boaz.backend.global.common.enums.Track;
@@ -17,20 +16,13 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
     // recruitment_id 기반 전체 삭제
     void deleteByRecruitmentId(Long recruitmentId);
 
-    // recruitment_id, track 기반 검색 (중복 제거)
-    @Query("""
-        SELECT a FROM Applicant a
-        WHERE a.recruitment.id = :recruitmentId
-        AND a.track = :track
-        AND a.createdAt = (
-            SELECT MAX(a2.createdAt) FROM Applicant a2
-            WHERE a2.email = a.email
-            AND a2.recruitment.id = :recruitmentId
-        )
-        ORDER BY a.createdAt ASC
-    """)
-    List<Applicant> findLatestByRecruitmentIdAndTrack(
-            @Param("recruitmentId") Long recruitmentId,
-            @Param("track") Track track
+    // (recruitment_id, user_id) 조합으로 지원서 조회
+    Optional<Applicant> findByRecruitmentIdAndUserId(Long recruitmentId, Long userId);
+
+    // recruitment_id + track + status 기반 조회 (CSV 다운로드용)
+    List<Applicant> findByRecruitmentIdAndTrackAndStatus(
+            Long recruitmentId,
+            Track track,
+            Applicant.ApplicantStatus status
     );
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -434,9 +434,15 @@ public class RecruitmentService {
                     String answerText = null;
                     String answerJson = null;
                     if (question.getType() == ApplicationQuestion.Type.TEXT) {
+                        if (answer != null && !answer.isTextual()) {
+                            throw new CustomException(ErrorCode.INVALID_ANSWER_TYPE);
+                        }
                         answerText = answer != null ? answer.asText() : null;
                     } else {
                         try {
+                            if (answer != null && !answer.isObject()) {
+                                throw new CustomException(ErrorCode.INVALID_ANSWER_TYPE);
+                            }
                             answerJson = answer != null ? objectMapper.writeValueAsString(answer) : null;
                         } catch (Exception e) {
                             throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -2,6 +2,7 @@ package com.boaz.backend.domain.recruitment.service;
 
 import com.boaz.backend.domain.recruitment.dto.request.AnswerRequest;
 import com.boaz.backend.domain.recruitment.dto.request.ApplicationRequest;
+import com.boaz.backend.domain.recruitment.dto.request.DraftApplicationRequest;
 import com.boaz.backend.domain.recruitment.dto.request.QuestionItemRequest;
 import com.boaz.backend.domain.recruitment.dto.request.QuestionsCreateRequest;
 import com.boaz.backend.domain.recruitment.dto.request.QuestionUpdateRequest;
@@ -10,6 +11,8 @@ import com.boaz.backend.domain.recruitment.dto.request.RecruitmentUpdateRequest;
 import com.boaz.backend.domain.recruitment.dto.request.SubscriptionRequest;
 import com.boaz.backend.domain.recruitment.dto.response.ApplicationResponse;
 import com.boaz.backend.domain.recruitment.dto.response.DeadlineResponse;
+import com.boaz.backend.domain.recruitment.dto.response.DraftApplicationResponse;
+import com.boaz.backend.domain.recruitment.dto.response.MyApplicationResponse;
 import com.boaz.backend.domain.recruitment.dto.response.QuestionIdResponse;
 import com.boaz.backend.domain.recruitment.dto.response.QuestionIdsResponse;
 import com.boaz.backend.domain.recruitment.dto.response.QuestionResponse;
@@ -28,12 +31,16 @@ import com.boaz.backend.domain.recruitment.repository.ApplicantRepository;
 import com.boaz.backend.domain.recruitment.repository.ApplicationQuestionRepository;
 import com.boaz.backend.domain.recruitment.repository.RecruitmentRepository;
 import com.boaz.backend.domain.recruitment.repository.SubscriptionRepository;
+import com.boaz.backend.domain.user.entity.User;
+import com.boaz.backend.domain.user.repository.UserRepository;
 import com.boaz.backend.global.common.enums.Track;
 import com.boaz.backend.global.exception.CustomException;
 import com.boaz.backend.global.exception.ErrorCode;
 import com.boaz.backend.global.util.S3Service;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.TextNode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -63,6 +70,7 @@ public class RecruitmentService {
     private final ApplicationQuestionRepository applicationQuestionRepository;
     private final ApplicantRepository applicantRepository;
     private final ApplicantAnswerRepository applicantAnswerRepository;
+    private final UserRepository userRepository;
     private final ObjectMapper objectMapper;
     private final SubscriptionRepository subscriptionRepository;
     private final CsvService csvService;
@@ -76,7 +84,7 @@ public class RecruitmentService {
     public RecruitmentStatusResponse getRecruitmentStatus() {
         Optional<Recruitment> activeRecruitment = recruitmentRepository
                 .findActiveRecruitment(LocalDateTime.now());
-        
+
         return activeRecruitment
                 .map(r -> RecruitmentStatusResponse.of(true, r.getTerm()))
                 .orElse(RecruitmentStatusResponse.of(false, null));
@@ -94,9 +102,9 @@ public class RecruitmentService {
     public RecruitmentResponse getRecruitment(Integer term) {
         Recruitment recruitment = recruitmentRepository.findByTerm(term)
                 .orElseThrow(() -> new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
-        
+
         LocalDateTime now = LocalDateTime.now();
-        boolean isActive = !now.isBefore(recruitment.getStartDate()) 
+        boolean isActive = !now.isBefore(recruitment.getStartDate())
                         && !now.isAfter(recruitment.getEndDate());
 
         return RecruitmentResponse.from(recruitment, isActive);
@@ -111,12 +119,12 @@ public class RecruitmentService {
 
         // 모집 중 여부 확인
         LocalDateTime now = LocalDateTime.now();
-        boolean isActive = !now.isBefore(recruitment.getStartDate()) 
+        boolean isActive = !now.isBefore(recruitment.getStartDate())
                         && !now.isAfter(recruitment.getEndDate());
         if (!isActive) {
             throw new CustomException(ErrorCode.RECRUITMENT_NOT_AVAILABLE);
         }
-        
+
         // 부문 검증
         track.validateNotAll();
 
@@ -143,10 +151,14 @@ public class RecruitmentService {
 
     // 지원서 제출하기
     @Transactional
-    public ApplicationResponse submitApplication(ApplicationRequest request) {
+    public ApplicationResponse submitApplication(Long userId, Long recruitmentId, ApplicationRequest request) {
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // 공고 존재 여부 확인
-        Recruitment recruitment = recruitmentRepository.findById(request.getRecruitmentId())
+        Recruitment recruitment = recruitmentRepository.findById(recruitmentId)
                 .orElseThrow(() -> new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
 
         // 모집 기간 확인
@@ -155,6 +167,12 @@ public class RecruitmentService {
                         && !now.isAfter(recruitment.getEndDate());
         if (!isActive) {
             throw new CustomException(ErrorCode.RECRUITMENT_CLOSED);
+        }
+
+        // 이미 제출된 지원서 확인
+        Optional<Applicant> existing = applicantRepository.findByRecruitmentIdAndUserId(recruitmentId, userId);
+        if (existing.isPresent() && existing.get().getStatus() == Applicant.ApplicantStatus.SUBMITTED) {
+            throw new CustomException(ErrorCode.ALREADY_SUBMITTED);
         }
 
         // 부문 검증
@@ -177,12 +195,12 @@ public class RecruitmentService {
         } catch (DateTimeParseException e) {
             throw new CustomException(ErrorCode.INVALID_BIRTH_DATE_FORMAT);
         }
-        
+
         // 해당 공고의 질문 목록 조회
         ApplicationQuestion.Category trackCategory = toQuestionCategory(request.getTrack());
         List<ApplicationQuestion> questions = applicationQuestionRepository
                 .findByRecruitmentIdAndCategories(
-                        request.getRecruitmentId(),
+                        recruitmentId,
                         ApplicationQuestion.Category.COMMON,
                         trackCategory
                 );
@@ -200,8 +218,7 @@ public class RecruitmentService {
                 .map(AnswerRequest::getQuestionId)
                 .toList();
 
-        boolean allRequiredAnswered = answeredQuestionIds.containsAll(requiredQuestionIds);
-        if (!allRequiredAnswered) {
+        if (!answeredQuestionIds.containsAll(requiredQuestionIds)) {
             throw new CustomException(ErrorCode.ANSWER_REQUIRED);
         }
 
@@ -210,17 +227,18 @@ public class RecruitmentService {
             throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
-        // 잘못된 questionId 검증
+        // 유효한 questionId 목록
         List<Long> validQuestionIds = questions.stream()
                 .map(ApplicationQuestion::getId)
                 .toList();
 
+        // 잘못된 questionId 검증
         for (AnswerRequest answerRequest : request.getAnswers()) {
             if (!validQuestionIds.contains(answerRequest.getQuestionId())) {
                 throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
             }
         }
-        
+
         // 답변 형식 검증 (TEXT → String, TABLE → JSON)
         Map<Long, ApplicationQuestion> questionMap = questions.stream()
                 .collect(Collectors.toMap(ApplicationQuestion::getId, q -> q));
@@ -246,33 +264,41 @@ public class RecruitmentService {
         }
 
         // minorDoubleMajor JSON 변환
-        String minorDoubleMajorJson = null;
-        if (request.getMinorDoubleMajor() != null && !request.getMinorDoubleMajor().isEmpty()) {
-            try {
-                minorDoubleMajorJson = objectMapper.writeValueAsString(request.getMinorDoubleMajor());
-            } catch (Exception e) {
-                throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
-            }
+        String minorDoubleMajorJson = serializeList(request.getMinorDoubleMajor());
+
+        // DRAFT 존재 시 덮어쓰기, 없으면 신규 생성
+        Applicant applicant;
+        if (existing.isPresent()) {
+            // DRAFT → SUBMITTED 전환 (overwrite: 전체 교체)
+            applicant = existing.get();
+            applicantAnswerRepository.deleteByApplicantId(applicant.getId());
+            applicant.overwrite(
+                    request.getTrack(), request.getName(), request.getEmail(), request.getPhone(),
+                    request.getUniversity(), request.getMajor(), minorDoubleMajorJson,
+                    request.getLastSemester(), request.getMilitaryStatus(), birthDate,
+                    request.getGraduationDate(), request.getGradSchoolPlan()
+            );
+        } else {
+            applicant = Applicant.builder()
+                    .recruitment(recruitment)
+                    .user(user)
+                    .status(Applicant.ApplicantStatus.SUBMITTED)
+                    .track(request.getTrack())
+                    .name(request.getName())
+                    .email(request.getEmail())
+                    .phone(request.getPhone())
+                    .university(request.getUniversity())
+                    .major(request.getMajor())
+                    .minorDoubleMajor(minorDoubleMajorJson)
+                    .lastSemester(request.getLastSemester())
+                    .militaryStatus(request.getMilitaryStatus())
+                    .birthDate(birthDate)
+                    .graduationDate(request.getGraduationDate())
+                    .gradSchoolPlan(request.getGradSchoolPlan())
+                    .build();
+            applicantRepository.save(applicant);
+            applicant.markSubmitted();
         }
-
-        // 지원자 저장
-        Applicant applicant = Applicant.builder()
-                .recruitment(recruitment)
-                .track(request.getTrack())
-                .name(request.getName())
-                .email(request.getEmail())
-                .phone(request.getPhone())
-                .university(request.getUniversity())
-                .major(request.getMajor())
-                .minorDoubleMajor(minorDoubleMajorJson)
-                .lastSemester(request.getLastSemester())
-                .militaryStatus(request.getMilitaryStatus())
-                .birthDate(birthDate)
-                .graduationDate(request.getGraduationDate())
-                .gradSchoolPlan(request.getGradSchoolPlan())
-                .build();
-
-        applicantRepository.save(applicant);
 
         // 답변 저장
         for (AnswerRequest answerRequest : request.getAnswers()) {
@@ -293,17 +319,189 @@ public class RecruitmentService {
                 }
             }
 
-            ApplicantAnswer applicantAnswer = ApplicantAnswer.builder()
+            applicantAnswerRepository.save(ApplicantAnswer.builder()
                     .applicant(applicant)
                     .question(question)
                     .answerText(answerText)
                     .answerJson(answerJson)
-                    .build();
-
-            applicantAnswerRepository.save(applicantAnswer);
+                    .build());
         }
 
-        return ApplicationResponse.of(applicant.getId(), applicant.getCreatedAt());
+        return ApplicationResponse.of(applicant.getId(), applicant.getSubmittedAt());
+    }
+
+    // 지원서 임시저장하기
+    @Transactional
+    public DraftApplicationResponse saveDraft(Long userId, Long recruitmentId, DraftApplicationRequest request) {
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 공고 존재 여부 확인
+        Recruitment recruitment = recruitmentRepository.findById(recruitmentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
+
+        // 모집 기간 확인
+        LocalDateTime now = LocalDateTime.now();
+        boolean isActive = !now.isBefore(recruitment.getStartDate())
+                        && !now.isAfter(recruitment.getEndDate());
+        if (!isActive) {
+            throw new CustomException(ErrorCode.RECRUITMENT_CLOSED);
+        }
+
+        // 기존 지원서 조회
+        Optional<Applicant> existing = applicantRepository.findByRecruitmentIdAndUserId(recruitmentId, userId);
+        if (existing.isPresent() && existing.get().getStatus() == Applicant.ApplicantStatus.SUBMITTED) {
+            throw new CustomException(ErrorCode.APPLICATION_ALREADY_SUBMITTED);
+        }
+
+        // minorDoubleMajor JSON 변환 (null이면 null 유지)
+        String minorDoubleMajorJson = null;
+        if (request.getMinorDoubleMajor() != null) {
+            minorDoubleMajorJson = serializeList(request.getMinorDoubleMajor());
+        }
+
+        // 생년월일 파싱 (null이면 null 유지)
+        LocalDate birthDate = null;
+        if (request.getBirthDate() != null) {
+            try {
+                birthDate = LocalDate.parse(request.getBirthDate());
+            } catch (DateTimeParseException e) {
+                throw new CustomException(ErrorCode.INVALID_BIRTH_DATE_FORMAT);
+            }
+        }
+
+        Applicant applicant;
+        if (existing.isPresent()) {
+            // DRAFT 존재 → 부분 업데이트
+            applicant = existing.get();
+            applicant.update(
+                    request.getTrack(), request.getName(), request.getEmail(), request.getPhone(),
+                    request.getUniversity(), request.getMajor(), minorDoubleMajorJson,
+                    request.getLastSemester(), request.getMilitaryStatus(), birthDate,
+                    request.getGraduationDate(), request.getGradSchoolPlan()
+            );
+        } else {
+            // 신규 생성
+            applicant = Applicant.builder()
+                    .recruitment(recruitment)
+                    .user(user)
+                    .status(Applicant.ApplicantStatus.DRAFT)
+                    .track(request.getTrack())
+                    .name(request.getName())
+                    .email(request.getEmail())
+                    .phone(request.getPhone())
+                    .university(request.getUniversity())
+                    .major(request.getMajor())
+                    .minorDoubleMajor(minorDoubleMajorJson)
+                    .lastSemester(request.getLastSemester())
+                    .militaryStatus(request.getMilitaryStatus())
+                    .birthDate(birthDate)
+                    .graduationDate(request.getGraduationDate())
+                    .gradSchoolPlan(request.getGradSchoolPlan())
+                    .build();
+            applicantRepository.save(applicant);
+        }
+
+        // answers 처리: null이면 유지, 빈 배열이면 전체 삭제, 값이 있으면 교체
+        if (request.getAnswers() != null) {
+            applicantAnswerRepository.deleteByApplicantId(applicant.getId());
+
+            if (!request.getAnswers().isEmpty()) {
+                // 해당 공고에 등록된 유효한 questionId 로드
+                List<ApplicationQuestion> allQuestions =
+                        applicationQuestionRepository.findByRecruitmentIdOrderByOrderNumAsc(recruitmentId);
+                Set<Long> validQuestionIds = allQuestions.stream()
+                        .map(ApplicationQuestion::getId)
+                        .collect(Collectors.toSet());
+                Map<Long, ApplicationQuestion> questionMap = allQuestions.stream()
+                        .collect(Collectors.toMap(ApplicationQuestion::getId, q -> q));
+
+                for (AnswerRequest answerRequest : request.getAnswers()) {
+                    // 알 수 없는 questionId는 skip
+                    if (!validQuestionIds.contains(answerRequest.getQuestionId())) continue;
+
+                    ApplicationQuestion question = questionMap.get(answerRequest.getQuestionId());
+                    JsonNode answer = answerRequest.getAnswer();
+
+                    String answerText = null;
+                    String answerJson = null;
+                    if (question.getType() == ApplicationQuestion.Type.TEXT) {
+                        answerText = answer != null ? answer.asText() : null;
+                    } else {
+                        try {
+                            answerJson = answer != null ? objectMapper.writeValueAsString(answer) : null;
+                        } catch (Exception e) {
+                            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+                        }
+                    }
+
+                    applicantAnswerRepository.save(ApplicantAnswer.builder()
+                            .applicant(applicant)
+                            .question(question)
+                            .answerText(answerText)
+                            .answerJson(answerJson)
+                            .build());
+                }
+            }
+        }
+
+        return DraftApplicationResponse.of(applicant.getId());
+    }
+
+    // 내 지원서 조회하기 (DRAFT만 허용)
+    public MyApplicationResponse getMyApplication(Long userId, Long recruitmentId) {
+
+        // 공고 존재 여부 확인
+        recruitmentRepository.findById(recruitmentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
+
+        // 지원서 조회
+        Applicant applicant = applicantRepository.findByRecruitmentIdAndUserId(recruitmentId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.APPLICATION_NOT_FOUND));
+
+        // SUBMITTED 상태 접근 불가
+        if (applicant.getStatus() == Applicant.ApplicantStatus.SUBMITTED) {
+            throw new CustomException(ErrorCode.APPLICATION_ALREADY_SUBMITTED);
+        }
+
+        // minorDoubleMajor 파싱
+        List<String> minorDoubleMajor = null;
+        if (applicant.getMinorDoubleMajor() != null) {
+            try {
+                minorDoubleMajor = objectMapper.readValue(
+                        applicant.getMinorDoubleMajor(),
+                        new TypeReference<List<String>>() {}
+                );
+            } catch (Exception e) {
+                minorDoubleMajor = Collections.emptyList();
+            }
+        }
+
+        // 답변 조회 및 변환
+        List<ApplicantAnswer> rawAnswers =
+                applicantAnswerRepository.findByApplicantIds(List.of(applicant.getId()));
+
+        List<MyApplicationResponse.AnswerItemResponse> answers = rawAnswers.stream()
+                .map(aa -> {
+                    JsonNode answerNode;
+                    if (aa.getAnswerText() != null) {
+                        answerNode = TextNode.valueOf(aa.getAnswerText());
+                    } else {
+                        try {
+                            answerNode = objectMapper.readTree(aa.getAnswerJson());
+                        } catch (Exception e) {
+                            answerNode = objectMapper.nullNode();
+                        }
+                    }
+                    return new MyApplicationResponse.AnswerItemResponse(
+                            aa.getQuestion().getId(), answerNode
+                    );
+                })
+                .toList();
+
+        return MyApplicationResponse.of(applicant, minorDoubleMajor, answers);
     }
 
     // 모집 사전 알림 신청하기
@@ -332,7 +530,7 @@ public class RecruitmentService {
         }
     }
 
-    
+
     // ========================
     // Admin 전용 메서드
     // ========================
@@ -350,15 +548,16 @@ public class RecruitmentService {
         // 부문별 CSV 생성 및 S3 업로드
         for (Track track : List.of(Track.VISUALIZATION, Track.ANALYSIS, Track.ENGINEERING)) {
 
-            // 해당 부문 지원자 조회
+            // 해당 부문 제출된 지원자 조회
             List<Applicant> applicants = applicantRepository
-                    .findLatestByRecruitmentIdAndTrack(recruitment.getId(), track);
+                    .findByRecruitmentIdAndTrackAndStatus(
+                            recruitment.getId(), track, Applicant.ApplicantStatus.SUBMITTED);
 
             // 공통 + 해당 부문 질문 조회
             List<ApplicationQuestion> questions = applicationQuestionRepository
                     .findByRecruitmentIdAndCategories(
                             recruitment.getId(),
-                            ApplicationQuestion.Category.COMMON, 
+                            ApplicationQuestion.Category.COMMON,
                             toQuestionCategory(track)
                     );
 
@@ -641,6 +840,15 @@ public class RecruitmentService {
         if (metadata == null) return null;
         try {
             return objectMapper.writeValueAsString(metadata);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private String serializeList(List<String> list) {
+        if (list == null || list.isEmpty()) return null;
+        try {
+            return objectMapper.writeValueAsString(list);
         } catch (Exception e) {
             throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
         }

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -248,8 +248,14 @@ public class RecruitmentService {
             if (question == null) continue;
 
             JsonNode answer = answerRequest.getAnswer();
+            if (answer == null) {
+                throw new CustomException(
+                        question.getIsRequired() ? ErrorCode.ANSWER_REQUIRED : ErrorCode.INVALID_ANSWER_TYPE
+                );
+            }
+
             if (question.getIsRequired()) {
-                if (answer == null || answer.isNull()
+                if (answer.isNull()
                         || (question.getType() == ApplicationQuestion.Type.TEXT && answer.asText().trim().isEmpty())
                         || (question.getType() == ApplicationQuestion.Type.TABLE && (!answer.isObject() || answer.size() == 0))) {
                     throw new CustomException(ErrorCode.ANSWER_REQUIRED);

--- a/src/main/java/com/boaz/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/boaz/backend/global/config/SecurityConfig.java
@@ -25,6 +25,8 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import org.springframework.http.HttpMethod;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -61,6 +63,10 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/admin/**").authenticated()
                         .requestMatchers("/api/v1/auth/admin/logout").authenticated()
                         .requestMatchers("/api/v1/auth/user/logout").authenticated()
+                        // 지원서 제출/임시저장/조회 (User 인증 필요)
+                        .requestMatchers(HttpMethod.POST, "/api/v1/recruitment/*/applications").authenticated()
+                        .requestMatchers(HttpMethod.PUT, "/api/v1/recruitment/*/applications/draft").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/recruitment/*/applications/me").authenticated()
                         .anyRequest().permitAll()
                 )
                 .oauth2Login(oauth2 -> oauth2

--- a/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
@@ -20,6 +20,9 @@ public enum ErrorCode {
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "EXPIRED_TOKEN", "만료된 토큰입니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "INVALID_CREDENTIALS", "아이디 또는 비밀번호가 올바르지 않습니다."),
 
+    // User
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
+
     // Admin
     ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND, "ADMIN_NOT_FOUND", "해당 계정을 찾을 수 없습니다."),
     DUPLICATE_USERNAME(HttpStatus.CONFLICT, "DUPLICATE_USERNAME", "이미 존재하는 아이디입니다."),
@@ -38,6 +41,7 @@ public enum ErrorCode {
     QUESTIONS_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTIONS_NOT_FOUND", "등록된 질문이 없습니다."),
     RECRUITMENT_CLOSED(HttpStatus.CONFLICT, "RECRUITMENT_CLOSED", "모집이 마감되었습니다."),
     ALREADY_SUBMITTED(HttpStatus.CONFLICT, "ALREADY_SUBMITTED", "이미 제출된 지원서가 있습니다."),
+    APPLICATION_ALREADY_SUBMITTED(HttpStatus.FORBIDDEN, "APPLICATION_ALREADY_SUBMITTED", "제출된 지원서에 접근할 수 없습니다."),
     APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "APPLICATION_NOT_FOUND", "지원서를 찾을 수 없습니다."),
     RECRUITMENT_NOT_CLOSED(HttpStatus.BAD_REQUEST, "RECRUITMENT_NOT_CLOSED", "모집이 진행 중인 공고의 지원서는 삭제할 수 없습니다."),
     ANSWER_REQUIRED(HttpStatus.BAD_REQUEST, "ANSWER_REQUIRED", "필수 질문에 답변해주세요."),

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -2,6 +2,8 @@
 SET FOREIGN_KEY_CHECKS = 0;
 
 -- 모든 테이블 초기화
+TRUNCATE refresh_token;
+TRUNCATE users;
 TRUNCATE admin;
 TRUNCATE recruitment;
 TRUNCATE application_question;
@@ -24,9 +26,25 @@ VALUES ('boaz_super', '$2a$10$7GogA3bv05pd830JHPishOFHtneEqmpZgE2s9fZuoARQxDZGg6
 INSERT INTO admin (username, password, role, name, track, term, team_name, created_by, created_at, updated_at)
 VALUES ('boaz_team', '$2a$10$7GogA3bv05pd830JHPishOFHtneEqmpZgE2s9fZuoARQxDZGg6N.y', 'TEAM', '이보아즈', 'ANALYSIS', 27, '서비스운영팀', 1, NOW(), NOW());
 
+-- users 임시 데이터
+-- id=1~3: 기존 테스트 지원자에 대응하는 더미 유저
+-- id=4: Swagger API 테스트용 (지원서 없음 → submit/draft 흐름 테스트)
+INSERT INTO users (id, provider, provider_id, nickname, member_type, created_at, updated_at)
+VALUES (1, 'kakao', 'dummy_kakao_001', '김엔지', 'OUTSIDER', NOW(), NOW());
+
+INSERT INTO users (id, provider, provider_id, nickname, member_type, created_at, updated_at)
+VALUES (2, 'kakao', 'dummy_kakao_002', '이분석', 'OUTSIDER', NOW(), NOW());
+
+INSERT INTO users (id, provider, provider_id, nickname, member_type, created_at, updated_at)
+VALUES (3, 'kakao', 'dummy_kakao_003', '박시각', 'OUTSIDER', NOW(), NOW());
+
+INSERT INTO users (id, provider, provider_id, nickname, member_type, created_at, updated_at)
+VALUES (4, 'kakao', 'dummy_kakao_004', '스웨거테스터', 'OUTSIDER', NOW(), NOW());
+
 -- recruitment 임시 데이터
+-- id=1: 26기 (종료된 공고) - 어드민 CSV 다운로드 테스트용
 INSERT INTO recruitment (id, term, start_date, end_date, schedule, brochure_url, created_at, updated_at)
-VALUES (1, 26, '2026-03-01 00:00:00', '2026-04-29 23:59:59', 
+VALUES (1, 26, '2026-03-01 00:00:00', '2026-04-29 23:59:59',
 '[
   { "step": "서류 모집", "start": "2026-03-01", "end": "2026-03-29", "sequence": 1 },
   { "step": "서류 합격 발표", "start": "2026-04-04", "end": "2026-04-04", "sequence": 2 },
@@ -34,16 +52,17 @@ VALUES (1, 26, '2026-03-01 00:00:00', '2026-04-29 23:59:59',
   { "step": "최종 합격 발표", "start": "2026-04-10", "end": "2026-04-10", "sequence": 4 }
 ]', 'https://example.com/brochure.pdf', NOW(), NOW());
 
+-- id=2: 27기 (현재 활성) - User API 테스트용 (지원서 제출/임시저장/조회)
 INSERT INTO recruitment (id, term, start_date, end_date, schedule, brochure_url, created_at, updated_at)
-VALUES (2, 27, '2026-07-01 00:00:00', '2026-07-31 23:59:59', 
+VALUES (2, 27, '2026-05-01 00:00:00', '2026-08-31 23:59:59',
 '[
-  { "step": "서류 모집", "start": "2026-07-01", "end": "2026-07-31", "sequence": 1 },
-  { "step": "서류 합격 발표", "start": "2026-08-04", "end": "2026-08-04", "sequence": 2 },
-  { "step": "면접", "start": "2026-08-06", "end": "2026-08-07", "sequence": 3 },
-  { "step": "최종 합격 발표", "start": "2026-08-10", "end": "2026-08-10", "sequence": 4 }
-]', 'https://example.com/brochure.pdf', NOW(), NOW());
+  { "step": "서류 모집", "start": "2026-05-01", "end": "2026-08-31", "sequence": 1 },
+  { "step": "서류 합격 발표", "start": "2026-09-05", "end": "2026-09-05", "sequence": 2 },
+  { "step": "면접", "start": "2026-09-07", "end": "2026-09-08", "sequence": 3 },
+  { "step": "최종 합격 발표", "start": "2026-09-12", "end": "2026-09-12", "sequence": 4 }
+]', 'https://example.com/brochure27.pdf', NOW(), NOW());
 
--- application_question 임시 데이터
+-- application_question 임시 데이터 (recruitment_id = 1, 26기)
 INSERT INTO application_question (id, recruitment_id, category, type, label, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
 VALUES (1, 1, 'COMMON', 'TEXT', 'COMMON1', 'RECRUITMENT 동기는 무엇인가요? (500자 이내)', null, 500, 1, true, NOW(), NOW());
 
@@ -71,69 +90,96 @@ VALUES (8, 1, 'ANALYSIS', 'TEXT', 'ANALYSIS1', '[빅데이터 / 인공지능 / �
 INSERT INTO application_question (id, recruitment_id, category, type, label, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
 VALUES (9, 1, 'ANALYSIS', 'TEXT', 'ANALYSIS2', '본인이 진행했던 [머신러닝 / 딥러닝 / 데이터ANALYSIS] 관련 PROJECT를 소개.. (700자 이내)', null, 700, 11, true, NOW(), NOW());
 
+-- application_question 임시 데이터 (recruitment_id = 2, 27기 - 현재 활성, Swagger 테스트용)
+INSERT INTO application_question (id, recruitment_id, category, type, label, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
+VALUES (10, 2, 'COMMON', 'TEXT', 'COMMON1', 'BOAZ에 지원하게 된 동기를 작성해주세요. (500자 이내)', null, 500, 1, true, NOW(), NOW());
+
+INSERT INTO application_question (id, recruitment_id, category, type, label, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
+VALUES (11, 2, 'COMMON', 'TEXT', 'COMMON2', '본인의 데이터 관련 경험을 소개해주세요. (500자 이내)', null, 500, 2, true, NOW(), NOW());
+
+INSERT INTO application_question (id, recruitment_id, category, type, label, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
+VALUES (12, 2, 'COMMON', 'TEXT', 'COMMON3', '활동 후 이루고 싶은 목표가 있다면 작성해주세요. (500자 이내)', null, 500, 99, false, NOW(), NOW());
+
+INSERT INTO application_question (id, recruitment_id, category, type, label, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
+VALUES (13, 2, 'ENGINEERING', 'TABLE', 'ENGINEERING1', '데이터 ENGINEERING 관련 기술 경험', '{"rows":["데이터베이스", "서버 및 클라우드 서비스", "데이터 파이프라인"], "columns":["경험 없음", "학습 경험 있음", "프로젝트 경험 있음"]}', null, 10, true, NOW(), NOW());
+
+INSERT INTO application_question (id, recruitment_id, category, type, label, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
+VALUES (14, 2, 'ENGINEERING', 'TEXT', 'ENGINEERING2', '데이터 ENGINEERING 분야 관심 세부 분야와 경험을 서술해주세요. (700자 이내)', null, 700, 11, true, NOW(), NOW());
+
+INSERT INTO application_question (id, recruitment_id, category, type, label, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
+VALUES (15, 2, 'VISUALIZATION', 'TABLE', 'VISUALIZATION1', '데이터 VISUALIZATION 관련 도구 경험', '{"rows":["Tableau", "Python (matplotlib/seaborn)", "D3.js"], "columns":["경험 없음", "관련 프로젝트 경험 있음"]}', null, 10, true, NOW(), NOW());
+
+INSERT INTO application_question (id, recruitment_id, category, type, label, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
+VALUES (16, 2, 'VISUALIZATION', 'TEXT', 'VISUALIZATION2', 'VISUALIZATION을 통해 인사이트를 도출한 경험을 서술해주세요. (700자 이내)', null, 700, 11, true, NOW(), NOW());
+
+INSERT INTO application_question (id, recruitment_id, category, type, label, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
+VALUES (17, 2, 'ANALYSIS', 'TEXT', 'ANALYSIS1', '머신러닝 / 딥러닝 관련 수강 과목 혹은 세미나 경험을 작성해주세요. (300자 이내)', null, 300, 10, true, NOW(), NOW());
+
+INSERT INTO application_question (id, recruitment_id, category, type, label, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
+VALUES (18, 2, 'ANALYSIS', 'TEXT', 'ANALYSIS2', '데이터 ANALYSIS 관련 프로젝트 경험을 소개해주세요. (700자 이내)', null, 700, 11, true, NOW(), NOW());
+
 -- archive 임시 데이터
-INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
+INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (1, 25, 'PROJECT', '사용자 맞춤형 뭐뭐뭐뭐 추천시스템 발표', '자료연구팀', 'ANALYSIS', 'https://example.com/conf1.png', '{"slideshare":"https://slideshare.net/example1"}', '2024-08-10', NOW(), NOW());
 
-INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
+INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (2, 0, 'PROJECT', '누구구구의 뭐뭐뭐뭐 오오오오우 발표', NULL, 'ANALYSIS', 'https://example.com/conf1.png', '{"slideshare":"https://slideshare.net/example1"}', NULL, NOW(), NOW());
 
-INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
+INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (3, 25, 'PROJECT', '무엇무엇 데이터 파이프라인 발표', '자료연구팀', 'ENGINEERING', 'https://example.com/conf2.png', '{"slideshare":"https://slideshare.net/example2"}', '2024-08-10', NOW(), NOW());
 
-INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
+INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (4, 25, 'BLOG', 'Spring Boot 예외 처리 구조 정리', NULL, 'ENGINEERING', 'https://example.com/blog1.png', '{"medium":"https://medium.com/@boaz/example1"}', '2025-02-14', NOW(), NOW());
 
-INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
+INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (5, 25, 'BLOG', '데이터 ANALYSIS PROJECT 회고', NULL, 'ANALYSIS', 'https://example.com/blog2.png', '{"medium":"https://medium.com/@boaz/example2"}', '2025-01-20', NOW(), NOW());
 
-INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
+INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (6, 25, 'ACTIVITY', '250402 ANALYSIS 7주차 Base세션', NULL, 'ANALYSIS', 'https://example.com/activity1.png', '{"instagram":"https://instagram.com/p/example1"}', '2025-04-02', NOW(), NOW());
 
-INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
+INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (7, 25, 'ACTIVITY', '25기 신입기수 OT', NULL, 'ALL', 'https://example.com/activity2.png', '{"instagram":"https://instagram.com/p/example2"}', '2025-03-01', NOW(), NOW());
 
-INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
+INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (8, 26, 'PROJECT', '추천 시스템 고도화 땡땡 발표', NULL, 'ENGINEERING', 'https://example.com/conf3.png', '{"slideshare":"https://slideshare.net/example3","github":"https://github.com/boaz/recommendation-system"}', '2025-08-12', NOW(), NOW());
 
-INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
+INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (9, 26, 'PROJECT', '실시간 데이터 처리 뭐뭐뭐뭐 시스템 발표', '데이터ENGINEERING팀', 'ENGINEERING', 'https://example.com/conf4.png', '{"slideshare":"https://slideshare.net/example4","github":"https://github.com/boaz/stream-processing"}', '2025-08-18', NOW(), NOW());
 
-INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
+INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (10, 26, 'PROJECT', '데이터 VISUALIZATION 대시보드 블라블라 발표', '데이터VISUALIZATION팀', 'VISUALIZATION', 'https://example.com/conf5.png', '{"slideshare":"https://slideshare.net/example5","github":"https://github.com/boaz/dashboard-project"}', '2025-08-25', NOW(), NOW());
 
-INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
+INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (11, 26, 'BLOG', 'Kafka 기반 데이터 스트리밍 아키텍처 정리', NULL, 'ENGINEERING', 'https://example.com/blog3.png', '{"medium":"https://medium.com/@boaz/kafka-stream","github":"https://github.com/boaz/kafka-stream-example"}', '2025-03-01', NOW(), NOW());
 
-INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
+INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (12, 26, 'BLOG', 'Spark 기반 대용량 데이터 처리 경험 정리', NULL, 'ENGINEERING', 'https://example.com/blog4.png', '{"medium":"https://medium.com/@boaz/spark-processing","github":"https://github.com/boaz/spark-example"}', '2025-03-05', NOW(), NOW());
 
-INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
+INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (13, 26, 'BLOG', '추천 시스템 협업 필터링 구현 과정', NULL, 'ANALYSIS', 'https://example.com/blog5.png', '{"medium":"https://medium.com/@boaz/collaborative-filtering","github":"https://github.com/boaz/cf-recommendation"}', '2025-03-10', NOW(), NOW());
 
-INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
+INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (14, 26, 'ACTIVITY', '26기 데이터 ANALYSIS 스터디 세션', NULL, 'ANALYSIS', 'https://example.com/activity3.png', '{"instagram":"https://instagram.com/p/example3","youtube":"https://youtube.com/watch?v=analysis-session"}', '2025-04-05', NOW(), NOW());
 
-INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
+INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (15, 26, 'ACTIVITY', '26기 데이터 ENGINEERING 워크샵', NULL, 'ENGINEERING', 'https://example.com/activity4.png', '{"instagram":"https://instagram.com/p/example4","youtube":"https://youtube.com/watch?v=engineering-workshop"}', '2025-04-10', NOW(), NOW());
 
-INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at) 
+INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (16, 26, 'ACTIVITY', '26기 데이터 VISUALIZATION 세션', NULL, 'VISUALIZATION', 'https://example.com/activity5.png', '{"instagram":"https://instagram.com/p/example5","youtube":"https://youtube.com/watch?v=visualization-session"}', '2025-04-15', NOW(), NOW());
 
--- applicant 임시 데이터
-INSERT INTO applicants (id, recruitment_id, track, name, email, phone, university, major, minor_double_major, last_semester, military_status, birth_date, graduation_date, grad_school_plan, created_at, updated_at)
-VALUES (1, 1, 'ENGINEERING', '테스트1', 'string@example', '01012345678', 'university', 'major', '["minor_double_major"]', 7, 'COMPLETED_OR_EXEMPT', '2002-01-01', '2026-08', false, '2026-03-14 22:19:27', '2026-03-14 22:19:27');
+-- applicant 임시 데이터 (26기 recruitment_id=1, 종료된 공고 - 어드민 CSV 다운로드 테스트용)
+-- user OneToOne 적용: user_id=1~3 각 트랙 1명씩
+-- status=SUBMITTED, submitted_at 설정
+INSERT INTO applicants (id, recruitment_id, user_id, status, track, name, email, phone, university, major, minor_double_major, last_semester, military_status, birth_date, graduation_date, grad_school_plan, submitted_at, created_at, updated_at)
+VALUES (1, 1, 1, 'SUBMITTED', 'ENGINEERING', '김엔지', 'eng@example.com', '01011111111', '한국대학교', '컴퓨터공학', '["통계학"]', 7, 'COMPLETED_OR_EXEMPT', '2002-01-01', '2026-08', false, '2026-03-14 22:19:27', '2026-03-14 22:19:27', '2026-03-14 22:19:27');
 
-INSERT INTO applicants (id, recruitment_id, track, name, email, phone, university, major, minor_double_major, last_semester, military_status, birth_date, graduation_date, grad_school_plan, created_at, updated_at)
-VALUES (2, 1, 'ENGINEERING', '테스트1', 'string@example', '01012345678', 'university', 'major', '["minor_double_major"]', 7, 'COMPLETED_OR_EXEMPT', '2002-01-01', '2026-08', false, '2026-03-14 22:38:15', '2026-03-14 22:38:15');
+INSERT INTO applicants (id, recruitment_id, user_id, status, track, name, email, phone, university, major, minor_double_major, last_semester, military_status, birth_date, graduation_date, grad_school_plan, submitted_at, created_at, updated_at)
+VALUES (3, 1, 2, 'SUBMITTED', 'ANALYSIS', '이분석', 'ana@example.com', '01022222222', '한국대학교', '통계학', null, 7, 'COMPLETED_OR_EXEMPT', '2002-01-01', '2026-08', false, '2026-03-14 22:21:18', '2026-03-14 22:21:18', '2026-03-14 22:21:18');
 
-INSERT INTO applicants (id, recruitment_id, track, name, email, phone, university, major, minor_double_major, last_semester, military_status, birth_date, graduation_date, grad_school_plan, created_at, updated_at)
-VALUES (3, 1, 'ANALYSIS', '테스트2', 'string22@example', '01012345688', 'university', 'major', '["minor_double_major"]', 7, 'COMPLETED_OR_EXEMPT', '2002-01-01', '2026-08', false, '2026-03-14 22:21:18', '2026-03-14 22:21:18');
+INSERT INTO applicants (id, recruitment_id, user_id, status, track, name, email, phone, university, major, minor_double_major, last_semester, military_status, birth_date, graduation_date, grad_school_plan, submitted_at, created_at, updated_at)
+VALUES (4, 1, 3, 'SUBMITTED', 'VISUALIZATION', '박시각', 'vis@example.com', '01033333333', '한국대학교', '시각디자인', null, 7, 'NOT_COMPLETED', '2002-01-01', '2026-08', false, '2026-03-14 22:21:58', '2026-03-14 22:21:58', '2026-03-14 22:21:58');
 
-INSERT INTO applicants (id, recruitment_id, track, name, email, phone, university, major, minor_double_major, last_semester, military_status, birth_date, graduation_date, grad_school_plan, created_at, updated_at)
-VALUES (4, 1, 'VISUALIZATION', '테스트3', 'string33@example', '01012345622', 'university', 'major', '["minor_double_major"]', 7, 'COMPLETED_OR_EXEMPT', '2002-01-01', '2026-08', false, '2026-03-14 22:21:58', '2026-03-14 22:21:58');
-
--- applicant_answer 임시 데이터 (테스트1 첫 번째 제출 - id: 1)
+-- applicant_answer 임시 데이터 (id=1, ENGINEERING)
 INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
 VALUES (1, 1, 'COMMON1답변', null, '2026-03-14 22:19:27', '2026-03-14 22:19:27');
 
@@ -147,25 +193,9 @@ INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_jso
 VALUES (1, 7, '엔지2답변', null, '2026-03-14 22:19:27', '2026-03-14 22:19:27');
 
 INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (1, 3, 'COMMON5답변\nurl', null, '2026-03-14 22:19:27', '2026-03-14 22:19:27');
+VALUES (1, 3, 'COMMON5답변', null, '2026-03-14 22:19:27', '2026-03-14 22:19:27');
 
--- applicant_answer 임시 데이터 (테스트1 두 번째 제출 - id: 2)
-INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (2, 1, 'COMMON1답변11111', null, '2026-03-14 22:38:15', '2026-03-14 22:38:15');
-
-INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (2, 2, 'COMMON2답변22222', null, '2026-03-14 22:38:15', '2026-03-14 22:38:15');
-
-INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (2, 6, null, '{"데이터베이스": "경험 없음", "서버 및 클라우드 서비스": "경험 없음"}', '2026-03-14 22:38:15', '2026-03-14 22:38:15');
-
-INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (2, 7, '엔지2답변2222', null, '2026-03-14 22:38:15', '2026-03-14 22:38:15');
-
-INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (2, 3, 'COMMON5답변5555\nurl', null, '2026-03-14 22:38:15', '2026-03-14 22:38:15');
-
--- applicant_answer 임시 데이터 (테스트2 ANALYSIS - id: 3)
+-- applicant_answer 임시 데이터 (id=3, ANALYSIS)
 INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
 VALUES (3, 1, 'COMMON1답변', null, NOW(), NOW());
 
@@ -179,9 +209,9 @@ INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_jso
 VALUES (3, 9, 'ANALYSIS2답변', null, NOW(), NOW());
 
 INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (3, 3, 'COMMON5답변\nurl', null, NOW(), NOW());
+VALUES (3, 3, 'COMMON5답변', null, NOW(), NOW());
 
--- applicant_answer 임시 데이터 (테스트3 VISUALIZATION - id: 4)
+-- applicant_answer 임시 데이터 (id=4, VISUALIZATION)
 INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
 VALUES (4, 1, 'COMMON1답변', null, NOW(), NOW());
 
@@ -195,7 +225,7 @@ INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_jso
 VALUES (4, 5, 'VISUALIZATION2답변', null, NOW(), NOW());
 
 INSERT INTO applicant_answer (applicant_id, question_id, answer_text, answer_json, created_at, updated_at)
-VALUES (4, 3, 'COMMON5답변\nurl', null, NOW(), NOW());
+VALUES (4, 3, 'COMMON5답변', null, NOW(), NOW());
 
 -- Curriculum 임시데이터
 INSERT INTO curriculum (track, curriculum_steps, created_at, updated_at) VALUES


### PR DESCRIPTION
## 💡 개요

* Issue Number: #110

## 🪐 주요 변경 사항
- 리크루팅 지원서 API에 User OAuth 인증 적용
- 지원서 임시저장 API 신규 개발
- 내 지원서 조회 API 신규 개발

## ✅ 상세 내용
- `Applicant` 엔티티: `User` `@OneToOne` 관계 추가, `ApplicantStatus(DRAFT/SUBMITTED)` 및 `submittedAt` 필드 추가, `name`/`email` nullable 처리
- `ErrorCode`: `USER_NOT_FOUND(404)` 추가
- `ApplicantRepository`: 이메일 기반 중복 제거 쿼리 제거 → `user_id` 기반 조회로 교체, `findByRecruitmentIdAndTrackAndStatus` 추가
- `ApplicantAnswerRepository`: `deleteByApplicantId` `@Modifying` 벌크 삭제 추가
- `ApplicationRequest`: `recruitmentId` 필드 제거 (path variable로 전환)
- 신규 DTO: `DraftApplicationRequest`, `DraftApplicationResponse`, `MyApplicationResponse`
- `RecruitmentService.submitApplication`: 시그니처에 `userId`/`recruitmentId` 추가, DRAFT→SUBMITTED 전환 로직 구현
- `RecruitmentService.saveDraft`: upsert 방식 임시저장, answers null/빈배열/값 구분 처리
- `RecruitmentService.getMyApplication`: DRAFT 상태만 허용, SUBMITTED 시 403 반환
- `RecruitmentController`: `POST /{recruitmentId}/applications`, `PUT /{recruitmentId}/applications/draft`, `GET /{recruitmentId}/applications/me` 엔드포인트 추가
- `SecurityConfig`: 지원서 3개 엔드포인트 `authenticated()` 처리
- `data.sql`: `users` 시드 데이터 추가, `applicants`에 `user_id`/`status`/`submitted_at` 반영, 27기(recruitment_id=2) 활성 기간으로 업데이트

## 🔔 참고 사항
- 재배포 전 RDS `applicants`, `applicant_answer` 테이블 DROP 필요 (스키마 변경으로 `ddl-auto: update` 자동 적용 불가)
- `Applicant` ↔ `User` 관계: 기수별 모집 완료 후 지원서 일괄 삭제 라이프사이클 기준으로 `@OneToOne` 채택 (`user_id` UNIQUE)
