### PR TITLE
[Test] 공통 테스트 설정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,10 @@ jobs:
       - name: Gradle 실행 권한 부여
         run: chmod +x gradlew
  
-      - name: JAR 빌드 (테스트 스킵)
+      - name: 테스트 실행
+        run: ./gradlew test
+
+      - name: JAR 빌드
         run: ./gradlew bootJar -x test
  
       - name: 빌드된 JAR 아티팩트 업로드

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,11 @@ dependencies {
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
+    // Testcontainers (Repository / 통합 테스트 — 운영과 동일한 MySQL 8.0)
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:mysql'
+
     // env
     implementation 'io.github.cdimascio:dotenv-java:3.1.0'
 

--- a/src/test/java/com/boaz/backend/BackendApplicationTests.java
+++ b/src/test/java/com/boaz/backend/BackendApplicationTests.java
@@ -1,12 +1,13 @@
 package com.boaz.backend;
 
+import com.boaz.backend.support.TestcontainersBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("test")
-class BackendApplicationTests {
+class BackendApplicationTests extends TestcontainersBase {
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/com/boaz/backend/support/TestcontainersBase.java
+++ b/src/test/java/com/boaz/backend/support/TestcontainersBase.java
@@ -1,0 +1,26 @@
+package com.boaz.backend.support;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+
+public abstract class TestcontainersBase {
+
+    @SuppressWarnings("resource")
+    static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("boaz_test")
+            .withUsername("test")
+            .withPassword("test");
+
+    static {
+        MYSQL.start();
+    }
+
+    @DynamicPropertySource
+    static void datasourceProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add("spring.datasource.driver-class-name", MYSQL::getDriverClassName);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,5 +1,7 @@
 spring:
   datasource:
+    # Testcontainers 가 동작하는 테스트(@DataJpaTest / @SpringBootTest + TestcontainersBase)에서는
+    # @DynamicPropertySource 가 아래 값을 컨테이너 JDBC URL 로 덮어쓴다.
     url: ${DB_URL:jdbc:mysql://localhost:3306/boaz?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
     username: ${DB_USERNAME:root}
     password: ${DB_PASSWORD:}
@@ -7,7 +9,8 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: ${DDL_AUTO:update}
+      # 컨테이너는 빈 스키마로 시작하므로 엔티티 기준으로 테이블을 생성한다.
+      ddl-auto: ${DDL_AUTO:create-drop}
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
@@ -16,6 +19,42 @@ spring:
 
   jackson:
     property-naming-strategy: SNAKE_CASE
+
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 6MB
+
+  # @SpringBootTest 통합 테스트 컨텍스트 기동에 필요한 더미 설정
+  cloud:
+    aws:
+      s3:
+        recruitment-bucket: test-recruitment-bucket
+        archiving-bucket: test-archiving-bucket
+      region:
+        static: ap-northeast-2
+      credentials:
+        access-key:
+        secret-key:
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: test-kakao-client-id
+            client-secret: test-kakao-client-secret
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+            scope:
+              - profile_nickname
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
 
 server:
   port: 8080
@@ -26,3 +65,24 @@ springdoc:
     tags-sorter: alpha
   api-docs:
     path: /api-docs
+
+swagger:
+  server-url: "http://localhost:8080"
+
+cors:
+  allowed-origins: "http://localhost:3000"
+
+jwt:
+  secret: dGVzdC1zZWNyZXQta2V5LWZvci10ZXN0aW5nLW9ubHktbXVzdC1iZS1sb25nZW5vdWdo
+  access-token-expiration: 900000
+  refresh-token-expiration: 604800000
+
+cookie:
+  same-site: Lax
+  secure: false
+  domain:
+
+oauth2:
+  redirect-uri: http://localhost:3000/auth/callback
+  failure-redirect-uri: http://localhost:3000/login?error=true
+  allowed-redirect-uris: "http://localhost:3000/auth/callback"

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -34,8 +34,8 @@ spring:
       region:
         static: ap-northeast-2
       credentials:
-        access-key:
-        secret-key:
+        access-key: test-access-key
+        secret-key: test-secret-key
 
   security:
     oauth2:


### PR DESCRIPTION
## 💡 개요

* Issue Number: #137

## 🪐 주요 변경 사항
- Testcontainers 기반 공통 테스트 인프라 구축
- CI 테스트 실행 활성화

## ✅ 상세 내용
- `build.gradle`: Testcontainers MySQL 의존성 3개 추가 (`spring-boot-testcontainers`, `junit-jupiter`, `mysql`)
- `TestcontainersBase`: Repository / 통합 테스트에서 상속받는 공용 MySQL 8.0 컨테이너 베이스 클래스 (static 싱글턴으로 JVM당 한 번만 기동)
- `BackendApplicationTests`: `TestcontainersBase` 상속으로 컨텍스트 로드 테스트가 실제 MySQL로 동작하도록 변경
- `application-test.yml`: 테스트 컨텍스트 기동에 필요한 더미 설정 추가 (jwt, cors, oauth2, swagger, cookie)
- `ci.yml`: `-x test` 제거 및 테스트 스텝 분리 — PR마다 전체 테스트 자동 실행

## 🔔 참고 사항
- Repository / 통합 테스트 작성 시 `TestcontainersBase` 상속 필요
- 각자 테스트 브랜치에서 dev rebase 후 작업 권장

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **변경 목적**: Testcontainers를 활용하여 MySQL 8.0 기반의 공통 테스트 인프라를 구축하고, CI 파이프라인에서 테스트 실행을 활성화하여 PR 마다 자동으로 통합 테스트가 실행되도록 설정합니다.

- **주요 변경 내용**:
  - **build.gradle**: Testcontainers 관련 의존성 3개 추가 (`spring-boot-testcontainers`, `junit-jupiter`, `testcontainers:mysql`)
  - **src/test/java/com/boaz/backend/support/TestcontainersBase.java**: 새로운 추상 베이스 클래스 추가 - MySQL Testcontainer를 정적 싱글턴으로 초기화하고 `@DynamicPropertySource`를 통해 DB 연결 정보를 동적 주입
  - **src/test/java/com/boaz/backend/BackendApplicationTests.java**: `TestcontainersBase` 상속으로 변경하여 실제 MySQL 컨테이너 환경에서 테스트 실행
  - **src/test/resources/application-test.yml**: 테스트 환경을 위한 설정 추가 - JPA DDL 정책(`create-drop`), AWS S3 더미 설정, OAuth2 클라이언트 설정, JWT/CORS/쿠키 등 통합 테스트 컨텍스트 기동에 필요한 설정
  - **.github/workflows/ci.yml**: 테스트 실행 단계를 JAR 빌드(`./gradlew bootJar -x test`) 전에 별도로 분리(`./gradlew test`)

- **영향 범위**: 
  - **설정 변경**: 테스트 환경 설정 파일 확장, CI 워크플로우 단계 재구성
  - **DB 스키마**: 테스트 시 `create-drop` 정책으로 매번 새로운 스키마 생성
  - **API 변경**: 없음 (테스트 인프라만 추가, 공개 API 변경 없음)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->