### PR TITLE
[Fix] EnvironmentFile 옵셔널 처리로 부팅 시 순환 의존성 해결

### DIFF
--- a/systemd/boaz.service
+++ b/systemd/boaz.service
@@ -13,7 +13,7 @@
 
   PermissionsStartOnly=true
   ExecStartPre=/opt/boaz/scripts/load-ssm-env.sh
-  EnvironmentFile=/run/boaz/app.env
+  EnvironmentFile=-/run/boaz/app.env
   Environment=SPRING_PROFILES_ACTIVE=prod
 
   ExecStart=/opt/boaz/scripts/start.sh


### PR DESCRIPTION
## 💡 개요

* Issue Number: #121

## 🪐 주요 변경 사항
- `systemd/boaz.service` — `EnvironmentFile` 에 `-` 접두사 추가 (옵셔널 처리)

## ✅ 상세 내용
- PR #122로 `tmpfiles.d`는 배포됐으나, 부팅 시 여전히 동일한 오류 발생 확인
- systemd는 EnvironmentFile 검증 후 ExecStartPre를 실행하는 구조라, `app.env`가 없으면 이를 만드는 `load-ssm-env.sh`조차 실행되지 못하는 순환 의존성 문제
- `EnvironmentFile=-/run/boaz/app.env` 로 변경하면: 파일 없어도 무시 → ExecStartPre 정상 실행 → `app.env` 생성 → ExecStart 시점에 env vars 주입

## 🔔 참고 사항
- PR #122 후속 수정

@coderabbitai ignore