### PR TITLE
[Chore] ALB 기반 시즌 전환 스크립트 추가

### DIFF
--- a/infra/scripts/README.md
+++ b/infra/scripts/README.md
@@ -1,0 +1,300 @@
+# BOAZ 시즌 전환 스크립트
+
+모집 시즌(1년 2회, 각 2주) 동안 active-active HA 구조로 전환했다가 평시엔 단일 인스턴스로 복귀하기 위한 자동화 스크립트.
+
+---
+
+## 디렉터리 구성
+
+```
+infra/scripts/
+├── register-ssm-params.sh   # SSM Parameter Store에 인프라 설정값 등록 (최초 1회)
+├── cf_set_origin.py         # CloudFront 단일 origin 도메인/포트 교체 헬퍼
+├── season-up.sh             # 모집 시즌 시작 (single EC2 → ALB + 2 EC2)
+└── season-down.sh           # 모집 시즌 종료 (ALB + 2 EC2 → single EC2)
+```
+
+---
+
+## 아키텍처 변화
+
+### 평시 (스크립트 미실행 기본 상태)
+
+```
+사용자 → Route53 → CloudFront → EC2-A (8080) → RDS (single-AZ)
+```
+
+- EC2-B: stopped
+- ALB: 존재 X
+- Target Group `boaz-api-tg`: EC2-A만 등록(상태 `unused`)
+- RDS: Multi-AZ OFF
+
+### 시즌 중 (`season-up.sh` 실행 후)
+
+```
+사용자 → Route53 → CloudFront → ALB (80) → ┬─ EC2-A (8080)
+                                           └─ EC2-B (8080)
+
+                                         RDS (Multi-AZ: primary + standby)
+```
+
+- EC2-B: running
+- ALB `boaz-alb`: 신규 생성, listener 80 → Target Group 포워딩
+- Target Group: EC2-A + EC2-B 모두 healthy
+- RDS: Multi-AZ ON (다른 AZ에 standby 동기 복제)
+
+---
+
+## season-up.sh 흐름 (7단계, 약 10~12분)
+
+| Step | 동작 | 소요시간 |
+|------|------|----------|
+| 0 | SSM에서 인프라 설정 12개 로드 | ~3초 |
+| 1 | EC2-B start → running 상태 대기 | ~60초 |
+| 2 | CodeDeploy 마지막 성공 배포를 재실행 (EC2-A/B 모두 최신화). `OneAtATime` 방식 | 3~5분 |
+| 3 | ALB 생성 → ACTIVE 대기 → HTTP 80 listener 추가 (TG 포워딩) | ~3분 |
+| 4 | EC2-B를 Target Group에 register → EC2-A/B 모두 healthy 대기 | ~2분 |
+| 5 | CloudFront origin을 EC2-A 직결 → ALB DNS로 교체 (port 8080 → 80) | 트리거 ~10초, 전파 5~15분 |
+| 6 | RDS Multi-AZ ON 트리거 (apply-immediately) | 트리거 ~5초, 실제 완료 10~30분 |
+| 7 | 헬스체크 안내 출력 | 즉시 |
+
+### Step 2의 잠재적 다운타임
+
+CodeDeploy `OneAtATime`이 EC2-A를 재배포하는 동안 ~30초 5xx 발생 가능. 시즌-up은 **트래픽 적은 시간대(예: 새벽)**에 실행 권장.
+
+---
+
+## season-down.sh 흐름 (5단계, 약 6~20분)
+
+| Step | 동작 | 소요시간 |
+|------|------|----------|
+| 0 | SSM에서 인프라 설정 로드 | ~3초 |
+| 1 | CloudFront origin을 ALB → EC2-A 직결로 복귀 (port 80 → 8080) | 트리거 ~10초 |
+| 2 | CloudFront `Deployed` 상태 폴링 (전파 완료 대기) | 5~15분 |
+| 3 | ALB 삭제 (listener 함께 삭제) | ~10초 |
+| 4 | EC2-B를 Target Group에서 deregister + stop | ~30초 |
+| 5 | RDS Multi-AZ OFF 트리거 (apply-immediately) | 트리거 ~5초, 실제 완료 10~30분 |
+
+### Step 2를 왜 폴링하는가
+
+CloudFront 전파가 끝나기 전에 ALB를 삭제하면, 아직 ALB origin을 사용하는 edge 캐시들이 502를 반환한다. 안전하게 `Deployed` 상태가 된 후에 ALB를 삭제.
+
+---
+
+## 영구 유지되는 인프라 (삭제 금지)
+
+스크립트가 매 시즌 재사용하므로 절대 손대지 말 것.
+
+- **Target Group** `boaz-api-tg` (EC2-A 영구 등록)
+- **ALB Security Group** `boaz-alb-sg` (CloudFront prefix list만 허용)
+- **EC2 SG의 ALB SG 인바운드 룰** (8080 허용)
+- **SSM Parameter Store** `/boaz/infra/*` 12개 파라미터
+- **EC2-B 인스턴스** (stopped 상태로 유지, ID 보존)
+
+---
+
+## 시즌마다 생성/삭제되는 인프라
+
+- **ALB** `boaz-alb` (DNS는 매번 달라짐, 스크립트가 CloudFront에 자동 반영)
+- **ALB Listener** (ALB와 함께 생성/삭제)
+- **EC2-B의 Target Group 등록 상태**
+- **RDS Multi-AZ 토글**
+
+---
+
+## 사전 준비 (최초 1회)
+
+### 1. AWS 계정 / CLI 설정
+
+- AWS CLI 설치 및 `tf` 프로파일 구성 (`aws configure --profile tf`)
+- 권한: EC2/ELBv2/CloudFront/RDS/CodeDeploy/SSM 관리 권한 필요
+
+### 2. Python 환경 (Windows)
+
+`cf_set_origin.py`가 표준 라이브러리만 쓰므로 별도 패키지 불필요. 다만 Windows Git Bash 환경에서 `python` 명령이 WindowsApps 스텁으로 가는 것을 피하기 위해 conda 가상환경 권장.
+
+```bash
+conda create -n boaz-ops python=3.11 -y
+```
+
+이후 매번 스크립트 실행 전:
+
+```bash
+conda activate boaz-ops
+```
+
+> conda init bash가 안 되어 있으면 Anaconda Prompt에서 `conda init bash` 한 번 실행 후 Git Bash 재시작.
+
+### 3. SSM 파라미터 등록
+
+```bash
+cd infra/scripts
+./register-ssm-params.sh
+```
+
+값이 바뀌었으면 `register-ssm-params.sh` 안의 `put-parameter` 호출에 `--overwrite` 옵션을 추가하고 재실행.
+
+### 4. 영구 인프라 세팅 (한 번만 콘솔에서)
+
+- Target Group `boaz-api-tg` 생성 (포트 8080, 헬스체크 `/actuator/health`, EC2-A 등록)
+- ALB Security Group `boaz-alb-sg` 생성 (inbound: CloudFront prefix list만 허용)
+- EC2-A/B의 Security Group에 `boaz-alb-sg → 8080` 허용 룰 추가
+
+---
+
+## 실행 가이드
+
+### 시즌 시작 (season-up)
+
+```bash
+conda activate boaz-ops
+cd infra/scripts
+./season-up.sh
+```
+
+#### 실행 후 검증
+
+```powershell
+# 1. ALB 생성 확인
+aws elbv2 describe-load-balancers --names boaz-alb --region ap-northeast-2 --profile tf \
+  --query "LoadBalancers[0].{State:State.Code,DNS:DNSName}" --output table
+
+# 2. Target Group에 EC2-A, EC2-B 모두 healthy
+aws elbv2 describe-target-health \
+  --target-group-arn arn:aws:elasticloadbalancing:ap-northeast-2:156312218841:targetgroup/boaz-api-tg/d42747d4f4ff49e6 \
+  --region ap-northeast-2 --profile tf \
+  --query "TargetHealthDescriptions[].{Id:Target.Id,Health:TargetHealth.State}" --output table
+
+# 3. CloudFront origin이 ALB DNS인지
+aws cloudfront get-distribution-config --id E2SER81QYNPRO9 --profile tf \
+  --query "DistributionConfig.Origins.Items[].{Domain:DomainName,Port:CustomOriginConfig.HTTPPort}" --output table
+
+# 4. RDS Multi-AZ 전환 상태
+aws rds describe-db-instances --db-instance-identifier boaz-prod-db --region ap-northeast-2 --profile tf \
+  --query "DBInstances[0].{Status:DBInstanceStatus,MultiAZ:MultiAZ,Pending:PendingModifiedValues.MultiAZ}" --output table
+
+# 5. 전파 완료 후 실제 호출 (5~15분 후)
+curl https://api.bigdataboaz.com/actuator/health
+```
+
+---
+
+### 시즌 종료 (season-down)
+
+```bash
+conda activate boaz-ops
+cd infra/scripts
+./season-down.sh
+```
+
+#### 실행 후 검증
+
+```powershell
+# 1. CloudFront origin이 EC2-A로 복귀
+aws cloudfront get-distribution-config --id E2SER81QYNPRO9 --profile tf \
+  --query "DistributionConfig.Origins.Items[].{Domain:DomainName,Port:CustomOriginConfig.HTTPPort}" --output table
+
+# 2. ALB 삭제 확인 (LoadBalancerNotFound 에러가 나야 정상)
+aws elbv2 describe-load-balancers --names boaz-alb --region ap-northeast-2 --profile tf
+
+# 3. EC2-B stopped
+aws ec2 describe-instances --instance-ids i-05405847d3897364a --region ap-northeast-2 --profile tf \
+  --query "Reservations[0].Instances[0].State.Name" --output text
+
+# 4. Target Group에 EC2-A만 남음
+aws elbv2 describe-target-health \
+  --target-group-arn arn:aws:elasticloadbalancing:ap-northeast-2:156312218841:targetgroup/boaz-api-tg/d42747d4f4ff49e6 \
+  --region ap-northeast-2 --profile tf \
+  --query "TargetHealthDescriptions[].{Id:Target.Id,Health:TargetHealth.State}" --output table
+
+# 5. 실제 호출
+curl https://api.bigdataboaz.com/actuator/health
+```
+
+---
+
+## 실행 환경 주의사항
+
+### Windows Git Bash
+
+- 경로 자동 변환을 막기 위해 스크립트 내부에서 `MSYS_NO_PATHCONV=1` 자동 설정
+- 직접 AWS CLI 호출 시(예: SSM 등록을 PowerShell이 아닌 Git Bash로 할 때) 동일 환경변수 필요
+- Python은 conda 가상환경(`boaz-ops`) 활성화 상태여야 함
+
+### AWS Profile
+
+기본값은 `tf`. 다른 프로파일 쓰려면:
+
+```bash
+AWS_PROFILE=other ./season-up.sh
+```
+
+---
+
+## 문제 발생 시 수동 롤백
+
+### season-up 도중 실패한 경우
+
+1. ALB 생성됐으면 콘솔에서 삭제
+2. EC2-B를 Target Group에서 deregister
+3. EC2-B stop
+4. CloudFront origin이 EC2-A인지 확인, 아니면 콘솔에서 수동 복귀(domain + port 8080)
+5. RDS Multi-AZ 토글된 상태면 콘솔에서 되돌리기
+
+### season-down 도중 실패한 경우
+
+1. CloudFront origin 상태 확인 후 필요시 수동 복귀
+2. ALB 남아있으면 콘솔에서 삭제
+3. EC2-B 상태 확인
+4. RDS Multi-AZ 토글된 상태면 콘솔에서 되돌리기
+
+---
+
+## 값 관리 정책
+
+스크립트가 사용하는 값은 두 종류로 나뉜다.
+- **고정값**: 인프라 리소스 식별자/설정. SSM Parameter Store에 저장하고 스크립트가 시작 시 한 번 로드한다. 값이 바뀌는 시점이 매우 드물다.
+- **동적값**: 스크립트 실행 도중 AWS API 호출로 조회/생성된다. 매 실행마다 값이 달라지므로 저장하지 않는다.
+
+### 고정값 (SSM Parameter Store에 저장)
+
+경로: `/boaz/infra/*` (12개). `register-ssm-params.sh`로 등록/갱신.
+
+| SSM 키 | 현재 값 | 용도 / 사용 스크립트 | 변경 시점 |
+|--------|---------|---------------------|-----------|
+| `EC2_B_ID` | `i-05405847d3897364a` | EC2-B start/stop, TG 등록·해제 (up/down) | EC2-B terminate 후 재생성 시 |
+| `EC2_A_DOMAIN` | `ec2-15-165-102-5.ap-northeast-2.compute.amazonaws.com` | CloudFront origin 복귀 (down) | EC2-A 퍼블릭 DNS 변경 시 (EIP 권장) |
+| `EC2_A_PORT` | `8080` | CloudFront origin 복귀 포트 (down) | Spring Boot 포트 변경 시 |
+| `CLOUDFRONT_DIST_ID` | `E2SER81QYNPRO9` | CloudFront origin 업데이트 (up/down) | CloudFront 재생성 시 |
+| `RDS_IDENTIFIER` | `boaz-prod-db` | Multi-AZ 토글 (up/down) | RDS 재생성 시 |
+| `S3_BUCKET` | `boaz-codedeploy-bucket` | CodeDeploy 번들 위치 참조 | 거의 안 바뀜 |
+| `CODEDEPLOY_APP` | `boaz-backend` | CodeDeploy 배포 (up) | 거의 안 바뀜 |
+| `CODEDEPLOY_GROUP` | `codedeploy-prod` | CodeDeploy 배포 (up) | 거의 안 바뀜 |
+| `TARGET_GROUP_ARN` | `arn:aws:elasticloadbalancing:ap-northeast-2:156312218841:targetgroup/boaz-api-tg/d42747d4f4ff49e6` | ALB listener forwarding, EC2-B 등록·해제 (up/down) | Target Group 재생성 시 |
+| `ALB_SG_ID` | `sg-0b98cad292282ebe5` | ALB 생성 시 SG 지정 (up) | ALB SG 재생성 시 |
+| `ALB_SUBNETS` | `subnet-02fd34391da42563b,subnet-092734d1357224a25` | ALB 생성 시 배치 서브넷 (up) | VPC 서브넷 재구성 시 |
+| `ALB_PORT` | `80` | ALB listener 포트 + CloudFront origin 포트 (up) | ALB 표준 포트 변경 시(거의 없음) |
+
+### 동적값 (스크립트가 런타임에 조회)
+
+저장하지 않고 매 실행마다 새로 가져온다. 저장하면 stale 데이터가 되어 사고로 이어지므로 의도적으로 저장 안 함.
+
+| 변수 | 어떻게 얻는가 | 왜 동적인가 |
+|------|--------------|-------------|
+| `ALB_ARN` | `elbv2 create-load-balancer` 응답 | 시즌마다 ALB를 새로 생성하므로 매번 다른 ARN |
+| `ALB_DNS` | `elbv2 describe-load-balancers --load-balancer-arns $ALB_ARN` | ALB 생성 시점에 AWS가 부여하는 도메인 (예: `boaz-alb-XXXXXX.ap-northeast-2.elb.amazonaws.com`). 매번 다른 prefix |
+| `LAST_DEPLOY_ID` | `deploy list-deployments --include-only-statuses Succeeded` | 마지막 성공 배포가 매번 다름 (코드 변경마다 새 배포 ID 발급) |
+| `BUNDLE_BUCKET`, `BUNDLE_KEY` | `deploy get-deployment $LAST_DEPLOY_ID` | 배포마다 새 S3 키로 번들 업로드됨 |
+| `DEPLOYMENT_ID` | `deploy create-deployment` 응답 | 신규 배포 트리거할 때마다 새로 발급. `deploy wait deployment-successful`에 필요 |
+| `ETAG` | `cloudfront get-distribution-config --query ETag` | CloudFront 설정이 바뀔 때마다 새 ETag 발급. `update-distribution --if-match`에 필수 (낙관적 락) |
+| `DIST_CONFIG` | `cloudfront get-distribution-config --query DistributionConfig` | 현재 distribution 전체 설정. origin만 수정해서 다시 PUT 해야 하므로 매번 fresh fetch 필요 |
+
+#### 동적값 흐름 예시 (season-up Step 5: CloudFront origin 교체)
+
+```
+1. ETAG = get-distribution-config로 현재 ETag 조회
+2. DIST_CONFIG = 같은 호출로 현재 전체 설정 조회
+3. cf_set_origin.py로 origin의 DomainName/HTTPPort만 ALB 값으로 치환 → NEW_CONFIG
+4. update-distribution --if-match $ETAG --distribution-config $NEW_CONFIG
+   → ETAG가 안 맞으면 누군가 그 사이 설정 바꾼 것 → 에러로 실패 (안전장치)
+```

--- a/infra/scripts/cf_set_origin.py
+++ b/infra/scripts/cf_set_origin.py
@@ -1,0 +1,29 @@
+"""
+CloudFront 단일 origin의 DomainName/HTTPPort 교체
+stdin:  DistributionConfig JSON
+env:    NEW_DOMAIN, NEW_HTTP_PORT
+stdout: 수정된 config JSON
+
+사용처: season-up/down에서 origin을 EC2-A ↔ ALB 사이로 교체
+가정:   distribution에 origin이 1개만 있음 (boaz API 서버)
+"""
+import json
+import os
+import sys
+
+config = json.load(sys.stdin)
+new_domain = os.environ["NEW_DOMAIN"]
+new_port = int(os.environ["NEW_HTTP_PORT"])
+
+if config["Origins"]["Quantity"] != 1:
+    print(
+        f"ERROR: expected exactly 1 origin, found {config['Origins']['Quantity']}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+origin = config["Origins"]["Items"][0]
+origin["DomainName"] = new_domain
+origin["CustomOriginConfig"]["HTTPPort"] = new_port
+
+print(json.dumps(config))

--- a/infra/scripts/register-ssm-params.sh
+++ b/infra/scripts/register-ssm-params.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# =====================================================
+# register-ssm-params.sh — SSM Parameter Store 등록
+# 최초 1회 실행. 값 변경 시 --overwrite 추가 후 재실행
+# 실행: ./register-ssm-params.sh  (Git Bash 또는 Linux/Mac 터미널)
+# 주의: Windows Git Bash에서 실행 시 경로 자동 변환 방지
+# =====================================================
+
+# Windows Git Bash(MSYS)가 /boaz/... 경로를 Windows 경로로 변환하는 것 방지
+export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL="*"
+
+AWS_REGION="ap-northeast-2"
+
+aws ssm put-parameter \
+  --name "/boaz/infra/EC2_B_ID" \
+  --value "i-05405847d3897364a" \
+  --type String \
+  --region "$AWS_REGION" \
+  --profile tf
+
+aws ssm put-parameter \
+  --name "/boaz/infra/CLOUDFRONT_DIST_ID" \
+  --value "E2SER81QYNPRO9" \
+  --type String \
+  --region "$AWS_REGION" \
+  --profile tf
+
+aws ssm put-parameter \
+  --name "/boaz/infra/EC2_A_DOMAIN" \
+  --value "ec2-15-165-102-5.ap-northeast-2.compute.amazonaws.com" \
+  --type String \
+  --region "$AWS_REGION" \
+  --profile tf
+
+aws ssm put-parameter \
+  --name "/boaz/infra/RDS_IDENTIFIER" \
+  --value "boaz-prod-db" \
+  --type String \
+  --region "$AWS_REGION" \
+  --profile tf
+
+aws ssm put-parameter \
+  --name "/boaz/infra/CODEDEPLOY_APP" \
+  --value "boaz-backend" \
+  --type String \
+  --region "$AWS_REGION" \
+  --profile tf
+
+aws ssm put-parameter \
+  --name "/boaz/infra/CODEDEPLOY_GROUP" \
+  --value "codedeploy-prod" \
+  --type String \
+  --region "$AWS_REGION" \
+  --profile tf
+
+aws ssm put-parameter \
+  --name "/boaz/infra/S3_BUCKET" \
+  --value "boaz-codedeploy-bucket" \
+  --type String \
+  --region "$AWS_REGION" \
+  --profile tf
+
+# ===== ALB / Target Group (시즌 전환용) =====
+
+aws ssm put-parameter \
+  --name "/boaz/infra/TARGET_GROUP_ARN" \
+  --value "arn:aws:elasticloadbalancing:ap-northeast-2:156312218841:targetgroup/boaz-api-tg/d42747d4f4ff49e6" \
+  --type String \
+  --region "$AWS_REGION" \
+  --profile tf
+
+aws ssm put-parameter \
+  --name "/boaz/infra/ALB_SG_ID" \
+  --value "sg-0b98cad292282ebe5" \
+  --type String \
+  --region "$AWS_REGION" \
+  --profile tf
+
+aws ssm put-parameter \
+  --name "/boaz/infra/ALB_SUBNETS" \
+  --value "subnet-02fd34391da42563b,subnet-092734d1357224a25" \
+  --type String \
+  --region "$AWS_REGION" \
+  --profile tf
+
+aws ssm put-parameter \
+  --name "/boaz/infra/EC2_A_PORT" \
+  --value "8080" \
+  --type String \
+  --region "$AWS_REGION" \
+  --profile tf
+
+aws ssm put-parameter \
+  --name "/boaz/infra/ALB_PORT" \
+  --value "80" \
+  --type String \
+  --region "$AWS_REGION" \
+  --profile tf
+
+echo ""
+echo "등록 완료. 확인:"
+aws ssm get-parameters-by-path \
+  --path "/boaz/infra/" \
+  --region "$AWS_REGION" \
+  --query "Parameters[*].{Name:Name,Value:Value}" \
+  --output table \
+  --profile tf

--- a/infra/scripts/season-down.sh
+++ b/infra/scripts/season-down.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# =====================================================
+# season-down.sh — 모집 시즌 종료
+# 실행: ./season-down.sh
+# 사전 조건: AWS CLI + tf 프로파일, conda boaz-ops 환경 활성화
+# =====================================================
+set -eo pipefail
+
+export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL="*"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AWS_REGION="ap-northeast-2"
+AWS_PROFILE="${AWS_PROFILE:-tf}"
+
+# Python 인터프리터 탐색 (WindowsApps 스텁 제외)
+PYTHON=""
+for cmd in py python3 python; do
+  _path=$(command -v "$cmd" 2>/dev/null || true)
+  if [ -n "$_path" ] && ! echo "$_path" | grep -qi "WindowsApps"; then
+    PYTHON="$cmd"
+    break
+  fi
+done
+if [ -z "$PYTHON" ]; then
+  echo "❌ Python을 찾지 못함. conda activate boaz-ops 후 재실행."
+  exit 1
+fi
+
+echo "=========================================="
+echo "  BOAZ 모집 시즌 종료 (season-down)"
+echo "=========================================="
+
+# --------------------------------------------------
+# 0. SSM 설정 로드
+# --------------------------------------------------
+echo ""
+echo "[0/5] SSM Parameter Store에서 설정 로드 중..."
+
+ssm_get() {
+  aws ssm get-parameter --name "/boaz/infra/$1" \
+    --region "$AWS_REGION" --profile "$AWS_PROFILE" \
+    --query "Parameter.Value" --output text
+}
+
+EC2_B_ID=$(ssm_get "EC2_B_ID")
+EC2_A_DOMAIN=$(ssm_get "EC2_A_DOMAIN")
+EC2_A_PORT=$(ssm_get "EC2_A_PORT")
+CLOUDFRONT_DIST_ID=$(ssm_get "CLOUDFRONT_DIST_ID")
+RDS_IDENTIFIER=$(ssm_get "RDS_IDENTIFIER")
+TARGET_GROUP_ARN=$(ssm_get "TARGET_GROUP_ARN")
+
+echo "  ✅ 설정 로드 완료"
+
+# --------------------------------------------------
+# 1. CloudFront origin을 EC2-A 직결로 복귀
+# --------------------------------------------------
+echo ""
+echo "[1/5] CloudFront origin을 EC2-A로 복귀 중..."
+
+CF_SCRIPT=$(cygpath -w "$SCRIPT_DIR/cf_set_origin.py")
+ETAG=$(aws cloudfront get-distribution-config --id "$CLOUDFRONT_DIST_ID" \
+  --profile "$AWS_PROFILE" --query 'ETag' --output text)
+DIST_CONFIG=$(aws cloudfront get-distribution-config --id "$CLOUDFRONT_DIST_ID" \
+  --profile "$AWS_PROFILE" --query 'DistributionConfig' --output json)
+
+NEW_CONFIG=$(NEW_DOMAIN="$EC2_A_DOMAIN" NEW_HTTP_PORT="$EC2_A_PORT" \
+  "$PYTHON" "$CF_SCRIPT" <<< "$DIST_CONFIG")
+
+aws cloudfront update-distribution --id "$CLOUDFRONT_DIST_ID" \
+  --distribution-config "$NEW_CONFIG" \
+  --if-match "$ETAG" \
+  --profile "$AWS_PROFILE" > /dev/null
+echo "  ✅ CloudFront origin 복귀 트리거 완료 (전파 5~15분)"
+
+# --------------------------------------------------
+# 2. CloudFront 전파 대기 (Deployed 상태 확인)
+# --------------------------------------------------
+echo ""
+echo "[2/5] CloudFront Deployed 상태 대기 중..."
+while true; do
+  status=$(aws cloudfront get-distribution --id "$CLOUDFRONT_DIST_ID" \
+    --profile "$AWS_PROFILE" --query 'Distribution.Status' --output text)
+  if [ "$status" = "Deployed" ]; then
+    break
+  fi
+  echo "  → 현재 status: $status (30초 후 재확인)"
+  sleep 30
+done
+echo "  ✅ CloudFront 전파 완료"
+
+# --------------------------------------------------
+# 3. ALB 삭제 (Listener는 ALB와 함께 삭제됨)
+# --------------------------------------------------
+echo ""
+echo "[3/5] ALB 삭제 중..."
+ALB_ARN=$(aws elbv2 describe-load-balancers --names "boaz-alb" \
+  --region "$AWS_REGION" --profile "$AWS_PROFILE" \
+  --query 'LoadBalancers[0].LoadBalancerArn' --output text 2>/dev/null || echo "")
+
+if [ -z "$ALB_ARN" ] || [ "$ALB_ARN" = "None" ]; then
+  echo "  ⚠️  ALB 'boaz-alb' 없음. 이미 삭제됐을 가능성. 건너뜀."
+else
+  aws elbv2 delete-load-balancer --load-balancer-arn "$ALB_ARN" \
+    --region "$AWS_REGION" --profile "$AWS_PROFILE"
+  echo "  ✅ ALB 삭제 완료"
+fi
+
+# --------------------------------------------------
+# 4. EC2-B를 Target Group에서 deregister + stop
+# --------------------------------------------------
+echo ""
+echo "[4/5] EC2-B Target Group에서 제거 + 중지 중..."
+
+aws elbv2 deregister-targets --target-group-arn "$TARGET_GROUP_ARN" \
+  --targets "Id=$EC2_B_ID" \
+  --region "$AWS_REGION" --profile "$AWS_PROFILE" 2>/dev/null || true
+
+aws ec2 stop-instances --instance-ids "$EC2_B_ID" \
+  --region "$AWS_REGION" --profile "$AWS_PROFILE" > /dev/null
+echo "  ✅ EC2-B stop 요청 완료 (인스턴스 ID 유지)"
+
+# --------------------------------------------------
+# 5. RDS Multi-AZ OFF (트리거만)
+# --------------------------------------------------
+echo ""
+echo "[5/5] RDS Multi-AZ 비활성화 트리거 중..."
+aws rds modify-db-instance --db-instance-identifier "$RDS_IDENTIFIER" \
+  --no-multi-az --apply-immediately \
+  --region "$AWS_REGION" --profile "$AWS_PROFILE" > /dev/null
+echo "  ✅ RDS Multi-AZ 비활성화 트리거 완료 (실제 완료는 수십분, 콘솔 확인)"
+
+echo ""
+echo "=========================================="
+echo "  ✅ season-down 완료"
+echo ""
+echo "  수동 확인:"
+echo "  - https://api.bigdataboaz.com/actuator/health 정상 응답"
+echo "  - Target Group에 EC2-A만 healthy"
+echo "  - RDS Multi-AZ 비활성화 완료 (콘솔)"
+echo "  - EC2-B stopped"
+echo "=========================================="

--- a/infra/scripts/season-up.sh
+++ b/infra/scripts/season-up.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+# =====================================================
+# season-up.sh — 모집 시즌 시작
+# 실행: ./season-up.sh
+# 사전 조건: AWS CLI + tf 프로파일, conda boaz-ops 환경 활성화
+# =====================================================
+set -eo pipefail
+
+export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL="*"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AWS_REGION="ap-northeast-2"
+AWS_PROFILE="${AWS_PROFILE:-tf}"
+
+# Python 인터프리터 탐색 (WindowsApps 스텁 제외)
+PYTHON=""
+for cmd in py python3 python; do
+  _path=$(command -v "$cmd" 2>/dev/null || true)
+  if [ -n "$_path" ] && ! echo "$_path" | grep -qi "WindowsApps"; then
+    PYTHON="$cmd"
+    break
+  fi
+done
+if [ -z "$PYTHON" ]; then
+  echo "❌ Python을 찾지 못함. conda activate boaz-ops 후 재실행."
+  exit 1
+fi
+
+echo "=========================================="
+echo "  BOAZ 모집 시즌 시작 (season-up)"
+echo "=========================================="
+
+# --------------------------------------------------
+# 0. SSM 설정 로드
+# --------------------------------------------------
+echo ""
+echo "[0/7] SSM Parameter Store에서 설정 로드 중..."
+
+ssm_get() {
+  aws ssm get-parameter --name "/boaz/infra/$1" \
+    --region "$AWS_REGION" --profile "$AWS_PROFILE" \
+    --query "Parameter.Value" --output text
+}
+
+EC2_B_ID=$(ssm_get "EC2_B_ID")
+EC2_A_DOMAIN=$(ssm_get "EC2_A_DOMAIN")
+CLOUDFRONT_DIST_ID=$(ssm_get "CLOUDFRONT_DIST_ID")
+RDS_IDENTIFIER=$(ssm_get "RDS_IDENTIFIER")
+CODEDEPLOY_APP=$(ssm_get "CODEDEPLOY_APP")
+CODEDEPLOY_GROUP=$(ssm_get "CODEDEPLOY_GROUP")
+TARGET_GROUP_ARN=$(ssm_get "TARGET_GROUP_ARN")
+ALB_SG_ID=$(ssm_get "ALB_SG_ID")
+ALB_SUBNETS=$(ssm_get "ALB_SUBNETS")
+ALB_PORT=$(ssm_get "ALB_PORT")
+
+echo "  ✅ 설정 로드 완료"
+
+# --------------------------------------------------
+# 1. EC2-B 시작
+# --------------------------------------------------
+echo ""
+echo "[1/7] EC2-B 시작 중... ($EC2_B_ID)"
+aws ec2 start-instances --instance-ids "$EC2_B_ID" \
+  --region "$AWS_REGION" --profile "$AWS_PROFILE" > /dev/null
+aws ec2 wait instance-running --instance-ids "$EC2_B_ID" \
+  --region "$AWS_REGION" --profile "$AWS_PROFILE"
+echo "  ✅ EC2-B running"
+
+# --------------------------------------------------
+# 2. CodeDeploy 배포 (마지막 성공 배포 재실행 → EC2-A/B 모두 최신화)
+# --------------------------------------------------
+echo ""
+echo "[2/7] CodeDeploy 배포 트리거 중..."
+
+LAST_DEPLOY_ID=$(aws deploy list-deployments \
+  --application-name "$CODEDEPLOY_APP" \
+  --deployment-group-name "$CODEDEPLOY_GROUP" \
+  --include-only-statuses Succeeded \
+  --region "$AWS_REGION" --profile "$AWS_PROFILE" \
+  --query 'deployments[0]' --output text)
+
+BUNDLE_BUCKET=$(aws deploy get-deployment --deployment-id "$LAST_DEPLOY_ID" \
+  --region "$AWS_REGION" --profile "$AWS_PROFILE" \
+  --query 'deploymentInfo.revision.s3Location.bucket' --output text)
+BUNDLE_KEY=$(aws deploy get-deployment --deployment-id "$LAST_DEPLOY_ID" \
+  --region "$AWS_REGION" --profile "$AWS_PROFILE" \
+  --query 'deploymentInfo.revision.s3Location.key' --output text)
+
+echo "  → 번들: s3://$BUNDLE_BUCKET/$BUNDLE_KEY"
+
+DEPLOYMENT_ID=$(aws deploy create-deployment \
+  --application-name "$CODEDEPLOY_APP" \
+  --deployment-group-name "$CODEDEPLOY_GROUP" \
+  --deployment-config-name CodeDeployDefault.OneAtATime \
+  --s3-location "bucket=$BUNDLE_BUCKET,key=$BUNDLE_KEY,bundleType=zip" \
+  --region "$AWS_REGION" --profile "$AWS_PROFILE" \
+  --query 'deploymentId' --output text)
+
+echo "  → 배포 ID: $DEPLOYMENT_ID (대기 중, 수분 소요)"
+aws deploy wait deployment-successful --deployment-id "$DEPLOYMENT_ID" \
+  --region "$AWS_REGION" --profile "$AWS_PROFILE"
+echo "  ✅ CodeDeploy 배포 완료"
+
+# --------------------------------------------------
+# 3. ALB 생성 + Listener 추가 (Target Group 연결)
+#    Target은 ALB가 연결되어야 health check가 시작됨
+# --------------------------------------------------
+echo ""
+echo "[3/7] ALB 생성 중..."
+
+SUBNET_ARGS=$(echo "$ALB_SUBNETS" | tr ',' ' ')
+ALB_ARN=$(aws elbv2 create-load-balancer \
+  --name "boaz-alb" \
+  --type application \
+  --scheme internet-facing \
+  --ip-address-type ipv4 \
+  --subnets $SUBNET_ARGS \
+  --security-groups "$ALB_SG_ID" \
+  --region "$AWS_REGION" --profile "$AWS_PROFILE" \
+  --query 'LoadBalancers[0].LoadBalancerArn' --output text)
+
+echo "  → ALB ARN: $ALB_ARN"
+echo "  → active 상태 대기 중..."
+aws elbv2 wait load-balancer-available --load-balancer-arns "$ALB_ARN" \
+  --region "$AWS_REGION" --profile "$AWS_PROFILE"
+
+ALB_DNS=$(aws elbv2 describe-load-balancers --load-balancer-arns "$ALB_ARN" \
+  --region "$AWS_REGION" --profile "$AWS_PROFILE" \
+  --query 'LoadBalancers[0].DNSName' --output text)
+echo "  → ALB DNS: $ALB_DNS"
+
+echo "  → Listener 추가 중 (HTTP $ALB_PORT → Target Group)..."
+aws elbv2 create-listener --load-balancer-arn "$ALB_ARN" \
+  --protocol HTTP --port "$ALB_PORT" \
+  --default-actions "Type=forward,TargetGroupArn=$TARGET_GROUP_ARN" \
+  --region "$AWS_REGION" --profile "$AWS_PROFILE" > /dev/null
+echo "  ✅ ALB 준비 완료"
+
+# --------------------------------------------------
+# 4. EC2-B를 Target Group에 등록 + healthy 대기
+#    EC2-A는 영구 등록되어 있어 ALB 붙는 즉시 healthy
+# --------------------------------------------------
+echo ""
+echo "[4/7] EC2-B를 Target Group에 등록 중..."
+aws elbv2 register-targets --target-group-arn "$TARGET_GROUP_ARN" \
+  --targets "Id=$EC2_B_ID" \
+  --region "$AWS_REGION" --profile "$AWS_PROFILE"
+
+echo "  → EC2-A/B 모두 healthy 대기 중 (~2분)..."
+aws elbv2 wait target-in-service --target-group-arn "$TARGET_GROUP_ARN" \
+  --region "$AWS_REGION" --profile "$AWS_PROFILE"
+echo "  ✅ Target 모두 healthy"
+
+# --------------------------------------------------
+# 5. CloudFront origin 교체 (EC2-A → ALB)
+# --------------------------------------------------
+echo ""
+echo "[5/7] CloudFront origin을 ALB로 교체 중..."
+
+CF_SCRIPT=$(cygpath -w "$SCRIPT_DIR/cf_set_origin.py")
+ETAG=$(aws cloudfront get-distribution-config --id "$CLOUDFRONT_DIST_ID" \
+  --profile "$AWS_PROFILE" --query 'ETag' --output text)
+DIST_CONFIG=$(aws cloudfront get-distribution-config --id "$CLOUDFRONT_DIST_ID" \
+  --profile "$AWS_PROFILE" --query 'DistributionConfig' --output json)
+
+NEW_CONFIG=$(NEW_DOMAIN="$ALB_DNS" NEW_HTTP_PORT="$ALB_PORT" \
+  "$PYTHON" "$CF_SCRIPT" <<< "$DIST_CONFIG")
+
+aws cloudfront update-distribution --id "$CLOUDFRONT_DIST_ID" \
+  --distribution-config "$NEW_CONFIG" \
+  --if-match "$ETAG" \
+  --profile "$AWS_PROFILE" > /dev/null
+echo "  ✅ CloudFront origin 교체 완료 (전파 5~15분)"
+
+# --------------------------------------------------
+# 6. RDS Multi-AZ ON (트리거만)
+# --------------------------------------------------
+echo ""
+echo "[6/7] RDS Multi-AZ 활성화 트리거 중..."
+aws rds modify-db-instance --db-instance-identifier "$RDS_IDENTIFIER" \
+  --multi-az --apply-immediately \
+  --region "$AWS_REGION" --profile "$AWS_PROFILE" > /dev/null
+echo "  ✅ RDS Multi-AZ 트리거 완료 (실제 완료는 수십분, 콘솔 확인)"
+
+# --------------------------------------------------
+# 7. 헬스체크 (직접 ALB 호출은 SG 차단됨 → CloudFront 통해 확인)
+# --------------------------------------------------
+echo ""
+echo "[7/7] 전파 후 헬스체크 안내"
+echo "  CloudFront 전파(5~15분) 후 직접 확인:"
+echo "    curl https://api.bigdataboaz.com/actuator/health"
+
+echo ""
+echo "=========================================="
+echo "  ✅ season-up 완료"
+echo ""
+echo "  수동 확인:"
+echo "  - CloudFront 전파 완료 후 https://api.bigdataboaz.com 동작"
+echo "  - Target Group에 EC2-A/B 모두 healthy"
+echo "  - RDS Multi-AZ 전환 (콘솔)"
+echo "=========================================="


### PR DESCRIPTION
## 💡 개요

* Issue Number: #105

모집 시즌(연 2회, 각 2주) 동안 ALB + 2 EC2 active-active HA 구조로 자동 전환하고, 시즌 종료 시 단일 EC2 평시 구성으로 복귀하는 운영 스크립트를 추가합니다.

## 🪐 주요 변경 사항

- `infra/scripts/season-up.sh` — 모집 시즌 시작 자동화 (EC2-B 가동 → 배포 → ALB 생성 → CloudFront origin 교체 → RDS Multi-AZ ON)
- `infra/scripts/season-down.sh` — 모집 시즌 종료 자동화 (CloudFront origin 복귀 → ALB 삭제 → EC2-B 중지 → RDS Multi-AZ OFF)
- `infra/scripts/register-ssm-params.sh` — 인프라 설정값 12개를 SSM Parameter Store에 등록
- `infra/scripts/cf_set_origin.py` — CloudFront 단일 origin의 도메인/포트를 교체하는 헬퍼
- `infra/scripts/README.md` — 아키텍처 변화, 단계별 흐름, 값 관리 정책, 실행 가이드, 수동 롤백 가이드

## ✅ 상세 내용

### 아키텍처 변화

| 상태 | 트래픽 경로 |
|------|-------------|
| 평시 | Route53 → CloudFront → EC2-A (8080) → RDS (single-AZ) |
| 시즌 중 | Route53 → CloudFront → ALB (80) → EC2-A/B (8080) → RDS (Multi-AZ) |

### season-up.sh (7단계, 약 10~12분)

0. SSM에서 인프라 설정 12개 로드
1. EC2-B start (running 대기)
2. CodeDeploy 마지막 성공 배포 재실행 (EC2-A/B 모두 최신화)
3. ALB 생성 + listener(HTTP 80) 추가
4. EC2-B를 Target Group에 등록 + EC2-A/B 모두 healthy 대기
5. CloudFront origin을 EC2-A 직결 → ALB DNS로 교체 (port 8080 → 80)
6. RDS Multi-AZ ON 트리거

### season-down.sh (5단계, 약 6~20분)

0. SSM에서 인프라 설정 로드
1. CloudFront origin을 ALB → EC2-A 직결로 복귀 (port 80 → 8080)
2. CloudFront `Deployed` 상태 폴링 (전파 완료 대기 후 ALB 삭제 진행 — edge 캐시가 ALB 가리키는 동안 ALB 삭제하면 502 발생 가능)
3. ALB 삭제 (listener 동시 삭제)
4. EC2-B를 Target Group에서 deregister + stop
5. RDS Multi-AZ OFF 트리거

### 값 관리 정책

- **고정값(SSM `/boaz/infra/*` 12개)**: 인프라 식별자/설정. `register-ssm-params.sh`로 등록·갱신.
- **동적값(스크립트 런타임 조회)**: `ALB_ARN`, `ALB_DNS`, `LAST_DEPLOY_ID`, `DEPLOYMENT_ID`, `ETAG`, `DIST_CONFIG` 등. stale 위험을 피하기 위해 의도적으로 저장하지 않음.

### 영구 유지 인프라 (스크립트가 매 시즌 재사용 — 삭제 금지)

- Target Group `boaz-api-tg` (EC2-A 영구 등록)
- ALB Security Group `boaz-alb-sg` (CloudFront prefix list만 inbound 허용)
- EC2 SG의 ALB SG → 8080 인바운드 룰
- EC2-B 인스턴스 (stopped 상태로 ID 보존)

### 시즌마다 생성/삭제 리소스

- ALB `boaz-alb` (DNS는 매번 달라짐 → CloudFront에 자동 반영)
- EC2-B의 Target Group 등록 상태
- RDS Multi-AZ 토글

## 🔔 참고 사항

- **테스트 결과**: season-up / season-down 양쪽 모두 실제 운영 환경에서 1회 검증 완료. ALB 생성·삭제, CloudFront origin 교체, EC2-B 라이프사이클, RDS Multi-AZ 토글 정상 동작 확인.
- **실행 환경**: Windows Git Bash + AWS CLI(`tf` 프로파일) + conda 가상환경(`boaz-ops`) 활성화 상태에서 실행. 자세한 사전 준비는 README 참고.
- **잠재적 다운타임**: season-up Step 2의 CodeDeploy(`OneAtATime`)가 EC2-A를 재배포하는 동안 ~30초 5xx 가능. **트래픽 적은 시간대(예: 새벽) 실행 권장.**
- **CloudFront 전파**: origin 교체 후 전파에 5~15분 소요. season-down은 전파 완료까지 폴링 후 ALB 삭제 진행.
- **CRLF 경고**: 스크립트들은 로컬 Git Bash에서만 실행되므로 줄바꿈 변환 경고는 무시 가능.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 변경 목적
모집 시즌(연 2회, 각 2주) 기간 동안 단일 EC2 구성에서 ALB + 2 EC2 active-active HA 구성으로 자동 전환하고, 시즌 종료 시 원래 구성으로 복귀하는 운영 자동화 스크립트 및 관련 문서를 추가한다.

## 주요 변경 내용

- **`infra/scripts/season-up.sh` (202줄)**: 시즌 시작 자동화 스크립트
  - SSM Parameter Store에서 리소스 ID/설정값 로드
  - EC2-B 인스턴스 시작 및 CodeDeploy 배포 재실행
  - ALB 생성 및 리스너 추가, Target Group 등록
  - CloudFront origin을 EC2-A에서 ALB로 교체 (포트 8080 → 80)
  - RDS Multi-AZ 활성화
  - 전체 소요 시간: 약 10~12분

- **`infra/scripts/season-down.sh` (142줄)**: 시즌 종료 자동화 스크립트
  - CloudFront origin을 ALB에서 EC2-A로 복귀 (포트 80 → 8080)
  - CloudFront distribution 상태 폴링 대기
  - ALB 및 리스너 삭제
  - EC2-B deregister 및 인스턴스 중지
  - RDS Multi-AZ 비활성화
  - 전체 소요 시간: 약 6~20분

- **`infra/scripts/register-ssm-params.sh` (108줄)**: SSM Parameter Store 일괄 등록 스크립트
  - `/boaz/infra/` 하위 12개 파라미터 등록/갱신 (EC2, RDS, CodeDeploy, ALB/Target Group 관련 설정값)
  - Windows Git Bash(MSYS) 경로 변환 비활성화

- **`infra/scripts/cf_set_origin.py` (29줄)**: CloudFront origin 교체 헬퍼 도구
  - 표준입력 JSON(Distribution Config)에서 단일 origin의 도메인/포트 치환
  - 수정된 JSON을 표준출력으로 반환

- **`infra/scripts/README.md` (300줄)**: 아키텍처 및 운영 가이드 문서
  - 시즌 전환 아키텍처 및 단계별 실행 흐름 설명
  - 영구 유지 리소스(Target Group, ALB SG, SSM 파라미터 등) vs 시즌마다 생성/삭제 리소스(ALB) 구분 명시
  - 고정값(SSM 파라미터 표)과 동적값(런타임 조회 항목) 관리 정책
  - 실행 준비, 검증 커맨드, 수동 롤백 체크리스트 포함

## 영향 범위

- **설정 변경**: SSM Parameter Store에 12개 새 파라미터 추가 (`/boaz/infra/ec2_a_id`, `/boaz/infra/target_group_arn` 등)
- **인프라 구성 변경**: 시즌 기간 ALB 생성/삭제, Target Group 등록/해제, RDS Multi-AZ 토글, CloudFront origin 변경
- **API 변경**: 없음
- **DB 스키마 변경**: 없음

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BOAZ-website/backend/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->