### PR TITLE
[Feat] 합격자 벌크 승격 API 구현 (PATCH /api/v1/admin/users/promote)

### DIFF
--- a/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantRepository.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantRepository.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.boaz.backend.domain.recruitment.entity.Applicant;
 import com.boaz.backend.global.common.enums.Track;
@@ -24,5 +26,12 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
             Long recruitmentId,
             Track track,
             Applicant.ApplicantStatus status
+    );
+
+    // userId + status 기반 조회 (합격자 승격용, recruitment JOIN FETCH로 term 접근)
+    @Query("SELECT a FROM Applicant a JOIN FETCH a.recruitment WHERE a.user.id = :userId AND a.status = :status")
+    Optional<Applicant> findByUserIdAndStatus(
+            @Param("userId") Long userId,
+            @Param("status") Applicant.ApplicantStatus status
     );
 }

--- a/src/main/java/com/boaz/backend/domain/user/controller/UserAdminController.java
+++ b/src/main/java/com/boaz/backend/domain/user/controller/UserAdminController.java
@@ -1,0 +1,39 @@
+package com.boaz.backend.domain.user.controller;
+
+import com.boaz.backend.domain.user.dto.request.PromoteUsersRequest;
+import com.boaz.backend.domain.user.dto.response.PromoteUsersResponse;
+import com.boaz.backend.domain.user.service.UserAdminService;
+import com.boaz.backend.global.common.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "[Admin] User", description = "Admin 전용 유저 관리 API")
+@SecurityRequirement(name = "bearerAuth")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/users")
+public class UserAdminController {
+
+    private final UserAdminService userAdminService;
+
+    @Operation(
+            summary = "합격자 승격",
+            description = "합격자 userIds를 받아 memberType을 MEMBER로 변경하고 지원서 개인정보를 User에 복사한다. " +
+                          "비즈니스 오류가 발생한 userId는 skip하고 failedUserIds에 포함하여 반환한다."
+    )
+    @PatchMapping("/promote")
+    public ResponseEntity<ApiResponse<PromoteUsersResponse>> promoteUsers(
+            @RequestBody @Valid PromoteUsersRequest request) {
+        return ResponseEntity.ok(ApiResponse.ok(userAdminService.bulkPromote(request.getUserIds())));
+    }
+}

--- a/src/main/java/com/boaz/backend/domain/user/dto/request/PromoteUsersRequest.java
+++ b/src/main/java/com/boaz/backend/domain/user/dto/request/PromoteUsersRequest.java
@@ -2,6 +2,8 @@ package com.boaz.backend.domain.user.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -13,5 +15,9 @@ public class PromoteUsersRequest {
 
     @Schema(description = "승격할 유저 ID 목록", example = "[1, 2, 3, 48]")
     @NotEmpty(message = "승격할 유저 ID 목록을 입력해주세요.")
-    private List<Long> userIds;
+    private List<
+            @NotNull(message = "유저 ID는 null일 수 없습니다.")
+            @Positive(message = "유저 ID는 1 이상이어야 합니다.")
+            Long
+            > userIds;
 }

--- a/src/main/java/com/boaz/backend/domain/user/dto/request/PromoteUsersRequest.java
+++ b/src/main/java/com/boaz/backend/domain/user/dto/request/PromoteUsersRequest.java
@@ -1,5 +1,6 @@
 package com.boaz.backend.domain.user.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,7 @@ import java.util.List;
 @NoArgsConstructor
 public class PromoteUsersRequest {
 
+    @Schema(description = "승격할 유저 ID 목록", example = "[1, 2, 3, 48]")
     @NotEmpty(message = "승격할 유저 ID 목록을 입력해주세요.")
     private List<Long> userIds;
 }

--- a/src/main/java/com/boaz/backend/domain/user/dto/request/PromoteUsersRequest.java
+++ b/src/main/java/com/boaz/backend/domain/user/dto/request/PromoteUsersRequest.java
@@ -1,0 +1,15 @@
+package com.boaz.backend.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class PromoteUsersRequest {
+
+    @NotEmpty(message = "승격할 유저 ID 목록을 입력해주세요.")
+    private List<Long> userIds;
+}

--- a/src/main/java/com/boaz/backend/domain/user/dto/response/PromoteUsersResponse.java
+++ b/src/main/java/com/boaz/backend/domain/user/dto/response/PromoteUsersResponse.java
@@ -1,5 +1,6 @@
 package com.boaz.backend.domain.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 import java.util.List;
@@ -7,6 +8,7 @@ import java.util.List;
 @Getter
 public class PromoteUsersResponse {
 
+    @Schema(description = "승격 실패한 유저 ID 목록 및 사유")
     private final List<FailedUserInfo> failedUserIds;
 
     private PromoteUsersResponse(List<FailedUserInfo> failedUserIds) {
@@ -19,7 +21,11 @@ public class PromoteUsersResponse {
 
     @Getter
     public static class FailedUserInfo {
+
+        @Schema(description = "유저 ID", example = "5")
         private final Long userId;
+
+        @Schema(description = "에러 코드", example = "USER_NOT_FOUND")
         private final String errorCode;
 
         public FailedUserInfo(Long userId, String errorCode) {

--- a/src/main/java/com/boaz/backend/domain/user/dto/response/PromoteUsersResponse.java
+++ b/src/main/java/com/boaz/backend/domain/user/dto/response/PromoteUsersResponse.java
@@ -1,0 +1,30 @@
+package com.boaz.backend.domain.user.dto.response;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class PromoteUsersResponse {
+
+    private final List<FailedUserInfo> failedUserIds;
+
+    private PromoteUsersResponse(List<FailedUserInfo> failedUserIds) {
+        this.failedUserIds = failedUserIds;
+    }
+
+    public static PromoteUsersResponse of(List<FailedUserInfo> failedUserIds) {
+        return new PromoteUsersResponse(failedUserIds);
+    }
+
+    @Getter
+    public static class FailedUserInfo {
+        private final Long userId;
+        private final String errorCode;
+
+        public FailedUserInfo(Long userId, String errorCode) {
+            this.userId = userId;
+            this.errorCode = errorCode;
+        }
+    }
+}

--- a/src/main/java/com/boaz/backend/domain/user/entity/User.java
+++ b/src/main/java/com/boaz/backend/domain/user/entity/User.java
@@ -53,4 +53,15 @@ public class User extends BaseEntity {
         this.nickname = nickname;
         this.memberType = memberType;
     }
+
+    // 합격자 승격: memberType → MEMBER, 지원서 개인정보 복사
+    public void promote(String name, String phone, String university, String major, Track track, Integer term) {
+        this.memberType = MemberType.MEMBER;
+        this.name = name;
+        this.phone = phone;
+        this.university = university;
+        this.major = major;
+        this.track = track;
+        this.term = term;
+    }
 }

--- a/src/main/java/com/boaz/backend/domain/user/service/UserAdminService.java
+++ b/src/main/java/com/boaz/backend/domain/user/service/UserAdminService.java
@@ -1,0 +1,70 @@
+package com.boaz.backend.domain.user.service;
+
+import com.boaz.backend.domain.recruitment.entity.Applicant;
+import com.boaz.backend.domain.recruitment.repository.ApplicantRepository;
+import com.boaz.backend.domain.user.dto.response.PromoteUsersResponse;
+import com.boaz.backend.domain.user.entity.User;
+import com.boaz.backend.domain.user.repository.UserRepository;
+import com.boaz.backend.global.common.enums.MemberType;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserAdminService {
+
+    private final UserRepository userRepository;
+    private final ApplicantRepository applicantRepository;
+    private final TransactionTemplate transactionTemplate;
+
+    public PromoteUsersResponse bulkPromote(List<Long> userIds) {
+        List<PromoteUsersResponse.FailedUserInfo> failed = new ArrayList<>();
+
+        for (Long userId : userIds) {
+            try {
+                transactionTemplate.execute(status -> {
+                    promoteOne(userId);
+                    return null;
+                });
+            } catch (CustomException e) {
+                // 비즈니스 오류: skip 후 실패 목록에 추가
+                failed.add(new PromoteUsersResponse.FailedUserInfo(userId, e.getErrorCode().getCode()));
+            }
+            // RuntimeException(서버 오류)은 그대로 전파 → 즉시 중단
+        }
+
+        return PromoteUsersResponse.of(failed);
+    }
+
+    private void promoteOne(Long userId) {
+        // 유저 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 이미 MEMBER인 경우
+        if (user.getMemberType() == MemberType.MEMBER) {
+            throw new CustomException(ErrorCode.ALREADY_MEMBER);
+        }
+
+        // SUBMITTED 지원서 조회 (recruitment JOIN FETCH로 term 접근)
+        Applicant applicant = applicantRepository
+                .findByUserIdAndStatus(userId, Applicant.ApplicantStatus.SUBMITTED)
+                .orElseThrow(() -> new CustomException(ErrorCode.APPLICATION_NOT_FOUND));
+
+        // 승격: 지원서 개인정보 → User 복사 + memberType → MEMBER
+        user.promote(
+                applicant.getName(),
+                applicant.getPhone(),
+                applicant.getUniversity(),
+                applicant.getMajor(),
+                applicant.getTrack(),
+                applicant.getRecruitment().getTerm()
+        );
+    }
+}

--- a/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
 
     // User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
+    ALREADY_MEMBER(HttpStatus.CONFLICT, "ALREADY_MEMBER", "이미 동아리원으로 등록된 유저입니다."),
 
     // Admin
     ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND, "ADMIN_NOT_FOUND", "해당 계정을 찾을 수 없습니다."),

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -62,7 +62,7 @@ VALUES (2, 27, '2026-08-01 00:00:00', '2026-08-31 23:59:59',
   { "step": "최종 합격 발표", "start": "2026-09-12", "end": "2026-09-12", "sequence": 4 }
 ]', 'https://example.com/brochure27.pdf', NOW(), NOW());
 
--- application_question 임시 데이터 (recruitment_id = 1, 26기)
+-- application_question 임시 데이터 (recruitment_id = 1, 26기 - 현재 활성, Swagger 테스트용)
 INSERT INTO application_question (id, recruitment_id, category, type, label, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
 VALUES (1, 1, 'COMMON', 'TEXT', 'COMMON1', 'RECRUITMENT 동기는 무엇인가요? (500자 이내)', null, 500, 1, true, NOW(), NOW());
 
@@ -90,7 +90,7 @@ VALUES (8, 1, 'ANALYSIS', 'TEXT', 'ANALYSIS1', '[빅데이터 / 인공지능 / �
 INSERT INTO application_question (id, recruitment_id, category, type, label, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
 VALUES (9, 1, 'ANALYSIS', 'TEXT', 'ANALYSIS2', '본인이 진행했던 [머신러닝 / 딥러닝 / 데이터ANALYSIS] 관련 PROJECT를 소개.. (700자 이내)', null, 700, 11, true, NOW(), NOW());
 
--- application_question 임시 데이터 (recruitment_id = 2, 27기 - 현재 활성, Swagger 테스트용)
+-- application_question 임시 데이터 (recruitment_id = 2, 27기)
 INSERT INTO application_question (id, recruitment_id, category, type, label, content, metadata, limit_length, order_num, is_required, created_at, updated_at)
 VALUES (10, 2, 'COMMON', 'TEXT', 'COMMON1', 'BOAZ에 지원하게 된 동기를 작성해주세요. (500자 이내)', null, 500, 1, true, NOW(), NOW());
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -27,8 +27,6 @@ INSERT INTO admin (username, password, role, name, track, term, team_name, creat
 VALUES ('boaz_team', '$2a$10$7GogA3bv05pd830JHPishOFHtneEqmpZgE2s9fZuoARQxDZGg6N.y', 'TEAM', '이보아즈', 'ANALYSIS', 27, '서비스운영팀', 1, NOW(), NOW());
 
 -- users 임시 데이터
--- id=1~3: 기존 테스트 지원자에 대응하는 더미 유저
--- id=4: Swagger API 테스트용 (지원서 없음 → submit/draft 흐름 테스트)
 INSERT INTO users (id, provider, provider_id, nickname, member_type, created_at, updated_at)
 VALUES (1, 'kakao', 'dummy_kakao_001', '김엔지', 'OUTSIDER', NOW(), NOW());
 
@@ -42,7 +40,7 @@ INSERT INTO users (id, provider, provider_id, nickname, member_type, created_at,
 VALUES (4, 'kakao', 'dummy_kakao_004', '스웨거테스터', 'OUTSIDER', NOW(), NOW());
 
 -- recruitment 임시 데이터
--- id=1: 26기 (종료된 공고) - 어드민 CSV 다운로드 테스트용
+-- id=1: 26기
 INSERT INTO recruitment (id, term, start_date, end_date, schedule, brochure_url, created_at, updated_at)
 VALUES (1, 26, '2026-03-01 00:00:00', '2026-06-30 23:59:59',
 '[
@@ -52,7 +50,7 @@ VALUES (1, 26, '2026-03-01 00:00:00', '2026-06-30 23:59:59',
   { "step": "최종 합격 발표", "start": "2026-04-10", "end": "2026-04-10", "sequence": 4 }
 ]', 'https://example.com/brochure.pdf', NOW(), NOW());
 
--- id=2: 27기 (현재 활성) - User API 테스트용 (지원서 제출/임시저장/조회)
+-- id=2: 27기
 INSERT INTO recruitment (id, term, start_date, end_date, schedule, brochure_url, created_at, updated_at)
 VALUES (2, 27, '2026-08-01 00:00:00', '2026-08-31 23:59:59',
 '[
@@ -167,7 +165,7 @@ VALUES (15, 26, 'ACTIVITY', '26기 데이터 ENGINEERING 워크샵', NULL, 'ENGI
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (16, 26, 'ACTIVITY', '26기 데이터 VISUALIZATION 세션', NULL, 'VISUALIZATION', 'https://example.com/activity5.png', '{"instagram":"https://instagram.com/p/example5","youtube":"https://youtube.com/watch?v=visualization-session"}', '2025-04-15', NOW(), NOW());
 
--- applicant 임시 데이터 (26기 recruitment_id=1, 종료된 공고 - 어드민 CSV 다운로드 테스트용)
+-- applicant 임시 데이터
 -- user OneToOne 적용: user_id=1~3 각 트랙 1명씩
 -- status=SUBMITTED, submitted_at 설정
 INSERT INTO applicants (id, recruitment_id, user_id, status, track, name, email, phone, university, major, minor_double_major, last_semester, military_status, birth_date, graduation_date, grad_school_plan, submitted_at, created_at, updated_at)


### PR DESCRIPTION
## 💡 개요

* Issue Number: #127

## 🪐 주요 변경 사항
- 합격자 벌크 승격 API 구현 (`PATCH /api/v1/admin/users/promote`)
- userId별 개별 트랜잭션 처리 + 비즈니스 오류 skip 패턴 적용

## ✅ 상세 내용
- `UserAdminController` — `PATCH /api/v1/admin/users/promote` 엔드포인트 추가
- `UserAdminService` — userId별 트랜잭션 분리, `CustomException`은 skip 후 `failed_user_ids` 반환, `RuntimeException`은 즉시 전파
- `PromoteUsersRequest` / `PromoteUsersResponse` — 요청·응답 DTO 추가 (`@Schema` 보강)
- `ApplicantRepository` — `findByUserIdAndStatus` 추가 (recruitment JOIN FETCH로 term 접근)
- `User.promote()` — 지원서 개인정보 복사 + memberType MEMBER 전환 메서드 추가
- `ErrorCode.ALREADY_MEMBER` 추가

## 🔔 참고 사항
- SNAKE_CASE 전략이 전 환경 yml에 설정되어 있어 `@JsonProperty` 미사용, `@Schema`만 적용