### PR TITLE
[feat] Swagger UI에서 multipart/form-data 엔드포인트 직접 테스트 가능하도록 설정

### DIFF
--- a/src/main/java/com/boaz/backend/domain/archive/controller/ArchiveAdminController.java
+++ b/src/main/java/com/boaz/backend/domain/archive/controller/ArchiveAdminController.java
@@ -7,12 +7,18 @@ import com.boaz.backend.domain.archive.service.ArchiveAdminService;
 import com.boaz.backend.global.common.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Encoding;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.SchemaProperty;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -23,11 +29,19 @@ import org.springframework.web.multipart.MultipartFile;
 @RequestMapping("/api/v1/admin/archiving")
 @RequiredArgsConstructor
 public class ArchiveAdminController {
-    
+
     private final ArchiveAdminService archiveAdminService;
 
     // 프로젝트 등록
     @Operation(summary = "프로젝트 등록", description = "프로젝트 데이터와 이미지를 등록합니다.")
+    @RequestBody(content = @Content(
+        mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+        schemaProperties = {
+            @SchemaProperty(name = "data", schema = @Schema(implementation = ArchiveCreateRequest.class)),
+            @SchemaProperty(name = "image", schema = @Schema(type = "string", format = "binary"))
+        },
+        encoding = @Encoding(name = "data", contentType = MediaType.APPLICATION_JSON_VALUE)
+    ))
     @PostMapping(value = "/projects", consumes = "multipart/form-data")
     public ResponseEntity<ApiResponse<Void>> createProject(
         @Valid @RequestPart("data") ArchiveCreateRequest request,
@@ -39,6 +53,14 @@ public class ArchiveAdminController {
 
     // 활동사진 등록
     @Operation(summary = "활동사진 등록", description = "활동사진 데이터와 이미지를 등록합니다.")
+    @RequestBody(content = @Content(
+        mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+        schemaProperties = {
+            @SchemaProperty(name = "data", schema = @Schema(implementation = ArchiveCreateRequest.class)),
+            @SchemaProperty(name = "image", schema = @Schema(type = "string", format = "binary"))
+        },
+        encoding = @Encoding(name = "data", contentType = MediaType.APPLICATION_JSON_VALUE)
+    ))
     @PostMapping(value = "/activities", consumes = "multipart/form-data")
     public ResponseEntity<ApiResponse<Void>> createActivity(
         @Valid @RequestPart("data") ArchiveCreateRequest request,
@@ -50,8 +72,16 @@ public class ArchiveAdminController {
 
     // 기술블로그 등록
     @Operation(summary = "기술블로그 등록", description = "기술블로그 데이터와 이미지를 등록합니다.")
+    @RequestBody(content = @Content(
+        mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+        schemaProperties = {
+            @SchemaProperty(name = "data", schema = @Schema(implementation = ArchiveCreateRequest.class)),
+            @SchemaProperty(name = "image", schema = @Schema(type = "string", format = "binary"))
+        },
+        encoding = @Encoding(name = "data", contentType = MediaType.APPLICATION_JSON_VALUE)
+    ))
     @PostMapping(value = "/blogs", consumes = "multipart/form-data")
-    public ResponseEntity<ApiResponse<Void>> createBlog (
+    public ResponseEntity<ApiResponse<Void>> createBlog(
         @Valid @RequestPart("data") ArchiveCreateRequest request,
         @RequestPart("image") MultipartFile image
     ) {
@@ -61,8 +91,16 @@ public class ArchiveAdminController {
 
     // 프로젝트 수정
     @Operation(summary = "프로젝트 수정", description = "프로젝트 데이터를 수정합니다.")
+    @RequestBody(content = @Content(
+        mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+        schemaProperties = {
+            @SchemaProperty(name = "data", schema = @Schema(implementation = ArchiveUpdateRequest.class)),
+            @SchemaProperty(name = "image", schema = @Schema(type = "string", format = "binary"))
+        },
+        encoding = @Encoding(name = "data", contentType = MediaType.APPLICATION_JSON_VALUE)
+    ))
     @PatchMapping(value = "/projects/{id}", consumes = "multipart/form-data")
-    public ResponseEntity<ApiResponse<Void>> updateProject (
+    public ResponseEntity<ApiResponse<Void>> updateProject(
         @PathVariable Long id,
         @Valid @RequestPart(value = "data", required = false) ArchiveUpdateRequest request,
         @RequestPart(value = "image", required = false) MultipartFile image
@@ -73,6 +111,14 @@ public class ArchiveAdminController {
 
     // 활동사진 수정
     @Operation(summary = "활동사진 수정", description = "활동사진 데이터를 수정합니다.")
+    @RequestBody(content = @Content(
+        mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+        schemaProperties = {
+            @SchemaProperty(name = "data", schema = @Schema(implementation = ArchiveUpdateRequest.class)),
+            @SchemaProperty(name = "image", schema = @Schema(type = "string", format = "binary"))
+        },
+        encoding = @Encoding(name = "data", contentType = MediaType.APPLICATION_JSON_VALUE)
+    ))
     @PatchMapping(value = "/activities/{id}", consumes = "multipart/form-data")
     public ResponseEntity<ApiResponse<Void>> updateActivity(
         @PathVariable Long id,
@@ -85,6 +131,14 @@ public class ArchiveAdminController {
 
     // 기술블로그 수정
     @Operation(summary = "기술블로그 수정", description = "기술블로그 데이터를 수정합니다.")
+    @RequestBody(content = @Content(
+        mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+        schemaProperties = {
+            @SchemaProperty(name = "data", schema = @Schema(implementation = ArchiveUpdateRequest.class)),
+            @SchemaProperty(name = "image", schema = @Schema(type = "string", format = "binary"))
+        },
+        encoding = @Encoding(name = "data", contentType = MediaType.APPLICATION_JSON_VALUE)
+    ))
     @PatchMapping(value = "/blogs/{id}", consumes = "multipart/form-data")
     public ResponseEntity<ApiResponse<Void>> updateBlog(
         @PathVariable Long id,
@@ -118,11 +172,10 @@ public class ArchiveAdminController {
     // 기술블로그 삭제
     @Operation(summary = "기술블로그 삭제", description = "기술블로그 데이터를 삭제합니다.")
     @DeleteMapping("/blogs/{id}")
-    public ResponseEntity<ApiResponse<Void>> deleteBlog (
+    public ResponseEntity<ApiResponse<Void>> deleteBlog(
         @PathVariable Long id
     ) {
         archiveAdminService.deleteArchive(Category.BLOG, id);
         return ResponseEntity.ok(ApiResponse.ok(null));
     }
-
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -117,21 +117,9 @@ INSERT INTO application_question (id, recruitment_id, category, type, label, con
 VALUES (18, 2, 'ANALYSIS', 'TEXT', 'ANALYSIS2', '데이터 ANALYSIS 관련 프로젝트 경험을 소개해주세요. (700자 이내)', null, 700, 11, true, NOW(), NOW());
 
 -- archive 임시 데이터
--- 정렬 기준: contentDate DESC → title ASC (NULL은 마지막)
--- 예상 PROJECT 조회 순서:
---   1. 나. 자연어처리 발표       (2025-12-01 - 가장 최신)
---   2. 가. AI 추천 시스템 발표   (2025-08-15 - 같은 날짜 중 가나다 첫번째)
---   3. 다. 데이터 파이프라인 발표 (2025-08-15 - 같은 날짜 중 가나다 두번째)
---   4. 라. 실시간 처리 발표      (2025-08-15 - 같은 날짜 중 가나다 세번째)
---   5. 마. 미정 프로젝트 A       (NULL - 마지막 그룹 가나다 첫번째)
---   6. 바. 미정 프로젝트 B       (NULL - 마지막 그룹 가나다 두번째)
-
--- [PROJECT] 최신 날짜 (2025-12-01)
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (1, 27, 'PROJECT', '나. 자연어처리 발표', 'NLP팀', 'ANALYSIS', 'https://example.com/img1.png', '{"slideshare":"https://slideshare.net/1"}', '2025-12-01', NOW(), NOW());
 
--- [PROJECT] 같은 날짜 그룹 (2025-08-15) - title 가나다 순으로 정렬되는지 검증
--- DB 등록 순서를 의도적으로 가나다 역순(라→다→가)으로 삽입하여 ID 기반 정렬과 title 기반 정렬의 차이를 확인
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (2, 26, 'PROJECT', '라. 실시간 처리 발표', '스트림팀', 'ENGINEERING', 'https://example.com/img2.png', '{"slideshare":"https://slideshare.net/2"}', '2025-08-15', NOW(), NOW());
 
@@ -141,29 +129,24 @@ VALUES (3, 26, 'PROJECT', '다. 데이터 파이프라인 발표', '파이프팀
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (4, 26, 'PROJECT', '가. AI 추천 시스템 발표', '추천팀', 'ANALYSIS', 'https://example.com/img4.png', '{"slideshare":"https://slideshare.net/4"}', '2025-08-15', NOW(), NOW());
 
--- [PROJECT] contentDate NULL - 맨 마지막 + title 가나다 순 검증
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (5, 25, 'PROJECT', '바. 미정 프로젝트 B', NULL, 'VISUALIZATION', 'https://example.com/img5.png', '{"slideshare":"https://slideshare.net/5"}', NULL, NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (6, 25, 'PROJECT', '마. 미정 프로젝트 A', NULL, 'ANALYSIS', 'https://example.com/img6.png', '{"slideshare":"https://slideshare.net/6"}', NULL, NOW(), NOW());
 
--- [BLOG] 같은 날짜 그룹 (2025-03-05) - 역순 삽입
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (7, 26, 'BLOG', 'Spark 기반 대용량 데이터 처리', NULL, 'ENGINEERING', 'https://example.com/blog1.png', '{"medium":"https://medium.com/@boaz/spark"}', '2025-03-05', NOW(), NOW());
 
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (8, 26, 'BLOG', 'Kafka 기반 스트리밍 아키텍처 정리', NULL, 'ENGINEERING', 'https://example.com/blog2.png', '{"medium":"https://medium.com/@boaz/kafka"}', '2025-03-05', NOW(), NOW());
 
--- [BLOG] 이전 날짜 (2025-01-20)
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (9, 25, 'BLOG', '추천 시스템 협업 필터링 구현 과정', NULL, 'ANALYSIS', 'https://example.com/blog3.png', '{"medium":"https://medium.com/@boaz/cf"}', '2025-01-20', NOW(), NOW());
 
--- [BLOG] contentDate NULL
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (10, 25, 'BLOG', 'Spring Boot 예외 처리 구조 정리', NULL, 'ENGINEERING', 'https://example.com/blog4.png', '{"medium":"https://medium.com/@boaz/spring"}', NULL, NOW(), NOW());
 
--- [ACTIVITY] 같은 날짜 그룹 (2025-04-10) - 역순 삽입
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (11, 26, 'ACTIVITY', '다. VISUALIZATION 세션', NULL, 'VISUALIZATION', 'https://example.com/act1.png', '{"instagram":"https://instagram.com/p/1"}', '2025-04-10', NOW(), NOW());
 
@@ -173,7 +156,6 @@ VALUES (12, 26, 'ACTIVITY', '나. ENGINEERING 워크샵', NULL, 'ENGINEERING', '
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (13, 26, 'ACTIVITY', '가. ANALYSIS 스터디 세션', NULL, 'ANALYSIS', 'https://example.com/act3.png', '{"instagram":"https://instagram.com/p/3"}', '2025-04-10', NOW(), NOW());
 
--- [ACTIVITY] 이전 날짜 (2025-03-01)
 INSERT INTO archive (id, term, category, title, team_name, track, image_url, links, content_date, created_at, updated_at)
 VALUES (14, 25, 'ACTIVITY', '26기 신입기수 OT', NULL, 'ALL', 'https://example.com/act4.png', '{"instagram":"https://instagram.com/p/4"}', '2025-03-01', NOW(), NOW());
 


### PR DESCRIPTION
## 💡 개요

* Issue Number: #94 

## 🪐 주요 변경 사항
- `ArchiveAdminController` 아카이브 등록/수정 6개 엔드포인트에 Swagger 어노테이션 추가

## ✅ 상세 내용
- `@RequestBody` + `@SchemaProperty`로 `data`(JSON), `image`(binary) 파트 스키마 명시
- `@Encoding`으로 `data` 파트의 Content-Type을 `application/json`으로 강제

## 🔔 참고 사항
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **변경 목적**: Swagger UI에서 multipart/form-data 엔드포인트를 직접 테스트할 수 있도록 OpenAPI 스키마 문서를 정확히 생성하기 위해 필요한 어노테이션을 추가했습니다.

- **주요 변경 내용**:
  - **ArchiveAdminController (컨트롤러 레이어)**: 프로젝트/활동사진/기술블로그의 생성/수정 엔드포인트 6개에 `@RequestBody`, `@Content`, `@Encoding`, `@Schema` 어노테이션 추가
    - `data` 파라미터를 `ArchiveCreateRequest` 또는 `ArchiveUpdateRequest` 타입의 JSON으로 정의
    - `image` 파라미터를 바이너리 파일 업로드로 정의
    - `@Encoding`으로 `data` 파트의 Content-Type을 `application/json`으로 강제 지정
  - 코드 포맷 정리 (일부 메서드 시그니처의 불필요한 공백 제거)

- **영향 범위**: API 문서 스키마 변경만 해당되며, 비즈니스 로직, DB 스키마, 런타임 동작에는 변경 없음

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BOAZ-website/backend/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->