### PR TITLE
[Fix] EC2 리부팅 시 boaz.service 시작 실패 문제 수정

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -14,6 +14,9 @@ files:
   - source: /systemd/boaz.service
     destination: /etc/systemd/system
     overwrite: true
+  - source: /systemd/boaz-tmpfiles.conf
+    destination: /etc/tmpfiles.d
+    overwrite: true
 
 hooks:
   BeforeInstall:

--- a/scripts/after_install.sh
+++ b/scripts/after_install.sh
@@ -6,3 +6,4 @@ chmod 644 /opt/boaz/app.jar
 chmod 755 /opt/boaz/scripts/*.sh
 
 systemctl daemon-reload
+systemd-tmpfiles --create /etc/tmpfiles.d/boaz-tmpfiles.conf

--- a/systemd/boaz-tmpfiles.conf
+++ b/systemd/boaz-tmpfiles.conf
@@ -1,0 +1,1 @@
+d /run/boaz 0755 boaz boaz -


### PR DESCRIPTION
## 💡 개요

* Issue Number: #121

## 🪐 주요 변경 사항
- `systemd/boaz.service` — EnvironmentFile 옵셔널 처리 (`-` 접두사 추가)
- `systemd/boaz-tmpfiles.conf` 신규 추가
- `appspec.yml` — tmpfiles.conf 배포 경로 추가
- `scripts/after_install.sh` — 배포 직후 tmpfiles 즉시 적용 명령 추가

## ✅ 상세 내용

**근본 원인**

EC2 리부팅 시 tmpfs인 `/run/`이 초기화되어 `/run/boaz/`와 `/run/boaz/app.env`가 사라짐.
systemd는 EnvironmentFile 검증 → ExecStartPre 실행 순서로 동작하기 때문에, `app.env`가 없으면 이를 만들어야 할 `load-ssm-env.sh`조차 실행되지 못하는 순환 의존성 문제가 발생.

**수정 내용**

1. `EnvironmentFile=-/run/boaz/app.env` — `-` 접두사로 파일 부재 시 무시하도록 처리. ExecStartPre가 정상 실행되어 `app.env`를 생성하고, ExecStart 시점에 env vars 주입됨
2. `boaz-tmpfiles.conf` 추가 — 부팅 시 `systemd-tmpfiles-setup.service`가 `/run/boaz/`를 자동 생성. `ReadWritePaths=/run/boaz` 네임스페이스 셋업 실패 방지

## 🔔 참고 사항
- 5/24 AMI 생성으로 EC2가 리부팅되면서 발견된 장애에 대한 수정
- AMI 생성 시 "재부팅 안 함(No reboot)" 옵션 체크 필요 — 팀 내 공유 필요

@coderabbitai ignore