### PR TITLE
[Fix] TABLE 타입 답변 임시저장 시 500 에러 반환 문제

### DIFF
--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -439,10 +439,10 @@ public class RecruitmentService {
                         }
                         answerText = answer != null ? answer.asText() : null;
                     } else {
+                        if (answer != null && !answer.isObject()) {
+                            throw new CustomException(ErrorCode.INVALID_ANSWER_TYPE);
+                        }
                         try {
-                            if (answer != null && !answer.isObject()) {
-                                throw new CustomException(ErrorCode.INVALID_ANSWER_TYPE);
-                            }
                             answerJson = answer != null ? objectMapper.writeValueAsString(answer) : null;
                         } catch (Exception e) {
                             throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
@coderabbitai ignore

## 💡 개요

* Issue Number: #141

## 🪐 주요 변경 사항
- `TABLE` 타입 답변 validation 로직을 `try` 블록 밖으로 분리

## ✅ 상세 내용
- `saveDraft()` 내 `TABLE` 타입 처리 시, `CustomException(INVALID_ANSWER_TYPE)`이 `catch (Exception e)` 블록에 삼켜져 500 에러가 반환되던 문제 수정
- validation 체크(`!answer.isObject()`)를 `try` 블록 밖으로 이동하여 `CustomException`이 그대로 전파되도록 수정
- `try-catch`는 `objectMapper.writeValueAsString()` 직렬화 실패만 처리하도록 범위 축소

## 🔔 참고 사항
- 관련 파일: `RecruitmentService.java` `saveDraft()` 메서드