### PR TITLE
[Feat] 내 정보 조회 (GET /api/v1/users/me)

### DIFF
--- a/src/main/java/com/boaz/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/boaz/backend/domain/user/controller/UserController.java
@@ -25,7 +25,7 @@ public class UserController {
 
     private final UserService userService;
 
-    @Operation(summary = "내 정보 조회", description = "로그인한 사용자의 닉네임 및 회원 타입 조회")
+    @Operation(summary = "내 정보 조회", description = "로그인한 사용자의 닉네임 조회")
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<UserInfoResponse>> getMyInfo(
             @AuthenticationPrincipal UserPrincipal principal) {

--- a/src/main/java/com/boaz/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/boaz/backend/domain/user/controller/UserController.java
@@ -1,0 +1,34 @@
+package com.boaz.backend.domain.user.controller;
+
+import com.boaz.backend.domain.user.dto.response.UserInfoResponse;
+import com.boaz.backend.domain.user.service.UserService;
+import com.boaz.backend.global.common.ApiResponse;
+import com.boaz.backend.global.security.UserPrincipal;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "User", description = "User 정보 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "내 정보 조회", description = "로그인한 사용자의 닉네임 및 회원 타입 조회")
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<UserInfoResponse>> getMyInfo(
+            @AuthenticationPrincipal UserPrincipal principal) {
+        return ResponseEntity.ok(ApiResponse.ok(userService.getMyInfo(principal.userId())));
+    }
+}

--- a/src/main/java/com/boaz/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/boaz/backend/domain/user/controller/UserController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "User", description = "User 정보 관련 API")
+@SecurityRequirement(name = "bearerAuth")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/users")
@@ -25,7 +26,6 @@ public class UserController {
     private final UserService userService;
 
     @Operation(summary = "내 정보 조회", description = "로그인한 사용자의 닉네임 및 회원 타입 조회")
-    @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<UserInfoResponse>> getMyInfo(
             @AuthenticationPrincipal UserPrincipal principal) {

--- a/src/main/java/com/boaz/backend/domain/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/boaz/backend/domain/user/dto/response/UserInfoResponse.java
@@ -1,7 +1,6 @@
 package com.boaz.backend.domain.user.dto.response;
 
 import com.boaz.backend.domain.user.entity.User;
-import com.boaz.backend.global.common.enums.MemberType;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,12 +9,10 @@ import lombok.Getter;
 public class UserInfoResponse {
 
     private String nickname;
-    private MemberType memberType;
 
     public static UserInfoResponse from(User user) {
         return UserInfoResponse.builder()
                 .nickname(user.getNickname())
-                .memberType(user.getMemberType())
                 .build();
     }
 }

--- a/src/main/java/com/boaz/backend/domain/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/boaz/backend/domain/user/dto/response/UserInfoResponse.java
@@ -1,0 +1,21 @@
+package com.boaz.backend.domain.user.dto.response;
+
+import com.boaz.backend.domain.user.entity.User;
+import com.boaz.backend.global.common.enums.MemberType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserInfoResponse {
+
+    private String nickname;
+    private MemberType memberType;
+
+    public static UserInfoResponse from(User user) {
+        return UserInfoResponse.builder()
+                .nickname(user.getNickname())
+                .memberType(user.getMemberType())
+                .build();
+    }
+}

--- a/src/main/java/com/boaz/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/boaz/backend/domain/user/service/UserService.java
@@ -1,8 +1,11 @@
 package com.boaz.backend.domain.user.service;
 
+import com.boaz.backend.domain.user.dto.response.UserInfoResponse;
 import com.boaz.backend.domain.user.entity.User;
 import com.boaz.backend.domain.user.repository.UserRepository;
 import com.boaz.backend.global.common.enums.MemberType;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
 import com.boaz.backend.global.oauth.OAuth2UserInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,5 +28,12 @@ public class UserService {
                                 .memberType(MemberType.OUTSIDER)
                                 .build()
                 ));
+    }
+
+    @Transactional(readOnly = true)
+    public UserInfoResponse getMyInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        return UserInfoResponse.from(user);
     }
 }

--- a/src/main/java/com/boaz/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/boaz/backend/global/config/SecurityConfig.java
@@ -67,6 +67,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/v1/recruitment/*/applications").authenticated()
                         .requestMatchers(HttpMethod.PUT, "/api/v1/recruitment/*/applications/draft").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/recruitment/*/applications/me").authenticated()
+                        // 내 정보 조회 (User 인증 필요)
+                        .requestMatchers(HttpMethod.GET, "/api/v1/users/me").authenticated()
                         .anyRequest().permitAll()
                 )
                 .oauth2Login(oauth2 -> oauth2


### PR DESCRIPTION
## 💡 개요

* Issue Number: #112

## 🪐 주요 변경 사항
- `UserController` 신규 생성 — `GET /api/v1/users/me`
- `UserService.getMyInfo()` 메서드 추가
- `UserInfoResponse` DTO 신규 생성
- `SecurityConfig` — `GET /api/v1/users/me` 인증 라우트 추가

## ✅ 상세 내용
- JWT 토큰에서 추출한 `user_id`로 사용자 조회
- 응답: `{ "nickname": "..." }`
- 존재하지 않는 사용자 요청 시 `USER_NOT_FOUND (404)` 반환

## 🔔 참고 사항
- 기능명세서: `docs/user/USER-001_내_정보_조회하기.md`
- `USER_NOT_FOUND` ErrorCode는 이전 PR에서 이미 추가됨
- `member_type`은 현재 미사용으로 응답에서 제외 (추후 필드 추가 가능)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 변경 목적
JWT 토큰에서 추출한 사용자 ID로 현재 로그인한 사용자의 정보를 조회하는 엔드포인트를 추가합니다. 이를 통해 클라이언트가 자신의 정보를 조회할 수 있게 합니다.

## 주요 변경 내용
- **Controller 계층**: `UserController` 신규 추가 - `GET /api/v1/users/me` 엔드포인트 구현
- **Service 계층**: `UserService.getMyInfo(Long userId)` 메서드 추가 - 사용자 ID로 조회 후 존재하지 않으면 USER_NOT_FOUND 예외 발생
- **DTO 계층**: `UserInfoResponse` 신규 DTO 생성 - `nickname` 필드 포함, `from(User user)` 정적 팩토리 메서드 제공
- **Security 설정**: `SecurityConfig`에 `GET /api/v1/users/me` 경로를 인증 필수 라우트로 추가

## 영향 범위
**API 변경**: 새로운 인증 엔드포인트 추가 (GET /api/v1/users/me, 응답: { "nickname": "..." })

**설정 변경**: Spring Security에 인증 경로 규칙 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BOAZ-website/backend/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->