### PR TITLE
[Feat] 아카이빙 기수 목록 조회 API 추가

### DIFF
--- a/src/main/java/com/boaz/backend/domain/archive/controller/ArchiveController.java
+++ b/src/main/java/com/boaz/backend/domain/archive/controller/ArchiveController.java
@@ -1,6 +1,7 @@
 package com.boaz.backend.domain.archive.controller;
 
 import com.boaz.backend.domain.archive.dto.response.ArchivePageResponse;
+import com.boaz.backend.domain.archive.dto.response.ArchiveTermsResponse;
 import com.boaz.backend.domain.archive.entity.Archive.Category;
 import com.boaz.backend.domain.archive.service.ArchiveService;
 import com.boaz.backend.global.common.ApiResponse;
@@ -84,4 +85,12 @@ public class ArchiveController {
 
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
+
+    @Operation(summary = "아카이빙 기수 목록 조회", description = "필터 드롭다운용 기수 목록 반환")
+    @GetMapping("/terms")
+    public ResponseEntity<ApiResponse<ArchiveTermsResponse>> getTerms() {
+
+        return ResponseEntity.ok(ApiResponse.ok(archiveService.getTerms()));
+    }
+
 }

--- a/src/main/java/com/boaz/backend/domain/archive/dto/response/ArchiveTermsResponse.java
+++ b/src/main/java/com/boaz/backend/domain/archive/dto/response/ArchiveTermsResponse.java
@@ -1,0 +1,19 @@
+package com.boaz.backend.domain.archive.dto.response;
+
+import java.util.List;
+
+public record ArchiveTermsResponse(List<TermItem> terms) {
+
+    public record TermItem(int value, String label) {
+        public static TermItem from(int term) {
+            String label = (term == 0) ? "7기 이전" : term + "기";
+            return new TermItem(term, label);
+        }
+    }
+
+    public static ArchiveTermsResponse from(List<Integer> terms) {
+        return new ArchiveTermsResponse( 
+            terms.stream().map(TermItem::from).toList()
+        );
+    }
+}

--- a/src/main/java/com/boaz/backend/domain/archive/repository/ArchiveRepository.java
+++ b/src/main/java/com/boaz/backend/domain/archive/repository/ArchiveRepository.java
@@ -10,6 +10,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 
 // 메서드 호출 시 JPQL 쿼리 실행 
 public interface ArchiveRepository extends JpaRepository<Archive, Long> {
@@ -37,4 +39,12 @@ public interface ArchiveRepository extends JpaRepository<Archive, Long> {
         @Param("keyword") String keyword, 
         Pageable pageable
     );
+
+    @Query("""
+            SELECT DISTINCT a.term FROM Archive a
+            ORDER BY
+                CASE WHEN a.term = 0 THEN 1 ELSE 0 END ASC, 
+                a.term DESC
+    """)
+    List<Integer> findDistinctTermsOrdered();
 }

--- a/src/main/java/com/boaz/backend/domain/archive/service/ArchiveService.java
+++ b/src/main/java/com/boaz/backend/domain/archive/service/ArchiveService.java
@@ -2,6 +2,7 @@ package com.boaz.backend.domain.archive.service;
 
 import com.boaz.backend.domain.archive.dto.response.ArchiveItemResponse;
 import com.boaz.backend.domain.archive.dto.response.ArchivePageResponse;
+import com.boaz.backend.domain.archive.dto.response.ArchiveTermsResponse;
 import com.boaz.backend.domain.archive.entity.Archive;
 import com.boaz.backend.domain.archive.entity.Archive.Category;
 import com.boaz.backend.domain.archive.repository.ArchiveRepository;
@@ -11,6 +12,7 @@ import com.boaz.backend.global.exception.CustomException;
 import com.boaz.backend.global.exception.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
+import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -64,6 +66,11 @@ public class ArchiveService {
 
         // 페이지 메타데이터 + 게시글 목록을 포함한 응답 DTO로 변환  
         return ArchivePageResponse.from(itemPage);   
+    }
+
+    public ArchiveTermsResponse getTerms() {
+        List<Integer> terms = archiveRepository.findDistinctTermsOrdered();
+        return ArchiveTermsResponse.from(terms);
     }
 
     // 페이지 값 검증


### PR DESCRIPTION
## 💡 개요

* Issue Number: #119 

## 🪐 주요 변경 사항
- 아카이빙 기수 목록 조회 API 추가 (GET /api/v1/archiving/terms)

## ✅ 상세 내용
- ArchiveRepository에 DISTINCT term 조회 쿼리 추가 (term = 0은 항상 마지막 정렬)
- ArchiveService에 getTerms() 메서드 추가
- ArchiveTermsResponse DTO 추가 (term 값 → label 변환 포함, 0 → "7기 이전")
- ArchiveController에 GET /api/v1/archiving/terms 엔드포인트 추가

## 🔔 참고 사항
- term = 0은 "7기 이전"을 의미하며 항상 목록 마지막에 위치
- 데이터가 없는 경우 빈 리스트 반환

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**변경 목적**
아카이빙 기수 목록 조회 API를 새로 추가하여, 드롭다운 필터에서 사용할 기수 목록을 반환하는 기능을 구현합니다.

**주요 변경 내용**
- **Repository (`ArchiveRepository`)**: `findDistinctTermsOrdered()` 메서드 추가 - 중복 제거된 term 값을 조회하되, `term = 0`을 마지막에 정렬하는 쿼리 구현
- **Service (`ArchiveService`)**: `getTerms()` 메서드 추가 - Repository에서 조회한 term 목록을 DTO로 변환하여 반환
- **DTO (`ArchiveTermsResponse`)**: 새 레코드 DTO 추가 - `term` 값을 기반으로 `TermItem` 리스트를 생성하며, `term = 0`은 "7기 이전"으로 변환, 나머지는 "{term}기" 형식으로 라벨 생성
- **Controller (`ArchiveController`)**: `GET /api/v1/archiving/terms` 엔드포인트 추가 - `ApiResponse` 형태로 기수 목록 반환

**영향 범위**
API 엔드포인트 추가 (신규 GET 엔드포인트, DB 스키마 변경 없음)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BOAZ-website/backend/pull/120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->