### PR TITLE
[Fix] URL 컬럼 VARCHAR(255) 잘림 현상 수정 및 multipart 크기 제한 설정 추가

### DIFF
--- a/src/main/java/com/boaz/backend/domain/archive/entity/Archive.java
+++ b/src/main/java/com/boaz/backend/domain/archive/entity/Archive.java
@@ -52,7 +52,7 @@ public class Archive extends BaseEntity {
     @Column(nullable = false, length = 50)
     private Track track;
 
-    @Column(nullable = false, length = 255)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String imageUrl;
 
     @Column(nullable = false, columnDefinition = "json")

--- a/src/main/java/com/boaz/backend/domain/recruitment/entity/Recruitment.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/entity/Recruitment.java
@@ -28,7 +28,7 @@ public class Recruitment extends BaseEntity {
     @Column(columnDefinition = "JSON", nullable = false)
     private String schedule;
 
-    @Column(length = 255)
+    @Column(columnDefinition = "TEXT")
     private String brochureUrl;
 
     public boolean isActive() {

--- a/src/main/java/com/boaz/backend/domain/review/entity/Review.java
+++ b/src/main/java/com/boaz/backend/domain/review/entity/Review.java
@@ -25,6 +25,7 @@ public class Review extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String content;
 
+    @Column(columnDefinition = "TEXT")
     private String imageUrl;
 
     public static Review create(String name, Track track, Integer term, String content, String imageUrl) {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,5 +1,10 @@
 spring:
 
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 6MB
+
   datasource:
     url: ${DB_URL:jdbc:mysql://localhost:3306/boaz?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
     username: ${DB_USERNAME:root}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,5 +1,10 @@
 spring:
 
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 6MB
+
   datasource:
     url: ${DB_URL:jdbc:mysql://localhost:3306/boaz?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
     username: ${DB_USERNAME:root}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,5 +1,10 @@
 spring:
 
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 6MB
+
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}


### PR DESCRIPTION
## 💡 개요

* Issue Number: #114 

## 🪐 주요 변경 사항
- URL 컬럼 타입 `VARCHAR(255)` → `TEXT` 변경 (Archive, Review, Recruitment)
- `application-*.yml` multipart 크기 제한 추가 (`max-file-size: 5MB` / `max-request-size: 6MB`)

## ✅ 상세 내용
- S3 URL에 한글 폴더명이 포함되면 URL 인코딩 후 255자를 초과해 DB 저장 시 잘리는 문제 수정
  - `Archive.imageUrl` : `@Column(length = 255)` → `@Column(columnDefinition = "TEXT")`
  - `Review.imageUrl` : `@Column` 미지정(묵시적 VARCHAR 255) → `@Column(columnDefinition = "TEXT")`
  - `Recruitment.brochureUrl` : `@Column(length = 255)` → `@Column(columnDefinition = "TEXT")`
- Spring Boot 기본 multipart 제한(1MB)이 적용되는 문제 수정 — local / dev / prod 프로필 파일에 각각 추가

## 🔔 참고 사항
- X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**변경 목적**
Issue `#114` 해결을 위해 인코딩된 S3 URL의 255자 초과로 인한 잘림 현상을 방지하고, Spring Boot의 기본 multipart 크기 제한으로 인한 업로드 문제를 해결

**주요 변경 내용**
- DB 엔티티 컬럼 정의 변경 (3개 파일)
  - Archive.imageUrl: `@Column(length = 255)` → `@Column(columnDefinition = "TEXT")`
  - Review.imageUrl: 암묵적 VARCHAR(255) → `@Column(columnDefinition = "TEXT")`
  - Recruitment.brochureUrl: `@Column(length = 255)` → `@Column(columnDefinition = "TEXT")`
- Spring Boot 프로필 설정에 multipart 크기 제한 추가 (3개 프로필)
  - application-local.yml, application-dev.yml, application-prod.yml
  - `spring.servlet.multipart.max-file-size: 5MB`
  - `spring.servlet.multipart.max-request-size: 6MB`

**영향 범위**
- DB 스키마 변경: 3개 컬럼의 데이터 타입 변경 (VARCHAR(255) → TEXT)
- 설정 변경: multipart 업로드 크기 제한 설정

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BOAZ-website/backend/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->