### PR TITLE
[Feat] OAuth 성공/실패 redirect_uri 동적 처리 (dev 프론트 환경 지원)

### DIFF
--- a/src/main/java/com/boaz/backend/global/oauth/CookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/boaz/backend/global/oauth/CookieOAuth2AuthorizationRequestRepository.java
@@ -9,12 +9,18 @@ import org.springframework.security.oauth2.client.web.AuthorizationRequestReposi
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.stereotype.Component;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Optional;
+
 @Component
 @RequiredArgsConstructor
 public class CookieOAuth2AuthorizationRequestRepository
         implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
 
     private static final String COOKIE_NAME = "oauth2_auth_request";
+    private static final String REDIRECT_URI_COOKIE_NAME = "oauth2_redirect_uri";
+    private static final String REDIRECT_URI_PARAM = "redirect_uri";
     private static final int COOKIE_EXPIRE_SECONDS = 180;
 
     private final CookieProvider cookieProvider;
@@ -40,10 +46,19 @@ public class CookieOAuth2AuthorizationRequestRepository
     ) {
         if (authorizationRequest == null) {
             cookieProvider.deleteOAuth2StateCookie(response, COOKIE_NAME);
+            cookieProvider.deleteOAuth2StateCookie(response, REDIRECT_URI_COOKIE_NAME);
             return;
         }
         cookieProvider.addOAuth2StateCookie(response, COOKIE_NAME,
                 CookieUtils.serialize(authorizationRequest), COOKIE_EXPIRE_SECONDS);
+
+        String redirectUri = request.getParameter(REDIRECT_URI_PARAM);
+        if (redirectUri != null && !redirectUri.isBlank()) {
+            String encoded = Base64.getUrlEncoder()
+                    .encodeToString(redirectUri.getBytes(StandardCharsets.UTF_8));
+            cookieProvider.addOAuth2StateCookie(response, REDIRECT_URI_COOKIE_NAME,
+                    encoded, COOKIE_EXPIRE_SECONDS);
+        }
     }
 
     @Override
@@ -53,6 +68,19 @@ public class CookieOAuth2AuthorizationRequestRepository
     ) {
         OAuth2AuthorizationRequest authRequest = loadAuthorizationRequest(request);
         cookieProvider.deleteOAuth2StateCookie(response, COOKIE_NAME);
+        cookieProvider.deleteOAuth2StateCookie(response, REDIRECT_URI_COOKIE_NAME);
         return authRequest;
+    }
+
+    public static Optional<String> resolveRedirectUriFromCookie(HttpServletRequest request) {
+        return CookieUtils.getCookie(request, REDIRECT_URI_COOKIE_NAME)
+                .map(cookie -> {
+                    try {
+                        return new String(Base64.getUrlDecoder().decode(cookie.getValue()),
+                                StandardCharsets.UTF_8);
+                    } catch (Exception e) {
+                        return null;
+                    }
+                });
     }
 }

--- a/src/main/java/com/boaz/backend/global/oauth/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/boaz/backend/global/oauth/OAuth2AuthenticationFailureHandler.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 
 @Component
 public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
@@ -29,9 +30,13 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
         String targetUri = CookieOAuth2AuthorizationRequestRepository
                 .resolveRedirectUriFromCookie(request)
                 .filter(allowedRedirectUris::contains)
-                .map(uri -> {
-                    URI parsed = URI.create(uri);
-                    return parsed.getScheme() + "://" + parsed.getAuthority() + "/login?error=true";
+                .flatMap(uri -> {
+                    try {
+                        URI parsed = URI.create(uri);
+                        return Optional.of(parsed.getScheme() + "://" + parsed.getAuthority() + "/login?error=true");
+                    } catch (Exception e) {
+                        return Optional.empty();
+                    }
                 })
                 .orElse(defaultFailureRedirectUri);
 

--- a/src/main/java/com/boaz/backend/global/oauth/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/boaz/backend/global/oauth/OAuth2AuthenticationFailureHandler.java
@@ -8,12 +8,17 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationFa
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.net.URI;
+import java.util.List;
 
 @Component
 public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
 
     @Value("${oauth2.failure-redirect-uri}")
-    private String failureRedirectUri;
+    private String defaultFailureRedirectUri;
+
+    @Value("${oauth2.allowed-redirect-uris}")
+    private List<String> allowedRedirectUris;
 
     @Override
     public void onAuthenticationFailure(
@@ -21,6 +26,15 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
             HttpServletResponse response,
             AuthenticationException exception
     ) throws IOException {
-        getRedirectStrategy().sendRedirect(request, response, failureRedirectUri);
+        String targetUri = CookieOAuth2AuthorizationRequestRepository
+                .resolveRedirectUriFromCookie(request)
+                .filter(allowedRedirectUris::contains)
+                .map(uri -> {
+                    URI parsed = URI.create(uri);
+                    return parsed.getScheme() + "://" + parsed.getAuthority() + "/login?error=true";
+                })
+                .orElse(defaultFailureRedirectUri);
+
+        getRedirectStrategy().sendRedirect(request, response, targetUri);
     }
 }

--- a/src/main/java/com/boaz/backend/global/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/boaz/backend/global/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -26,7 +27,10 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     private final CookieProvider cookieProvider;
 
     @Value("${oauth2.redirect-uri}")
-    private String redirectUri;
+    private String defaultRedirectUri;
+
+    @Value("${oauth2.allowed-redirect-uris}")
+    private List<String> allowedRedirectUris;
 
     @Override
     @Transactional
@@ -54,6 +58,11 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
         cookieProvider.addUserRefreshTokenCookie(response, refreshToken);
 
-        getRedirectStrategy().sendRedirect(request, response, redirectUri + "#token=" + accessToken);
+        String targetUri = CookieOAuth2AuthorizationRequestRepository
+                .resolveRedirectUriFromCookie(request)
+                .filter(allowedRedirectUris::contains)
+                .orElse(defaultRedirectUri);
+
+        getRedirectStrategy().sendRedirect(request, response, targetUri + "#token=" + accessToken);
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -113,3 +113,4 @@ cookie:
 oauth2:
   redirect-uri: https://boazwebv1.vercel.app/auth/callback
   failure-redirect-uri: https://boazwebv1.vercel.app/login?error=true
+  allowed-redirect-uris: "https://boazwebv1.vercel.app/auth/callback,https://dev.bigdataboaz.com/auth/callback"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -105,4 +105,5 @@ cookie:
 
 oauth2:
   redirect-uri: http://localhost:3000/auth/callback
-  failure-redirect-uri: http://localhost:3000/login?error=true 
+  failure-redirect-uri: http://localhost:3000/login?error=true
+  allowed-redirect-uris: "http://localhost:3000/auth/callback,http://localhost:5173/auth/callback"

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -88,7 +88,7 @@ swagger:
   server-url: "https://api.bigdataboaz.com"
 
 cors:
-  allowed-origins: "https://www.bigdataboaz.com,https://prod-www.bigdataboaz.com,https://api.bigdataboaz.com,http://localhost:5173,http://localhost:5173/,http://localhost:5174,http://localhost:5174/,http://localhost:5174,http://localhost:8080"
+  allowed-origins: "https://www.bigdataboaz.com,https://prod-www.bigdataboaz.com,https://dev.bigdataboaz.com,https://api.bigdataboaz.com,http://localhost:5173,http://localhost:5173/,http://localhost:5174,http://localhost:5174/,http://localhost:5174,http://localhost:8080"
 
 jwt:
   secret: ${JWT_SECRET}
@@ -112,6 +112,7 @@ cookie:
 oauth2:
   redirect-uri: https://prod-www.bigdataboaz.com/auth/callback
   failure-redirect-uri: https://prod-www.bigdataboaz.com/login?error=true
+  allowed-redirect-uris: "https://prod-www.bigdataboaz.com/auth/callback,https://www.bigdataboaz.com/auth/callback,https://dev.bigdataboaz.com/auth/callback"
 
 logging:
   level:


### PR DESCRIPTION
## 💡 개요

* Issue Number: #116

## 🪐 주요 변경 사항
- OAuth 로그인 시작 시 `redirect_uri` 쿼리 파라미터를 쿠키에 저장해, 단일 prod 백엔드가 prod·dev 프론트 양쪽으로 올바르게 리다이렉트하도록 개선
- 화이트리스트 exact match 검증으로 오픈 리다이렉트 방지

## ✅ 상세 내용
- `CookieOAuth2AuthorizationRequestRepository`: 로그인 시작 시 `redirect_uri` 파라미터를 Base64 인코딩해 `oauth2_redirect_uri` 쿠키(SameSite=Lax, 180s)로 저장. `removeAuthorizationRequest`에서 함께 삭제. `resolveRedirectUriFromCookie()` static 헬퍼 추가
- `OAuth2AuthenticationSuccessHandler`: 쿠키 값을 `oauth2.allowed-redirect-uris` 화이트리스트로 검증 후 해당 URI로 리다이렉트. 파라미터 없거나 미등록 URI면 기존 기본값 폴백
- `OAuth2AuthenticationFailureHandler`: 동일하게 쿠키 검증 후 origin 추출해 `{origin}/login?error=true`로 리다이렉트
- `application-prod.yml`: CORS에 `dev.bigdataboaz.com` 추가, `oauth2.allowed-redirect-uris` 추가 (prod-www, www, dev)
- `application-dev.yml`, `application-local.yml`: `oauth2.allowed-redirect-uris` 키 추가 (@Value 주입 실패 방지)

## 🔔 참고 사항
- **하위 호환**: `redirect_uri` 파라미터 미전달 시 기존 기본값(`oauth2.redirect-uri`)으로 폴백되어 현재 prod 동작에 영향 없음
- **쿠키 보안 설정 변경 없음**: `SameSite=Strict`, `domain=bigdataboaz.com` 그대로 유지. dev 서브도메인은 same-site라 refresh token 쿠키 정상 동작
- **소셜 제공자 콘솔 변경 불필요**: 제공자 콜백은 기존 `api.bigdataboaz.com/login/oauth2/code/*` 유지
- **프론트 계약**: dev 프론트에서 OAuth 시작 시 `?redirect_uri=https%3A%2F%2Fdev.bigdataboaz.com%2Fauth%2Fcallback` 파라미터 추가 필요. prod 프론트는 변경 불필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 변경 목적
단일 production 백엔드에서 OAuth2 인증 흐름의 redirect_uri 처리를 동적으로 처리해 production·development·local 프론트 환경으로 올바르게 리다이렉트되도록 개선합니다.

## 주요 변경 내용
**OAuth2 처리 계층**
- CookieOAuth2AuthorizationRequestRepository
  - 로그인 시작 시 전달된 redirect_uri 쿼리 파라미터를 Base64 URL-safe로 인코딩하여 REDIRECT_URI 쿠키(SameSite=Lax, 만료 180s)에 저장.
  - 인증 요청 제거 시 해당 redirect_uri 쿠키도 함께 삭제.
  - 쿠키에서 redirect_uri를 복원해 Optional<String>으로 반환하는 public static resolveRedirectUriFromCookie(HttpServletRequest) 헬퍼 추가.
- OAuth2AuthenticationSuccessHandler
  - 기존 단일 redirectUri를 대체해 defaultRedirectUri 및 oauth2.allowed-redirect-uris 화이트리스트를 사용.
  - 쿠키의 redirect_uri를 읽어 화이트리스트와 exact match 검증 후 유효하면 그 URI로, 없거나 미등록이면 defaultRedirectUri로 폴백하여 리다이렉트하고 액세스 토큰을 해시(`#token`=)로 포함.
  - URI 파싱 예외 처리(URI.create() 실패 대비)로 안전하게 기본값으로 폴백하도록 개선.
- OAuth2AuthenticationFailureHandler
  - 실패 시에도 쿠키의 redirect_uri를 화이트리스트와 검증하고, 유효하면 origin을 추출해 {origin}/login?error=true 형태로 리다이렉트. 기본 실패 리다이렉트는 설정값으로 폴백.
  - URI 파싱 예외 처리 추가로 실패 리다이렉트 안전성 향상.

**환경별 설정**
- application-prod.yml
  - oauth2.allowed-redirect-uris 항목 추가(프로덕션/메인/dev callback URL 포함).
  - CORS 허용 오리진에 https://dev.bigdataboaz.com 추가.
- application-dev.yml / application-local.yml
  - oauth2.allowed-redirect-uris에 각각 개발·로컬 콜백 URL 추가(예: vercel, dev.bigdataboaz.com, localhost:3000/5173 등).

## 영향 범위
- 설정 변경: 환경별 application-*.yml에 oauth2.allowed-redirect-uris 추가 및 prod CORS 확장 (필수 구성 변경).
- API 변경: 없음(기존 프로덕션 기본 동작은 redirect_uri 미전달 시 폴백으로 보존).
- DB 스키마 변경: 없음.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BOAZ-website/backend/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->