### PR TITLE
[Feat] JVM time zone 설정

### DIFF
--- a/src/main/java/com/boaz/backend/BackendApplication.java
+++ b/src/main/java/com/boaz/backend/BackendApplication.java
@@ -1,6 +1,9 @@
 package com.boaz.backend;
 
 import io.github.cdimascio.dotenv.Dotenv;
+
+import java.util.TimeZone;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -8,6 +11,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class BackendApplication {
 
 	public static void main(String[] args) {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+
 		Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
         dotenv.entries().forEach(entry -> System.setProperty(entry.getKey(), entry.getValue()));
 		


### PR DESCRIPTION
## 💡 개요

* Issue Number: #139 

## 🪐 주요 변경 사항
- JVM time zone 설정

## ✅ 상세 내용
- `BackendApplication.java` 에 타임존 설정 추가

## 🔔 참고 사항
- X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **변경 목적**: JVM 애플리케이션의 기본 시간대를 Asia/Seoul로 설정하여 애플리케이션 전체에서 일관된 시간대 사용을 보장합니다. 이를 통해 시간대 관련 오류와 데이터 불일치 문제를 사전에 방지합니다.

- **주요 변경 내용**:
  - `BackendApplication.java`: `main()` 메서드 시작 시점에 `TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"))` 추가
  - `java.util.TimeZone` 임포트 추가

- **영향 범위**: 설정 변경 (JVM 기본 타임존 설정)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->