### PR TITLE
[Fix] 지원서 CSV 추출 오류 수정

### DIFF
--- a/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantRepository.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantRepository.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.boaz.backend.domain.recruitment.entity.Applicant;
 import com.boaz.backend.global.common.enums.Track;
@@ -20,9 +22,14 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
     Optional<Applicant> findByRecruitmentIdAndUserId(Long recruitmentId, Long userId);
 
     // recruitment_id + track + status 기반 조회 (CSV 다운로드용)
-    List<Applicant> findByRecruitmentIdAndTrackAndStatus(
-            Long recruitmentId,
-            Track track,
-            Applicant.ApplicantStatus status
+    // - JOIN FETCH a.user: user_id 접근 시 N+1 방지
+    // - ORDER BY a.submittedAt ASC: 제출 순 정렬 (DRAFT 생성 시점과 분리)
+    @Query("SELECT a FROM Applicant a JOIN FETCH a.user " +
+           "WHERE a.recruitment.id = :recruitmentId AND a.track = :track AND a.status = :status " +
+           "ORDER BY a.submittedAt ASC")
+    List<Applicant> findSubmittedByRecruitmentIdAndTrackOrderBySubmittedAt(
+            @Param("recruitmentId") Long recruitmentId,
+            @Param("track") Track track,
+            @Param("status") Applicant.ApplicantStatus status
     );
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/CsvService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/CsvService.java
@@ -20,7 +20,7 @@ public class CsvService {
     private final ObjectMapper objectMapper;
 
     private static final List<String> BASE_HEADERS = List.of(
-            "지원 부문", "성명", "이메일 주소", "전화번호", "대학교", "본전공",
+            "user_id", "지원 부문", "성명", "이메일 주소", "전화번호", "대학교", "본전공",
             "복수/부전공", "마지막 재학 학기", "병역 이수 여부", "생년월일",
             "졸업 예정 시점", "대학원 진학 여부", "지원서 제출 일시"
     );
@@ -59,6 +59,7 @@ public class CsvService {
             // 지원자별 행 작성
             for (Applicant applicant : applicants) {
                 List<String> row = new ArrayList<>();
+                row.add(applicant.getUser().getId().toString());
                 row.add(applicant.getTrack() != null ? applicant.getTrack().name() : "");
                 row.add(applicant.getName());
                 row.add(applicant.getEmail());
@@ -71,7 +72,7 @@ public class CsvService {
                 row.add(applicant.getBirthDate() != null ? applicant.getBirthDate().toString() : "");
                 row.add(applicant.getGraduationDate() != null ? applicant.getGraduationDate() : "");
                 row.add(applicant.getGradSchoolPlan() != null ? (applicant.getGradSchoolPlan() ? "Y" : "N") : "");
-                row.add(applicant.getCreatedAt().toString());
+                row.add(applicant.getSubmittedAt() != null ? applicant.getSubmittedAt().toString() : "");
 
                 Map<Long, ApplicantAnswer> applicantAnswers = answerMap.getOrDefault(applicant.getId(), Collections.emptyMap());
                 for (Long questionId : questionIds) {

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -560,9 +560,9 @@ public class RecruitmentService {
         // 부문별 CSV 생성 및 S3 업로드
         for (Track track : List.of(Track.VISUALIZATION, Track.ANALYSIS, Track.ENGINEERING)) {
 
-            // 해당 부문 제출된 지원자 조회
+            // 해당 부문 제출된 지원자 조회 (submittedAt 오름차순 + user JOIN FETCH)
             List<Applicant> applicants = applicantRepository
-                    .findByRecruitmentIdAndTrackAndStatus(
+                    .findSubmittedByRecruitmentIdAndTrackOrderBySubmittedAt(
                             recruitment.getId(), track, Applicant.ApplicantStatus.SUBMITTED);
 
             // 공통 + 해당 부문 질문 조회

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -44,7 +44,7 @@ VALUES (4, 'kakao', 'dummy_kakao_004', '스웨거테스터', 'OUTSIDER', NOW(), 
 -- recruitment 임시 데이터
 -- id=1: 26기 (종료된 공고) - 어드민 CSV 다운로드 테스트용
 INSERT INTO recruitment (id, term, start_date, end_date, schedule, brochure_url, created_at, updated_at)
-VALUES (1, 26, '2026-03-01 00:00:00', '2026-04-29 23:59:59',
+VALUES (1, 26, '2026-03-01 00:00:00', '2026-06-30 23:59:59',
 '[
   { "step": "서류 모집", "start": "2026-03-01", "end": "2026-03-29", "sequence": 1 },
   { "step": "서류 합격 발표", "start": "2026-04-04", "end": "2026-04-04", "sequence": 2 },
@@ -54,7 +54,7 @@ VALUES (1, 26, '2026-03-01 00:00:00', '2026-04-29 23:59:59',
 
 -- id=2: 27기 (현재 활성) - User API 테스트용 (지원서 제출/임시저장/조회)
 INSERT INTO recruitment (id, term, start_date, end_date, schedule, brochure_url, created_at, updated_at)
-VALUES (2, 27, '2026-05-01 00:00:00', '2026-08-31 23:59:59',
+VALUES (2, 27, '2026-08-01 00:00:00', '2026-08-31 23:59:59',
 '[
   { "step": "서류 모집", "start": "2026-05-01", "end": "2026-08-31", "sequence": 1 },
   { "step": "서류 합격 발표", "start": "2026-09-05", "end": "2026-09-05", "sequence": 2 },


### PR DESCRIPTION
## 💡 개요

* Issue Number: #126

## 🪐 주요 변경 사항
- CSV 첫 번째 컬럼에 `user_id` 추가
- "지원서 제출 일시" 컬럼을 `createdAt` → `submittedAt` 으로 교체
- CSV 다운로드용 쿼리에 `JOIN FETCH a.user` + `ORDER BY a.submittedAt ASC` 적용

## ✅ 상세 내용
- DRAFT 기능 도입 이후 `createdAt`(DRAFT 최초 생성 시점)과 `submittedAt`(실제 제출 시점)이 달라졌으므로 제출 일시 컬럼 교체
- `user_id`는 합격자 승격 Admin API(#127) 개발 시 admin이 대상 유저를 식별하기 위해 사용
- 기존 `findByRecruitmentIdAndTrackAndStatus`는 `user` lazy load 시 N+1 발생 가능 + 정렬 미적용 상태였으므로 `@Query`로 교체

## 🔔 참고 사항
- 변경 파일: `ApplicantRepository`, `CsvService`, `RecruitmentService`
- 후속 이슈: #127 합격자 승격 Admin API