### PR TITLE
[Test] Recruitment 도메인 테스트 코드 작성

### DIFF
--- a/src/test/java/com/boaz/backend/domain/recruitment/controller/RecruitmentAdminControllerTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/controller/RecruitmentAdminControllerTest.java
@@ -15,7 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -43,7 +43,7 @@ class RecruitmentAdminControllerTest {
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;
 
-    @MockBean RecruitmentService recruitmentService;
+    @MockitoBean RecruitmentService recruitmentService;
 
     private UsernamePasswordAuthenticationToken adminAuth() {
         return new UsernamePasswordAuthenticationToken(

--- a/src/test/java/com/boaz/backend/domain/recruitment/controller/RecruitmentAdminControllerTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/controller/RecruitmentAdminControllerTest.java
@@ -1,0 +1,262 @@
+package com.boaz.backend.domain.recruitment.controller;
+
+import com.boaz.backend.domain.recruitment.dto.response.SubscriptionResponse;
+import com.boaz.backend.domain.recruitment.entity.Subscription;
+import com.boaz.backend.domain.recruitment.service.RecruitmentService;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import com.boaz.backend.global.security.UserPrincipal;
+import com.boaz.backend.support.TestSecurityConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ActiveProfiles("test")
+@WebMvcTest(
+    value = RecruitmentAdminController.class,
+    excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class}
+)
+@Import(TestSecurityConfig.class)
+class RecruitmentAdminControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockBean RecruitmentService recruitmentService;
+
+    private UsernamePasswordAuthenticationToken adminAuth() {
+        return new UsernamePasswordAuthenticationToken(
+                "admin", null,
+                List.of(new SimpleGrantedAuthority("ROLE_SUPER")));
+    }
+
+    private UsernamePasswordAuthenticationToken userAuth() {
+        return new UsernamePasswordAuthenticationToken(
+                new UserPrincipal(1L), null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+    }
+
+    // ──────────────────────────────────────────────
+    // REC-ADMIN-001: POST /api/v1/admin/recruitment/applications/download
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("REC-ADMIN-001 POST /api/v1/admin/recruitment/applications/download")
+    class DownloadApplications {
+
+        @Test
+        @DisplayName("정상 요청 → 200")
+        void success() throws Exception {
+            doNothing().when(recruitmentService).downloadApplications(27);
+
+            mockMvc.perform(post("/api/v1/admin/recruitment/applications/download")
+                            .with(authentication(adminAuth()))
+                            .param("term", "27"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200));
+        }
+
+        @Test
+        @DisplayName("EX-004 미인증 요청 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(post("/api/v1/admin/recruitment/applications/download")
+                            .param("term", "27"))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.error_code").value("TOKEN_NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("EX-004 User 권한으로 접근 → 403")
+        void forbidden() throws Exception {
+            mockMvc.perform(post("/api/v1/admin/recruitment/applications/download")
+                            .with(authentication(userAuth()))
+                            .param("term", "27"))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.error_code").value("ACCESS_DENIED"));
+        }
+
+        @Test
+        @DisplayName("EX-001 존재하지 않는 term → 404 RECRUITMENT_NOT_FOUND")
+        void notFound() throws Exception {
+            doThrow(new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND))
+                    .when(recruitmentService).downloadApplications(999);
+
+            mockMvc.perform(post("/api/v1/admin/recruitment/applications/download")
+                            .with(authentication(adminAuth()))
+                            .param("term", "999"))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.error_code").value("RECRUITMENT_NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("EX-002 S3 업로드 실패 → 500 S3_UPLOAD_FAILED")
+        void s3Failed() throws Exception {
+            doThrow(new CustomException(ErrorCode.S3_UPLOAD_FAILED))
+                    .when(recruitmentService).downloadApplications(27);
+
+            mockMvc.perform(post("/api/v1/admin/recruitment/applications/download")
+                            .with(authentication(adminAuth()))
+                            .param("term", "27"))
+                    .andExpect(status().isInternalServerError())
+                    .andExpect(jsonPath("$.error_code").value("S3_UPLOAD_FAILED"));
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // REC-ADMIN-010: DELETE /api/v1/admin/recruitment/{id}/applicants
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("REC-ADMIN-010 DELETE /api/v1/admin/recruitment/{id}/applicants")
+    class DeleteApplicants {
+
+        @Test
+        @DisplayName("TC-001 정상 삭제 → 200")
+        void success() throws Exception {
+            doNothing().when(recruitmentService).deleteApplicants(1L);
+
+            mockMvc.perform(delete("/api/v1/admin/recruitment/1/applicants")
+                            .with(authentication(adminAuth())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200));
+        }
+
+        @Test
+        @DisplayName("TC-005 미인증 요청 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(delete("/api/v1/admin/recruitment/1/applicants"))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("EX-004 User 권한으로 접근 → 403")
+        void forbidden() throws Exception {
+            mockMvc.perform(delete("/api/v1/admin/recruitment/1/applicants")
+                            .with(authentication(userAuth())))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("EX-001 모집 진행 중 → 400 RECRUITMENT_NOT_CLOSED")
+        void notClosed() throws Exception {
+            doThrow(new CustomException(ErrorCode.RECRUITMENT_NOT_CLOSED))
+                    .when(recruitmentService).deleteApplicants(1L);
+
+            mockMvc.perform(delete("/api/v1/admin/recruitment/1/applicants")
+                            .with(authentication(adminAuth())))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error_code").value("RECRUITMENT_NOT_CLOSED"));
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // REC-ADMIN-011: GET /api/v1/admin/recruitment/subscriptions
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("REC-ADMIN-011 GET /api/v1/admin/recruitment/subscriptions")
+    class GetSubscriptions {
+
+        @Test
+        @DisplayName("TC-001 데이터 있을 때 → 200 + 목록 반환")
+        void withData() throws Exception {
+            List<SubscriptionResponse> list = List.of(buildSubscriptionResponse(2L, "b@example.com"),
+                    buildSubscriptionResponse(1L, "a@example.com"));
+            when(recruitmentService.getAllSubscriptions()).thenReturn(list);
+
+            mockMvc.perform(get("/api/v1/admin/recruitment/subscriptions")
+                            .with(authentication(adminAuth())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.length()").value(2));
+        }
+
+        @Test
+        @DisplayName("TC-002 데이터 없을 때 → 200 + 빈 배열")
+        void empty() throws Exception {
+            when(recruitmentService.getAllSubscriptions()).thenReturn(Collections.emptyList());
+
+            mockMvc.perform(get("/api/v1/admin/recruitment/subscriptions")
+                            .with(authentication(adminAuth())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data.length()").value(0));
+        }
+
+        @Test
+        @DisplayName("[Security] 미인증 요청 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(get("/api/v1/admin/recruitment/subscriptions"))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("[Security] User 권한으로 접근 → 403")
+        void forbidden() throws Exception {
+            mockMvc.perform(get("/api/v1/admin/recruitment/subscriptions")
+                            .with(authentication(userAuth())))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // REC-ADMIN-012: DELETE /api/v1/admin/recruitment/subscriptions
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("REC-ADMIN-012 DELETE /api/v1/admin/recruitment/subscriptions")
+    class DeleteAllSubscriptions {
+
+        @Test
+        @DisplayName("TC-003 정상 삭제 → 200")
+        void success() throws Exception {
+            doNothing().when(recruitmentService).deleteAllSubscriptions();
+
+            mockMvc.perform(delete("/api/v1/admin/recruitment/subscriptions")
+                            .with(authentication(adminAuth())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200));
+        }
+
+        @Test
+        @DisplayName("[Security] 미인증 요청 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(delete("/api/v1/admin/recruitment/subscriptions"))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("[Security] User 권한으로 접근 → 403")
+        void forbidden() throws Exception {
+            mockMvc.perform(delete("/api/v1/admin/recruitment/subscriptions")
+                            .with(authentication(userAuth())))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // 헬퍼
+    // ──────────────────────────────────────────────
+
+    private SubscriptionResponse buildSubscriptionResponse(Long id, String email) {
+        Subscription s = Subscription.builder().email(email).build();
+        ReflectionTestUtils.setField(s, "id", id);
+        return SubscriptionResponse.from(s);
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/controller/RecruitmentControllerTest.java
@@ -16,7 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -47,7 +47,7 @@ class RecruitmentControllerTest {
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;
 
-    @MockBean RecruitmentService recruitmentService;
+    @MockitoBean RecruitmentService recruitmentService;
 
     private UsernamePasswordAuthenticationToken userAuth() {
         return new UsernamePasswordAuthenticationToken(

--- a/src/test/java/com/boaz/backend/domain/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/controller/RecruitmentControllerTest.java
@@ -1,0 +1,465 @@
+package com.boaz.backend.domain.recruitment.controller;
+
+import com.boaz.backend.domain.recruitment.dto.response.*;
+import com.boaz.backend.domain.recruitment.entity.Applicant;
+import com.boaz.backend.domain.recruitment.service.RecruitmentService;
+import com.boaz.backend.global.common.enums.Track;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import com.boaz.backend.global.security.UserPrincipal;
+import com.boaz.backend.support.TestSecurityConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ActiveProfiles("test")
+@WebMvcTest(
+    value = RecruitmentController.class,
+    excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class}
+)
+@Import(TestSecurityConfig.class)
+class RecruitmentControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockBean RecruitmentService recruitmentService;
+
+    private UsernamePasswordAuthenticationToken userAuth() {
+        return new UsernamePasswordAuthenticationToken(
+                new UserPrincipal(1L), null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+    }
+
+    private UsernamePasswordAuthenticationToken adminAuth() {
+        return new UsernamePasswordAuthenticationToken(
+                "admin", null,
+                List.of(new SimpleGrantedAuthority("ROLE_SUPER")));
+    }
+
+    // ──────────────────────────────────────────────
+    // REC-001: GET /api/v1/recruitment/status
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("REC-001 GET /api/v1/recruitment/status")
+    class GetStatus {
+
+        @Test
+        @DisplayName("TC-006 정상 조회 → 200 + is_active:true")
+        void success() throws Exception {
+            RecruitmentStatusResponse res = RecruitmentStatusResponse.of(true, 27);
+            when(recruitmentService.getRecruitmentStatus()).thenReturn(res);
+
+            mockMvc.perform(get("/api/v1/recruitment/status"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.is_active").value(true))
+                    .andExpect(jsonPath("$.data.term").value(27));
+        }
+
+        @Test
+        @DisplayName("TC-006 비모집 기간 → is_active:false (term 키 생략)")
+        void inactive() throws Exception {
+            RecruitmentStatusResponse res = RecruitmentStatusResponse.of(false, null);
+            when(recruitmentService.getRecruitmentStatus()).thenReturn(res);
+
+            mockMvc.perform(get("/api/v1/recruitment/status"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.is_active").value(false))
+                    .andExpect(jsonPath("$.data.term").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("[Security] 인증 없이 접근 가능 (공개 API)")
+        void publicApi() throws Exception {
+            RecruitmentStatusResponse res = RecruitmentStatusResponse.of(false, null);
+            when(recruitmentService.getRecruitmentStatus()).thenReturn(res);
+
+            mockMvc.perform(get("/api/v1/recruitment/status"))
+                    .andExpect(status().isOk());
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // REC-002: GET /api/v1/recruitment/{term}
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("REC-002 GET /api/v1/recruitment/{term}")
+    class GetRecruitment {
+
+        @Test
+        @DisplayName("TC-005 정상 조회 → 200 + 공고 응답")
+        void success() throws Exception {
+            when(recruitmentService.getRecruitment(27)).thenReturn(mockRecruitmentResponse());
+
+            mockMvc.perform(get("/api/v1/recruitment/27"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.term").value(27));
+        }
+
+        @Test
+        @DisplayName("TC-004 term 파라미터 타입 오류 → 400 INVALID_PARAMETER_TYPE")
+        void invalidTermType() throws Exception {
+            mockMvc.perform(get("/api/v1/recruitment/abc"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error_code").value("INVALID_PARAMETER_TYPE"));
+        }
+
+        @Test
+        @DisplayName("EX-001 존재하지 않는 term → 404 RECRUITMENT_NOT_FOUND")
+        void notFound() throws Exception {
+            when(recruitmentService.getRecruitment(999))
+                    .thenThrow(new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
+
+            mockMvc.perform(get("/api/v1/recruitment/999"))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.error_code").value("RECRUITMENT_NOT_FOUND"));
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // REC-003: GET /api/v1/recruitment/questions
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("REC-003 GET /api/v1/recruitment/questions")
+    class GetQuestions {
+
+        @Test
+        @DisplayName("TC-006 인증 없이 접근 가능 (공개 API)")
+        void publicApi() throws Exception {
+            when(recruitmentService.getQuestions(eq(1L), eq(Track.ENGINEERING)))
+                    .thenReturn(Collections.emptyList());
+
+            mockMvc.perform(get("/api/v1/recruitment/questions")
+                            .param("recruitmentId", "1")
+                            .param("track", "ENGINEERING"))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("EX-005 recruitmentId 누락 → 400 MISSING_PARAMETER")
+        void missingParam() throws Exception {
+            mockMvc.perform(get("/api/v1/recruitment/questions")
+                            .param("track", "ENGINEERING"))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("EX-004 track=ALL → 400 INVALID_TRACK_SELECTION")
+        void trackAll() throws Exception {
+            when(recruitmentService.getQuestions(any(), eq(Track.ALL)))
+                    .thenThrow(new CustomException(ErrorCode.INVALID_TRACK_SELECTION));
+
+            mockMvc.perform(get("/api/v1/recruitment/questions")
+                            .param("recruitmentId", "1")
+                            .param("track", "ALL"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error_code").value("INVALID_TRACK_SELECTION"));
+        }
+
+        @Test
+        @DisplayName("EX-002 모집 기간 아님 → 400 RECRUITMENT_NOT_AVAILABLE")
+        void notAvailable() throws Exception {
+            when(recruitmentService.getQuestions(any(), any()))
+                    .thenThrow(new CustomException(ErrorCode.RECRUITMENT_NOT_AVAILABLE));
+
+            mockMvc.perform(get("/api/v1/recruitment/questions")
+                            .param("recruitmentId", "1")
+                            .param("track", "ENGINEERING"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error_code").value("RECRUITMENT_NOT_AVAILABLE"));
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // REC-004: POST /api/v1/recruitment/{id}/applications
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("REC-004 POST /api/v1/recruitment/{id}/applications")
+    class SubmitApplication {
+
+        @Test
+        @DisplayName("[Security] 미인증 요청 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(post("/api/v1/recruitment/1/applications")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{}"))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.error_code").value("TOKEN_NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("정상 제출 → 201 Created")
+        void success() throws Exception {
+            ApplicationResponse res = ApplicationResponse.of(42L, LocalDateTime.now());
+            when(recruitmentService.submitApplication(eq(1L), eq(1L), any())).thenReturn(res);
+
+            mockMvc.perform(post("/api/v1/recruitment/1/applications")
+                            .with(authentication(userAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(validApplicationJson()))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.data.applicant_id").value(42));
+        }
+
+        @Test
+        @DisplayName("EX-001 이미 SUBMITTED → 409 ALREADY_SUBMITTED")
+        void alreadySubmitted() throws Exception {
+            when(recruitmentService.submitApplication(any(), any(), any()))
+                    .thenThrow(new CustomException(ErrorCode.ALREADY_SUBMITTED));
+
+            mockMvc.perform(post("/api/v1/recruitment/1/applications")
+                            .with(authentication(userAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(validApplicationJson()))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.error_code").value("ALREADY_SUBMITTED"));
+        }
+
+        @Test
+        @DisplayName("EX-002 모집 기간 아님 → 409 RECRUITMENT_CLOSED")
+        void closed() throws Exception {
+            when(recruitmentService.submitApplication(any(), any(), any()))
+                    .thenThrow(new CustomException(ErrorCode.RECRUITMENT_CLOSED));
+
+            mockMvc.perform(post("/api/v1/recruitment/1/applications")
+                            .with(authentication(userAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(validApplicationJson()))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.error_code").value("RECRUITMENT_CLOSED"));
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // REC-005: POST /api/v1/recruitment/subscriptions
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("REC-005 POST /api/v1/recruitment/subscriptions")
+    class Subscribe {
+
+        @Test
+        @DisplayName("TC-005 정상 신청 → 201 Created")
+        void success() throws Exception {
+            when(recruitmentService.subscribe(any())).thenReturn(mockSubscriptionResponse());
+
+            mockMvc.perform(post("/api/v1/recruitment/subscriptions")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"email\":\"test@example.com\"}"))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.data.email").value("test@example.com"));
+        }
+
+        @Test
+        @DisplayName("TC-006 이메일 미입력(@NotBlank) → 400 INVALID_INPUT_VALUE")
+        void blankEmail() throws Exception {
+            mockMvc.perform(post("/api/v1/recruitment/subscriptions")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"email\":\"\"}"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error_code").value("INVALID_INPUT_VALUE"));
+        }
+
+        @Test
+        @DisplayName("EX-001 중복 이메일 → 409 DUPLICATE_EMAIL")
+        void duplicate() throws Exception {
+            when(recruitmentService.subscribe(any()))
+                    .thenThrow(new CustomException(ErrorCode.DUPLICATE_EMAIL));
+
+            mockMvc.perform(post("/api/v1/recruitment/subscriptions")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"email\":\"dup@example.com\"}"))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.error_code").value("DUPLICATE_EMAIL"));
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // REC-006: GET /api/v1/recruitment/deadline
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("REC-006 GET /api/v1/recruitment/deadline")
+    class GetDeadline {
+
+        @Test
+        @DisplayName("TC-003 정상 조회 → 200 + 날짜 포맷 확인")
+        void success() throws Exception {
+            DeadlineResponse res = mockDeadlineResponse();
+            when(recruitmentService.getDeadline()).thenReturn(res);
+
+            mockMvc.perform(get("/api/v1/recruitment/deadline"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.recruitment_id").value(1))
+                    .andExpect(jsonPath("$.data.deadline").exists());
+        }
+
+        @Test
+        @DisplayName("EX-001 활성 공고 없음 → 404 RECRUITMENT_NOT_FOUND")
+        void notFound() throws Exception {
+            when(recruitmentService.getDeadline())
+                    .thenThrow(new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
+
+            mockMvc.perform(get("/api/v1/recruitment/deadline"))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.error_code").value("RECRUITMENT_NOT_FOUND"));
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // REC-007: PUT /api/v1/recruitment/{id}/applications/draft
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("REC-007 PUT /api/v1/recruitment/{id}/applications/draft")
+    class SaveDraft {
+
+        @Test
+        @DisplayName("[Security] 미인증 요청 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(put("/api/v1/recruitment/1/applications/draft")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{}"))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.error_code").value("TOKEN_NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("정상 임시저장 → 200 + applicant_id")
+        void success() throws Exception {
+            DraftApplicationResponse res = DraftApplicationResponse.of(42L);
+            when(recruitmentService.saveDraft(eq(1L), eq(1L), any())).thenReturn(res);
+
+            mockMvc.perform(put("/api/v1/recruitment/1/applications/draft")
+                            .with(authentication(userAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"name\":\"홍길동\"}"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.applicant_id").value(42));
+        }
+
+        @Test
+        @DisplayName("EX-001 SUBMITTED 지원서 존재 → 403 APPLICATION_ALREADY_SUBMITTED")
+        void alreadySubmitted() throws Exception {
+            when(recruitmentService.saveDraft(any(), any(), any()))
+                    .thenThrow(new CustomException(ErrorCode.APPLICATION_ALREADY_SUBMITTED));
+
+            mockMvc.perform(put("/api/v1/recruitment/1/applications/draft")
+                            .with(authentication(userAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{}"))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.error_code").value("APPLICATION_ALREADY_SUBMITTED"));
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // REC-008: GET /api/v1/recruitment/{id}/applications/me
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("REC-008 GET /api/v1/recruitment/{id}/applications/me")
+    class GetMyApplication {
+
+        @Test
+        @DisplayName("[Security] 미인증 요청 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(get("/api/v1/recruitment/1/applications/me"))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.error_code").value("TOKEN_NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("EX-002 SUBMITTED 상태 접근 → 403 APPLICATION_ALREADY_SUBMITTED")
+        void submittedForbidden() throws Exception {
+            when(recruitmentService.getMyApplication(any(), any()))
+                    .thenThrow(new CustomException(ErrorCode.APPLICATION_ALREADY_SUBMITTED));
+
+            mockMvc.perform(get("/api/v1/recruitment/1/applications/me")
+                            .with(authentication(userAuth())))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.error_code").value("APPLICATION_ALREADY_SUBMITTED"));
+        }
+
+        @Test
+        @DisplayName("EX-001 지원서 없음 → 404 APPLICATION_NOT_FOUND")
+        void notFound() throws Exception {
+            when(recruitmentService.getMyApplication(any(), any()))
+                    .thenThrow(new CustomException(ErrorCode.APPLICATION_NOT_FOUND));
+
+            mockMvc.perform(get("/api/v1/recruitment/1/applications/me")
+                            .with(authentication(userAuth())))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.error_code").value("APPLICATION_NOT_FOUND"));
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // 헬퍼
+    // ──────────────────────────────────────────────
+
+    private String validApplicationJson() {
+        return objectMapper.createObjectNode()
+                .put("track", "ENGINEERING")
+                .put("name", "홍길동")
+                .put("email", "hong@example.com")
+                .put("phone", "01012345678")
+                .put("university", "한국대학교")
+                .put("major", "컴퓨터공학")
+                .put("last_semester", 6)
+                .put("military_status", "COMPLETED_OR_EXEMPT")
+                .put("birth_date", "2000-01-01")
+                .put("graduation_date", "2026-02")
+                .put("grad_school_plan", false)
+                .set("answers", objectMapper.createArrayNode())
+                .toString();
+    }
+
+    private SubscriptionResponse mockSubscriptionResponse() {
+        com.boaz.backend.domain.recruitment.entity.Subscription sub =
+                com.boaz.backend.domain.recruitment.entity.Subscription.builder()
+                        .email("test@example.com").build();
+        org.springframework.test.util.ReflectionTestUtils.setField(sub, "id", 1L);
+        return SubscriptionResponse.from(sub);
+    }
+
+    private DeadlineResponse mockDeadlineResponse() {
+        com.boaz.backend.domain.recruitment.entity.Recruitment r =
+                com.boaz.backend.domain.recruitment.entity.Recruitment.create(
+                        27, LocalDateTime.now().minusDays(1), LocalDateTime.now().plusDays(7),
+                        "[]", null);
+        org.springframework.test.util.ReflectionTestUtils.setField(r, "id", 1L);
+        return DeadlineResponse.from(r);
+    }
+
+    private com.boaz.backend.domain.recruitment.dto.response.RecruitmentResponse mockRecruitmentResponse() {
+        com.boaz.backend.domain.recruitment.entity.Recruitment r =
+                com.boaz.backend.domain.recruitment.entity.Recruitment.create(
+                        27, LocalDateTime.now().minusDays(1), LocalDateTime.now().plusDays(1),
+                        "[]", null);
+        org.springframework.test.util.ReflectionTestUtils.setField(r, "id", 1L);
+        return com.boaz.backend.domain.recruitment.dto.response.RecruitmentResponse.from(r, true);
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/recruitment/integration/RecruitmentIntegrationTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/integration/RecruitmentIntegrationTest.java
@@ -1,11 +1,18 @@
 package com.boaz.backend.domain.recruitment.integration;
 
 import com.boaz.backend.domain.recruitment.dto.request.ApplicationRequest;
+import com.boaz.backend.domain.recruitment.dto.request.DraftApplicationRequest;
 import com.boaz.backend.domain.recruitment.dto.request.SubscriptionRequest;
 import com.boaz.backend.domain.recruitment.dto.response.ApplicationResponse;
+import com.boaz.backend.domain.recruitment.dto.response.DeadlineResponse;
+import com.boaz.backend.domain.recruitment.dto.response.DraftApplicationResponse;
+import com.boaz.backend.domain.recruitment.dto.response.MyApplicationResponse;
+import com.boaz.backend.domain.recruitment.dto.response.QuestionResponse;
+import com.boaz.backend.domain.recruitment.dto.response.RecruitmentResponse;
 import com.boaz.backend.domain.recruitment.dto.response.RecruitmentStatusResponse;
 import com.boaz.backend.domain.recruitment.dto.response.SubscriptionResponse;
 import com.boaz.backend.domain.recruitment.entity.Applicant;
+import com.boaz.backend.domain.recruitment.entity.ApplicantAnswer;
 import com.boaz.backend.domain.recruitment.entity.ApplicationQuestion;
 import com.boaz.backend.domain.recruitment.entity.ApplicationQuestion.Category;
 import com.boaz.backend.domain.recruitment.entity.ApplicationQuestion.Type;
@@ -32,16 +39,20 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @SpringBootTest
 @Transactional
@@ -60,7 +71,7 @@ class RecruitmentIntegrationTest extends TestcontainersBase {
     @PersistenceContext EntityManager em;
 
     // S3 는 외부 연동이므로 통합 테스트에서 모킹
-    @MockBean S3Service s3Service;
+    @MockitoBean S3Service s3Service;
 
     private int userSeq = 0;
 
@@ -83,10 +94,48 @@ class RecruitmentIntegrationTest extends TestcontainersBase {
                 .build());
     }
 
+    // label 컬럼은 length=20 제약이 있어 짧게 생성 (예: q-C1, q-E2)
+    private String shortLabel(String prefix, Category category, int orderNum) {
+        return prefix + category.name().charAt(0) + orderNum;
+    }
+
     private ApplicationQuestion saveQuestion(Recruitment r, Category category, int orderNum) {
         return questionRepository.save(ApplicationQuestion.create(
-                r, "label-" + category + "-" + orderNum, category, Type.TEXT,
+                r, shortLabel("q-", category, orderNum), category, Type.TEXT,
                 "content", 500, null, orderNum, true));
+    }
+
+    private ApplicationQuestion saveQuestion(Recruitment r, Category category, int orderNum, String content) {
+        return questionRepository.save(ApplicationQuestion.create(
+                r, shortLabel("q-", category, orderNum), category, Type.TEXT,
+                content, 500, null, orderNum, true));
+    }
+
+    private ApplicationQuestion saveTableQuestion(Recruitment r, Category category, int orderNum) {
+        return questionRepository.save(ApplicationQuestion.create(
+                r, shortLabel("qt-", category, orderNum), category, Type.TABLE,
+                "테이블 질문", null, "{\"rows\":[\"A\"],\"columns\":[\"B\"]}", orderNum, true));
+    }
+
+    // 제출 요청의 개인정보 공통 필드 (answers 제외)
+    private Map<String, Object> personalFields(Track track) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("track", track.name());
+        m.put("name", "홍길동");
+        m.put("email", "hong@example.com");
+        m.put("phone", "01012345678");
+        m.put("university", "한국대학교");
+        m.put("major", "컴퓨터공학");
+        m.put("last_semester", 4);
+        m.put("military_status", "COMPLETED_OR_EXEMPT");
+        m.put("birth_date", "2000-01-01");
+        m.put("graduation_date", "2025-02");
+        m.put("grad_school_plan", false);
+        return m;
+    }
+
+    private DraftApplicationRequest buildDraftRequest(Map<String, Object> fields) {
+        return objectMapper.convertValue(fields, DraftApplicationRequest.class);
     }
 
     private ApplicationRequest buildSubmitRequest(Track track, Long commonQId, Long trackQId) {
@@ -228,6 +277,273 @@ class RecruitmentIntegrationTest extends TestcontainersBase {
                     u.getId(), r.getId(), buildSubmitRequest(Track.ENGINEERING, commonQ, trackQ)))
                     .isInstanceOf(CustomException.class)
                     .extracting("errorCode").isEqualTo(ErrorCode.ALREADY_SUBMITTED);
+        }
+
+        @Test
+        @DisplayName("TABLE 답변 → JSON 컬럼에 정상 직렬화 저장")
+        void submitWithTableAnswer() {
+            Recruitment r = saveActiveRecruitment(27);
+            User u = saveUser();
+            Long commonQ = saveQuestion(r, Category.COMMON, 1).getId();
+            Long tableQ = saveTableQuestion(r, Category.ENGINEERING, 2).getId();
+            em.flush();
+            em.clear();
+
+            Map<String, Object> fields = personalFields(Track.ENGINEERING);
+            fields.put("answers", List.of(
+                    Map.of("question_id", commonQ, "answer", "공통 답변"),
+                    Map.of("question_id", tableQ, "answer", Map.of("키", "값"))));
+            ApplicationRequest req = objectMapper.convertValue(fields, ApplicationRequest.class);
+
+            ApplicationResponse res = recruitmentService.submitApplication(u.getId(), r.getId(), req);
+            em.flush();
+            em.clear();
+
+            List<ApplicantAnswer> answers = answerRepository.findByApplicantIds(List.of(res.getApplicantId()));
+            assertThat(answers).hasSize(2);
+            ApplicantAnswer tableAnswer = answers.stream()
+                    .filter(a -> a.getAnswerJson() != null).findFirst().orElseThrow();
+            assertThat(tableAnswer.getAnswerJson()).contains("키").contains("값");
+        }
+    }
+
+    @Nested
+    @DisplayName("기수별 공고 조회 end-to-end (REC-002)")
+    class GetRecruitment {
+
+        @Test
+        @DisplayName("존재하는 term → 공고 반환 (isActive 날짜 계산)")
+        void found() {
+            saveActiveRecruitment(27);
+            em.flush();
+            em.clear();
+
+            RecruitmentResponse res = recruitmentService.getRecruitment(27);
+
+            assertThat(res.getTerm()).isEqualTo(27);
+            assertThat(res.getIsActive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("마감된 공고 → isActive=false (404 아님)")
+        void closedStillReturns() {
+            saveClosedRecruitment(26);
+            em.flush();
+            em.clear();
+
+            RecruitmentResponse res = recruitmentService.getRecruitment(26);
+
+            assertThat(res.getIsActive()).isFalse();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 term → RECRUITMENT_NOT_FOUND")
+        void notFound() {
+            assertThatThrownBy(() -> recruitmentService.getRecruitment(999))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.RECRUITMENT_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("질문 목록 조회 end-to-end (REC-003)")
+    class GetQuestions {
+
+        @Test
+        @DisplayName("COMMON + 지정 트랙만 order_num 순 반환, {Track} 치환")
+        void filteredAndOrdered() {
+            Recruitment r = saveActiveRecruitment(27);
+            saveQuestion(r, Category.COMMON, 1);
+            saveQuestion(r, Category.ENGINEERING, 2, "{Track} 지원 동기");
+            saveQuestion(r, Category.VISUALIZATION, 3);
+            em.flush();
+            em.clear();
+
+            List<QuestionResponse> result = recruitmentService.getQuestions(r.getId(), Track.ENGINEERING);
+
+            assertThat(result).hasSize(2);
+            assertThat(result).extracting(QuestionResponse::getOrderNum).containsExactly(1, 2);
+            assertThat(result).noneMatch(q -> q.getCategory().equals("VISUALIZATION"));
+            assertThat(result.get(1).getContent()).contains("ENGINEERING");
+        }
+
+        @Test
+        @DisplayName("모집 기간 외 → RECRUITMENT_NOT_AVAILABLE")
+        void notAvailable() {
+            Recruitment r = saveClosedRecruitment(26);
+            em.flush();
+
+            assertThatThrownBy(() -> recruitmentService.getQuestions(r.getId(), Track.ENGINEERING))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.RECRUITMENT_NOT_AVAILABLE);
+        }
+    }
+
+    @Nested
+    @DisplayName("마감 일시 조회 end-to-end (REC-006)")
+    class GetDeadline {
+
+        @Test
+        @DisplayName("모집 중 공고 → end_date 반환")
+        void found() {
+            LocalDateTime now = LocalDateTime.now();
+            LocalDateTime end = now.plusDays(1).withNano(0);
+            Recruitment r = recruitmentRepository.save(
+                    Recruitment.create(27, now.minusDays(1), end, "{}", null));
+            em.flush();
+            em.clear();
+
+            DeadlineResponse res = recruitmentService.getDeadline();
+
+            assertThat(res.getDeadline()).isEqualToIgnoringNanos(r.getEndDate());
+        }
+
+        @Test
+        @DisplayName("활성 공고 없음 → RECRUITMENT_NOT_FOUND")
+        void notFound() {
+            assertThatThrownBy(() -> recruitmentService.getDeadline())
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.RECRUITMENT_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("임시저장 end-to-end (REC-007)")
+    class SaveDraft {
+
+        @Test
+        @DisplayName("신규 생성 후 부분 업데이트 → 같은 레코드 유지, name 보존 / track 갱신")
+        void createThenPartialUpdate() {
+            Recruitment r = saveActiveRecruitment(27);
+            User u = saveUser();
+            em.flush();
+            em.clear();
+
+            DraftApplicationResponse first = recruitmentService.saveDraft(
+                    u.getId(), r.getId(), buildDraftRequest(Map.of("name", "홍길동")));
+            em.flush();
+            em.clear();
+
+            DraftApplicationResponse second = recruitmentService.saveDraft(
+                    u.getId(), r.getId(), buildDraftRequest(Map.of("track", "ENGINEERING")));
+            em.flush();
+            em.clear();
+
+            assertThat(second.getApplicantId()).isEqualTo(first.getApplicantId());
+            assertThat(applicantRepository.count()).isEqualTo(1);
+            Applicant saved = applicantRepository.findById(first.getApplicantId()).orElseThrow();
+            assertThat(saved.getStatus()).isEqualTo(Applicant.ApplicantStatus.DRAFT);
+            assertThat(saved.getName()).isEqualTo("홍길동");          // null 필드라 유지
+            assertThat(saved.getTrack()).isEqualTo(Track.ENGINEERING); // 새로 들어온 값으로 갱신
+        }
+
+        @Test
+        @DisplayName("answers 분기: 값 교체 → null 유지 → [] 전삭제")
+        void answersBranching() {
+            Recruitment r = saveActiveRecruitment(27);
+            User u = saveUser();
+            Long q1 = saveQuestion(r, Category.COMMON, 1).getId();
+            em.flush();
+            em.clear();
+
+            // 1) 값 있는 answers → 1건 저장
+            recruitmentService.saveDraft(u.getId(), r.getId(), buildDraftRequest(Map.of(
+                    "answers", List.of(Map.of("question_id", q1, "answer", "초기 답변")))));
+            em.flush();
+            em.clear();
+            Long applicantId = applicantRepository.findByRecruitmentIdAndUserId(r.getId(), u.getId())
+                    .orElseThrow().getId();
+            assertThat(answerRepository.findByApplicantIds(List.of(applicantId))).hasSize(1);
+
+            // 2) answers 미포함(null) → 기존 답변 유지
+            recruitmentService.saveDraft(u.getId(), r.getId(), buildDraftRequest(Map.of("name", "홍길동")));
+            em.flush();
+            em.clear();
+            assertThat(answerRepository.findByApplicantIds(List.of(applicantId))).hasSize(1);
+
+            // 3) answers=[] → 전체 삭제
+            recruitmentService.saveDraft(u.getId(), r.getId(), buildDraftRequest(Map.of(
+                    "answers", List.of())));
+            em.flush();
+            em.clear();
+            assertThat(answerRepository.findByApplicantIds(List.of(applicantId))).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("내 지원서 조회 end-to-end (REC-008)")
+    class GetMyApplication {
+
+        @Test
+        @DisplayName("DRAFT + 답변 → answers 역직렬화 포함 응답 반환")
+        void draftWithAnswers() {
+            Recruitment r = saveActiveRecruitment(27);
+            User u = saveUser();
+            Long q1 = saveQuestion(r, Category.COMMON, 1).getId();
+            em.flush();
+            em.clear();
+
+            recruitmentService.saveDraft(u.getId(), r.getId(), buildDraftRequest(Map.of(
+                    "name", "홍길동",
+                    "answers", List.of(Map.of("question_id", q1, "answer", "내 답변")))));
+            em.flush();
+            em.clear();
+
+            MyApplicationResponse res = recruitmentService.getMyApplication(u.getId(), r.getId());
+
+            assertThat(res.getStatus()).isEqualTo(Applicant.ApplicantStatus.DRAFT);
+            assertThat(res.getName()).isEqualTo("홍길동");
+            assertThat(res.getAnswers()).hasSize(1);
+            assertThat(res.getAnswers().get(0).getAnswer().asText()).isEqualTo("내 답변");
+        }
+
+        @Test
+        @DisplayName("SUBMITTED 상태 → APPLICATION_ALREADY_SUBMITTED")
+        void submittedForbidden() {
+            Recruitment r = saveActiveRecruitment(27);
+            User u = saveUser();
+            applicantRepository.save(Applicant.builder()
+                    .recruitment(r).user(u).status(Applicant.ApplicantStatus.SUBMITTED)
+                    .track(Track.ENGINEERING).name("n").email("a@example.com").phone("01012345678")
+                    .build());
+            em.flush();
+            em.clear();
+
+            assertThatThrownBy(() -> recruitmentService.getMyApplication(u.getId(), r.getId()))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.APPLICATION_ALREADY_SUBMITTED);
+        }
+    }
+
+    @Nested
+    @DisplayName("CSV 생성 end-to-end (REC-ADMIN-001)")
+    class DownloadApplications {
+
+        @Test
+        @DisplayName("부문 3개 모두 S3 업로드 호출 (빈 부문 포함)")
+        void uploadsThreeTracks() {
+            Recruitment r = saveActiveRecruitment(27);
+            User u = saveUser();
+            saveQuestion(r, Category.COMMON, 1);
+            Applicant a = applicantRepository.save(Applicant.builder()
+                    .recruitment(r).user(u).status(Applicant.ApplicantStatus.SUBMITTED)
+                    .track(Track.ENGINEERING).name("n").email("a@example.com").phone("01012345678")
+                    .build());
+            a.markSubmitted();
+            em.flush();
+            em.clear();
+
+            recruitmentService.downloadApplications(27);
+
+            verify(s3Service, times(3)).uploadCsv(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 term → RECRUITMENT_NOT_FOUND")
+        void notFound() {
+            assertThatThrownBy(() -> recruitmentService.downloadApplications(999))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.RECRUITMENT_NOT_FOUND);
         }
     }
 

--- a/src/test/java/com/boaz/backend/domain/recruitment/integration/RecruitmentIntegrationTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/integration/RecruitmentIntegrationTest.java
@@ -1,0 +1,290 @@
+package com.boaz.backend.domain.recruitment.integration;
+
+import com.boaz.backend.domain.recruitment.dto.request.ApplicationRequest;
+import com.boaz.backend.domain.recruitment.dto.request.SubscriptionRequest;
+import com.boaz.backend.domain.recruitment.dto.response.ApplicationResponse;
+import com.boaz.backend.domain.recruitment.dto.response.RecruitmentStatusResponse;
+import com.boaz.backend.domain.recruitment.dto.response.SubscriptionResponse;
+import com.boaz.backend.domain.recruitment.entity.Applicant;
+import com.boaz.backend.domain.recruitment.entity.ApplicationQuestion;
+import com.boaz.backend.domain.recruitment.entity.ApplicationQuestion.Category;
+import com.boaz.backend.domain.recruitment.entity.ApplicationQuestion.Type;
+import com.boaz.backend.domain.recruitment.entity.Recruitment;
+import com.boaz.backend.domain.recruitment.repository.ApplicantAnswerRepository;
+import com.boaz.backend.domain.recruitment.repository.ApplicantRepository;
+import com.boaz.backend.domain.recruitment.repository.ApplicationQuestionRepository;
+import com.boaz.backend.domain.recruitment.repository.RecruitmentRepository;
+import com.boaz.backend.domain.recruitment.repository.SubscriptionRepository;
+import com.boaz.backend.domain.recruitment.service.RecruitmentService;
+import com.boaz.backend.domain.user.entity.User;
+import com.boaz.backend.domain.user.repository.UserRepository;
+import com.boaz.backend.global.common.enums.MemberType;
+import com.boaz.backend.global.common.enums.Track;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import com.boaz.backend.global.util.S3Service;
+import com.boaz.backend.support.TestcontainersBase;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class RecruitmentIntegrationTest extends TestcontainersBase {
+
+    @Autowired RecruitmentService recruitmentService;
+    @Autowired RecruitmentRepository recruitmentRepository;
+    @Autowired ApplicationQuestionRepository questionRepository;
+    @Autowired ApplicantRepository applicantRepository;
+    @Autowired ApplicantAnswerRepository answerRepository;
+    @Autowired SubscriptionRepository subscriptionRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired ObjectMapper objectMapper;
+
+    @PersistenceContext EntityManager em;
+
+    // S3 는 외부 연동이므로 통합 테스트에서 모킹
+    @MockBean S3Service s3Service;
+
+    private int userSeq = 0;
+
+    private Recruitment saveActiveRecruitment(int term) {
+        LocalDateTime now = LocalDateTime.now();
+        return recruitmentRepository.save(
+                Recruitment.create(term, now.minusDays(1), now.plusDays(1), "{}", null));
+    }
+
+    private Recruitment saveClosedRecruitment(int term) {
+        LocalDateTime now = LocalDateTime.now();
+        return recruitmentRepository.save(
+                Recruitment.create(term, now.minusDays(10), now.minusDays(1), "{}", null));
+    }
+
+    private User saveUser() {
+        return userRepository.save(User.builder()
+                .provider("kakao").providerId("p" + (++userSeq))
+                .nickname("nick").memberType(MemberType.OUTSIDER)
+                .build());
+    }
+
+    private ApplicationQuestion saveQuestion(Recruitment r, Category category, int orderNum) {
+        return questionRepository.save(ApplicationQuestion.create(
+                r, "label-" + category + "-" + orderNum, category, Type.TEXT,
+                "content", 500, null, orderNum, true));
+    }
+
+    private ApplicationRequest buildSubmitRequest(Track track, Long commonQId, Long trackQId) {
+        Map<String, Object> req = Map.ofEntries(
+                Map.entry("track", track.name()),
+                Map.entry("name", "홍길동"),
+                Map.entry("email", "hong@example.com"),
+                Map.entry("phone", "01012345678"),
+                Map.entry("university", "한국대학교"),
+                Map.entry("major", "컴퓨터공학"),
+                Map.entry("last_semester", 4),
+                Map.entry("military_status", "COMPLETED_OR_EXEMPT"),
+                Map.entry("birth_date", "2000-01-01"),
+                Map.entry("graduation_date", "2025-02"),
+                Map.entry("grad_school_plan", false),
+                Map.entry("answers", List.of(
+                        Map.of("question_id", commonQId, "answer", "공통 답변"),
+                        Map.of("question_id", trackQId, "answer", "트랙 답변")))
+        );
+        return objectMapper.convertValue(req, ApplicationRequest.class);
+    }
+
+    @Nested
+    @DisplayName("모집 상태 조회")
+    class Status {
+
+        @Test
+        @DisplayName("모집 중 공고가 있으면 isActive=true, term 반환")
+        void active() {
+            saveActiveRecruitment(27);
+            em.flush();
+            em.clear();
+
+            RecruitmentStatusResponse res = recruitmentService.getRecruitmentStatus();
+
+            assertThat(res.getIsActive()).isTrue();
+            assertThat(res.getTerm()).isEqualTo(27);
+        }
+
+        @Test
+        @DisplayName("공고가 없으면 isActive=false, term=null")
+        void inactive() {
+            RecruitmentStatusResponse res = recruitmentService.getRecruitmentStatus();
+
+            assertThat(res.getIsActive()).isFalse();
+            assertThat(res.getTerm()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("사전 알림 신청")
+    class Subscribe {
+
+        @Test
+        @DisplayName("신규 이메일 신청 후 DB 저장 + 중복 신청 시 DUPLICATE_EMAIL")
+        void subscribeAndDuplicate() {
+            SubscriptionRequest request = objectMapper.convertValue(
+                    Map.of("email", "new@example.com"), SubscriptionRequest.class);
+
+            SubscriptionResponse res = recruitmentService.subscribe(request);
+            em.flush();
+
+            assertThat(res.getEmail()).isEqualTo("new@example.com");
+            assertThat(subscriptionRepository.existsByEmail("new@example.com")).isTrue();
+
+            assertThatThrownBy(() -> recruitmentService.subscribe(request))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.DUPLICATE_EMAIL);
+        }
+    }
+
+    @Nested
+    @DisplayName("지원서 제출 end-to-end")
+    class Submit {
+
+        @Test
+        @DisplayName("신규 제출 → Applicant(SUBMITTED) + 답변이 실제 DB에 저장")
+        void submitNew() {
+            Recruitment r = saveActiveRecruitment(27);
+            User u = saveUser();
+            Long commonQ = saveQuestion(r, Category.COMMON, 1).getId();
+            Long trackQ = saveQuestion(r, Category.ENGINEERING, 2).getId();
+            em.flush();
+            em.clear();
+
+            ApplicationResponse res = recruitmentService.submitApplication(
+                    u.getId(), r.getId(), buildSubmitRequest(Track.ENGINEERING, commonQ, trackQ));
+            em.flush();
+            em.clear();
+
+            Applicant saved = applicantRepository.findById(res.getApplicantId()).orElseThrow();
+            assertThat(saved.getStatus()).isEqualTo(Applicant.ApplicantStatus.SUBMITTED);
+            assertThat(saved.getSubmittedAt()).isNotNull();
+            assertThat(answerRepository.findByApplicantIds(List.of(saved.getId()))).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("DRAFT 존재 시 제출 → 같은 레코드가 SUBMITTED 로 전환")
+        void draftToSubmitted() {
+            Recruitment r = saveActiveRecruitment(27);
+            User u = saveUser();
+            Long commonQ = saveQuestion(r, Category.COMMON, 1).getId();
+            Long trackQ = saveQuestion(r, Category.ENGINEERING, 2).getId();
+            Applicant draft = applicantRepository.save(Applicant.builder()
+                    .recruitment(r).user(u).status(Applicant.ApplicantStatus.DRAFT)
+                    .track(Track.ENGINEERING).name("임시").email("temp@example.com").phone("01000000000")
+                    .build());
+            Long draftId = draft.getId();
+            em.flush();
+            em.clear();
+
+            ApplicationResponse res = recruitmentService.submitApplication(
+                    u.getId(), r.getId(), buildSubmitRequest(Track.ENGINEERING, commonQ, trackQ));
+            em.flush();
+
+            assertThat(res.getApplicantId()).isEqualTo(draftId);
+            assertThat(applicantRepository.findById(draftId).orElseThrow().getStatus())
+                    .isEqualTo(Applicant.ApplicantStatus.SUBMITTED);
+            assertThat(applicantRepository.count()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("이미 SUBMITTED 상태에서 재제출 → ALREADY_SUBMITTED")
+        void alreadySubmitted() {
+            Recruitment r = saveActiveRecruitment(27);
+            User u = saveUser();
+            Long commonQ = saveQuestion(r, Category.COMMON, 1).getId();
+            Long trackQ = saveQuestion(r, Category.ENGINEERING, 2).getId();
+            Applicant submitted = Applicant.builder()
+                    .recruitment(r).user(u).status(Applicant.ApplicantStatus.SUBMITTED)
+                    .track(Track.ENGINEERING).name("홍길동").email("hong@example.com").phone("01012345678")
+                    .build();
+            submitted.markSubmitted();
+            applicantRepository.save(submitted);
+            em.flush();
+            em.clear();
+
+            assertThatThrownBy(() -> recruitmentService.submitApplication(
+                    u.getId(), r.getId(), buildSubmitRequest(Track.ENGINEERING, commonQ, trackQ)))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.ALREADY_SUBMITTED);
+        }
+    }
+
+    @Nested
+    @DisplayName("어드민 흐름")
+    class Admin {
+
+        @Test
+        @DisplayName("마감된 공고의 지원서 전체 삭제 → answer/applicant 모두 제거")
+        void deleteApplicants() {
+            Recruitment r = saveClosedRecruitment(26);
+            User u = saveUser();
+            ApplicationQuestion q = saveQuestion(r, Category.COMMON, 1);
+            Applicant a = applicantRepository.save(Applicant.builder()
+                    .recruitment(r).user(u).status(Applicant.ApplicantStatus.SUBMITTED)
+                    .track(Track.ENGINEERING).name("n").email("a@example.com").phone("01012345678")
+                    .build());
+            answerRepository.save(com.boaz.backend.domain.recruitment.entity.ApplicantAnswer.builder()
+                    .applicant(a).question(q).answerText("답").build());
+            em.flush();
+            em.clear();
+
+            recruitmentService.deleteApplicants(r.getId());
+            em.flush();
+            em.clear();
+
+            assertThat(applicantRepository.existsByRecruitmentId(r.getId())).isFalse();
+            assertThat(answerRepository.findByApplicantIds(List.of(a.getId()))).isEmpty();
+        }
+
+        @Test
+        @DisplayName("모집 진행 중 공고의 지원서 삭제 시도 → RECRUITMENT_NOT_CLOSED")
+        void deleteWhileActive() {
+            Recruitment r = saveActiveRecruitment(27);
+            em.flush();
+
+            assertThatThrownBy(() -> recruitmentService.deleteApplicants(r.getId()))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.RECRUITMENT_NOT_CLOSED);
+        }
+
+        @Test
+        @DisplayName("구독 목록 최신순 조회 후 전체 삭제")
+        void subscriptionsLifecycle() {
+            subscriptionRepository.save(com.boaz.backend.domain.recruitment.entity.Subscription.builder()
+                    .email("a@example.com").build());
+            subscriptionRepository.save(com.boaz.backend.domain.recruitment.entity.Subscription.builder()
+                    .email("b@example.com").build());
+            em.flush();
+
+            List<SubscriptionResponse> list = recruitmentService.getAllSubscriptions();
+            assertThat(list).hasSize(2);
+
+            recruitmentService.deleteAllSubscriptions();
+            em.flush();
+
+            assertThat(subscriptionRepository.count()).isZero();
+        }
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/recruitment/repository/ApplicantAnswerRepositoryTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/repository/ApplicantAnswerRepositoryTest.java
@@ -1,0 +1,126 @@
+package com.boaz.backend.domain.recruitment.repository;
+
+import com.boaz.backend.domain.recruitment.entity.Applicant;
+import com.boaz.backend.domain.recruitment.entity.ApplicantAnswer;
+import com.boaz.backend.domain.recruitment.entity.ApplicationQuestion;
+import com.boaz.backend.domain.recruitment.entity.ApplicationQuestion.Category;
+import com.boaz.backend.domain.recruitment.entity.ApplicationQuestion.Type;
+import com.boaz.backend.domain.recruitment.entity.Recruitment;
+import com.boaz.backend.domain.user.entity.User;
+import com.boaz.backend.global.common.enums.MemberType;
+import com.boaz.backend.global.common.enums.Track;
+import com.boaz.backend.global.config.JpaConfig;
+import com.boaz.backend.support.TestcontainersBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(JpaConfig.class)
+@ActiveProfiles("test")
+class ApplicantAnswerRepositoryTest extends TestcontainersBase {
+
+    @Autowired ApplicantAnswerRepository answerRepository;
+    @Autowired TestEntityManager em;
+
+    private int userSeq = 0;
+
+    private Recruitment persistRecruitment(int term) {
+        LocalDateTime now = LocalDateTime.now();
+        return em.persistFlushFind(Recruitment.create(term, now.minusDays(1), now.plusDays(1), "{}", null));
+    }
+
+    private User persistUser() {
+        User u = User.builder()
+                .provider("kakao").providerId("p" + (++userSeq))
+                .nickname("nick").memberType(MemberType.OUTSIDER)
+                .build();
+        return em.persistFlushFind(u);
+    }
+
+    private Applicant persistApplicant(Recruitment r) {
+        Applicant a = Applicant.builder()
+                .recruitment(r).user(persistUser()).status(Applicant.ApplicantStatus.DRAFT)
+                .track(Track.ENGINEERING).name("n").email("a@example.com").phone("01012345678")
+                .build();
+        return em.persistFlushFind(a);
+    }
+
+    private ApplicationQuestion persistQuestion(Recruitment r, int orderNum) {
+        ApplicationQuestion q = ApplicationQuestion.create(
+                r, "label" + orderNum, Category.COMMON, Type.TEXT, "content", 500, null, orderNum, true);
+        return em.persistFlushFind(q);
+    }
+
+    private void persistAnswer(Applicant a, ApplicationQuestion q, String text) {
+        em.persist(ApplicantAnswer.builder().applicant(a).question(q).answerText(text).build());
+    }
+
+    @Test
+    @DisplayName("existsByQuestionId / findByApplicantIds")
+    void existsAndFind() {
+        Recruitment r = persistRecruitment(27);
+        ApplicationQuestion q1 = persistQuestion(r, 1);
+        ApplicationQuestion q2 = persistQuestion(r, 2);
+        Applicant a = persistApplicant(r);
+        persistAnswer(a, q1, "답1");
+        persistAnswer(a, q2, "답2");
+        em.flush();
+        em.clear();
+
+        assertThat(answerRepository.existsByQuestionId(q1.getId())).isTrue();
+
+        List<ApplicantAnswer> answers = answerRepository.findByApplicantIds(List.of(a.getId()));
+        assertThat(answers).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("deleteByApplicantId: 해당 지원자 답변만 벌크 삭제")
+    void deleteByApplicantId() {
+        Recruitment r = persistRecruitment(27);
+        ApplicationQuestion q = persistQuestion(r, 1);
+        Applicant a = persistApplicant(r);
+        Applicant b = persistApplicant(r);
+        persistAnswer(a, q, "A-답");
+        persistAnswer(a, q, "A-답2");
+        persistAnswer(b, q, "B-답");
+        em.flush();
+
+        answerRepository.deleteByApplicantId(a.getId());
+        em.clear();
+
+        assertThat(answerRepository.findByApplicantIds(List.of(a.getId()))).isEmpty();
+        assertThat(answerRepository.findByApplicantIds(List.of(b.getId()))).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("deleteByRecruitmentId: 서브쿼리로 공고 단위 답변 벌크 삭제")
+    void deleteByRecruitmentId() {
+        Recruitment rA = persistRecruitment(27);
+        Recruitment rB = persistRecruitment(26);
+        ApplicationQuestion qA = persistQuestion(rA, 1);
+        ApplicationQuestion qB = persistQuestion(rB, 1);
+        Applicant aA = persistApplicant(rA);
+        Applicant aB = persistApplicant(rB);
+        persistAnswer(aA, qA, "A");
+        persistAnswer(aB, qB, "B");
+        em.flush();
+
+        answerRepository.deleteByRecruitmentId(rA.getId());
+        em.clear();
+
+        assertThat(answerRepository.findByApplicantIds(List.of(aA.getId()))).isEmpty();
+        assertThat(answerRepository.findByApplicantIds(List.of(aB.getId()))).hasSize(1);
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/recruitment/repository/ApplicantRepositoryTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/repository/ApplicantRepositoryTest.java
@@ -1,0 +1,152 @@
+package com.boaz.backend.domain.recruitment.repository;
+
+import com.boaz.backend.domain.recruitment.entity.Applicant;
+import com.boaz.backend.domain.recruitment.entity.Recruitment;
+import com.boaz.backend.domain.user.entity.User;
+import com.boaz.backend.global.common.enums.MemberType;
+import com.boaz.backend.global.common.enums.Track;
+import com.boaz.backend.global.config.JpaConfig;
+import com.boaz.backend.support.TestcontainersBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(JpaConfig.class)
+@ActiveProfiles("test")
+class ApplicantRepositoryTest extends TestcontainersBase {
+
+    @Autowired ApplicantRepository applicantRepository;
+    @Autowired TestEntityManager em;
+
+    private Recruitment persistRecruitment(int term) {
+        LocalDateTime now = LocalDateTime.now();
+        Recruitment r = Recruitment.create(term, now.minusDays(1), now.plusDays(1), "{}", null);
+        return em.persistFlushFind(r);
+    }
+
+    private User persistUser(String providerId) {
+        User u = User.builder()
+                .provider("kakao").providerId(providerId)
+                .nickname("nick-" + providerId).memberType(MemberType.OUTSIDER)
+                .build();
+        return em.persistFlushFind(u);
+    }
+
+    private Applicant persistApplicant(Recruitment r, User u, Track track,
+                                       Applicant.ApplicantStatus status, LocalDateTime submittedAt) {
+        Applicant a = Applicant.builder()
+                .recruitment(r).user(u).status(status).track(track)
+                .name("name").email("a@example.com").phone("01012345678")
+                .build();
+        if (submittedAt != null) {
+            ReflectionTestUtils.setField(a, "submittedAt", submittedAt);
+        }
+        return em.persistFlushFind(a);
+    }
+
+    @Nested
+    @DisplayName("findByRecruitmentIdAndUserId")
+    class FindByRecruitmentIdAndUserId {
+
+        @Test
+        @DisplayName("(recruitmentId, userId) 조합 일치 시 반환, 불일치 시 empty")
+        void match() {
+            Recruitment r = persistRecruitment(27);
+            User u = persistUser("p1");
+            persistApplicant(r, u, Track.ENGINEERING, Applicant.ApplicantStatus.DRAFT, null);
+
+            assertThat(applicantRepository.findByRecruitmentIdAndUserId(r.getId(), u.getId())).isPresent();
+            assertThat(applicantRepository.findByRecruitmentIdAndUserId(r.getId(), 999L)).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findSubmittedByRecruitmentIdAndTrackOrderBySubmittedAt")
+    class FindSubmittedByTrack {
+
+        @Test
+        @DisplayName("지정 트랙 SUBMITTED 만 submitted_at 오름차순, user JOIN FETCH")
+        void submittedOrdered() {
+            Recruitment r = persistRecruitment(27);
+            LocalDateTime base = LocalDateTime.now();
+
+            // ENGINEERING SUBMITTED 2건 (삽입 순서와 submittedAt 순서를 반대로)
+            persistApplicant(r, persistUser("eng-late"), Track.ENGINEERING,
+                    Applicant.ApplicantStatus.SUBMITTED, base.plusHours(2));
+            persistApplicant(r, persistUser("eng-early"), Track.ENGINEERING,
+                    Applicant.ApplicantStatus.SUBMITTED, base.plusHours(1));
+            // 다른 트랙 / DRAFT 는 제외돼야 함
+            persistApplicant(r, persistUser("ana"), Track.ANALYSIS,
+                    Applicant.ApplicantStatus.SUBMITTED, base.plusHours(1));
+            persistApplicant(r, persistUser("eng-draft"), Track.ENGINEERING,
+                    Applicant.ApplicantStatus.DRAFT, null);
+            em.clear();
+
+            List<Applicant> result = applicantRepository
+                    .findSubmittedByRecruitmentIdAndTrackOrderBySubmittedAt(
+                            r.getId(), Track.ENGINEERING, Applicant.ApplicantStatus.SUBMITTED);
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).getSubmittedAt()).isBefore(result.get(1).getSubmittedAt());
+            // JOIN FETCH 로 user 가 즉시 로딩되어 접근 가능해야 함
+            assertThat(result.get(0).getUser().getId()).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("existsByRecruitmentId / deleteByRecruitmentId")
+    class ExistsAndDelete {
+
+        @Test
+        @DisplayName("공고 연관 지원자 존재 여부 및 공고 단위 삭제")
+        void existsAndDelete() {
+            Recruitment r = persistRecruitment(27);
+            persistApplicant(r, persistUser("p1"), Track.ENGINEERING, Applicant.ApplicantStatus.DRAFT, null);
+
+            assertThat(applicantRepository.existsByRecruitmentId(r.getId())).isTrue();
+
+            applicantRepository.deleteByRecruitmentId(r.getId());
+            em.flush();
+            em.clear();
+
+            assertThat(applicantRepository.existsByRecruitmentId(r.getId())).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByUserIdAndStatus")
+    class FindByUserIdAndStatus {
+
+        @Test
+        @DisplayName("userId + status 로 조회 (recruitment JOIN FETCH)")
+        void byUserAndStatus() {
+            Recruitment r = persistRecruitment(27);
+            User u = persistUser("p1");
+            persistApplicant(r, u, Track.ENGINEERING, Applicant.ApplicantStatus.SUBMITTED, LocalDateTime.now());
+            em.clear();
+
+            Optional<Applicant> found = applicantRepository.findByUserIdAndStatus(
+                    u.getId(), Applicant.ApplicantStatus.SUBMITTED);
+
+            assertThat(found).isPresent();
+            assertThat(found.get().getRecruitment().getTerm()).isEqualTo(27);
+            assertThat(applicantRepository.findByUserIdAndStatus(
+                    u.getId(), Applicant.ApplicantStatus.DRAFT)).isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/recruitment/repository/ApplicationQuestionRepositoryTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/repository/ApplicationQuestionRepositoryTest.java
@@ -1,0 +1,97 @@
+package com.boaz.backend.domain.recruitment.repository;
+
+import com.boaz.backend.domain.recruitment.entity.ApplicationQuestion;
+import com.boaz.backend.domain.recruitment.entity.ApplicationQuestion.Category;
+import com.boaz.backend.domain.recruitment.entity.ApplicationQuestion.Type;
+import com.boaz.backend.domain.recruitment.entity.Recruitment;
+import com.boaz.backend.global.config.JpaConfig;
+import com.boaz.backend.support.TestcontainersBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(JpaConfig.class)
+@ActiveProfiles("test")
+class ApplicationQuestionRepositoryTest extends TestcontainersBase {
+
+    @Autowired ApplicationQuestionRepository questionRepository;
+    @Autowired TestEntityManager em;
+
+    private Recruitment persistRecruitment(int term) {
+        LocalDateTime now = LocalDateTime.now();
+        return em.persistFlushFind(Recruitment.create(term, now.minusDays(1), now.plusDays(1), "{}", null));
+    }
+
+    private void persistQuestion(Recruitment r, String label, Category category, int orderNum) {
+        ApplicationQuestion q = ApplicationQuestion.create(
+                r, label, category, Type.TEXT, "content", 500, null, orderNum, true);
+        em.persist(q);
+    }
+
+    @Test
+    @DisplayName("findByRecruitmentIdAndCategories: COMMON + 지정 트랙만, order_num 오름차순")
+    void findByCategories() {
+        Recruitment r = persistRecruitment(27);
+        persistQuestion(r, "공통2", Category.COMMON, 2);
+        persistQuestion(r, "공통1", Category.COMMON, 1);
+        persistQuestion(r, "엔지니어링", Category.ENGINEERING, 3);
+        persistQuestion(r, "시각화", Category.VISUALIZATION, 1);
+        em.flush();
+        em.clear();
+
+        List<ApplicationQuestion> result = questionRepository.findByRecruitmentIdAndCategories(
+                r.getId(), Category.COMMON, Category.ENGINEERING);
+
+        assertThat(result).hasSize(3);
+        assertThat(result).extracting(ApplicationQuestion::getOrderNum).containsExactly(1, 2, 3);
+        assertThat(result).noneMatch(q -> q.getCategory() == Category.VISUALIZATION);
+    }
+
+    @Test
+    @DisplayName("findByRecruitmentIdOrderByOrderNumAsc: order_num 오름차순 전체")
+    void findOrdered() {
+        Recruitment r = persistRecruitment(27);
+        persistQuestion(r, "q3", Category.COMMON, 3);
+        persistQuestion(r, "q1", Category.COMMON, 1);
+        persistQuestion(r, "q2", Category.ENGINEERING, 2);
+        em.flush();
+        em.clear();
+
+        List<ApplicationQuestion> result = questionRepository.findByRecruitmentIdOrderByOrderNumAsc(r.getId());
+
+        assertThat(result).extracting(ApplicationQuestion::getOrderNum).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("중복 검증 쿼리: label / (category, order_num) / 자기 자신 제외")
+    void existsQueries() {
+        Recruitment r = persistRecruitment(27);
+        persistQuestion(r, "공통1", Category.COMMON, 1);
+        em.flush();
+        Long savedId = questionRepository.findByRecruitmentIdOrderByOrderNumAsc(r.getId()).get(0).getId();
+        em.clear();
+
+        assertThat(questionRepository.existsByRecruitmentIdAndLabel(r.getId(), "공통1")).isTrue();
+        assertThat(questionRepository.existsByRecruitmentIdAndLabel(r.getId(), "없는라벨")).isFalse();
+
+        assertThat(questionRepository.existsByRecruitmentIdAndCategoryAndOrderNum(
+                r.getId(), Category.COMMON, 1)).isTrue();
+        // 자기 자신(savedId) 제외 시 중복 아님
+        assertThat(questionRepository.existsByRecruitmentIdAndCategoryAndOrderNumAndIdNot(
+                r.getId(), Category.COMMON, 1, savedId)).isFalse();
+        assertThat(questionRepository.existsByRecruitmentIdAndCategoryAndOrderNumAndIdNot(
+                r.getId(), Category.COMMON, 1, savedId + 1)).isTrue();
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/recruitment/repository/RecruitmentRepositoryTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/repository/RecruitmentRepositoryTest.java
@@ -1,0 +1,132 @@
+package com.boaz.backend.domain.recruitment.repository;
+
+import com.boaz.backend.domain.recruitment.entity.Recruitment;
+import com.boaz.backend.global.config.JpaConfig;
+import com.boaz.backend.support.TestcontainersBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(JpaConfig.class)
+@ActiveProfiles("test")
+class RecruitmentRepositoryTest extends TestcontainersBase {
+
+    @Autowired RecruitmentRepository recruitmentRepository;
+    @Autowired TestEntityManager em;
+
+    private Recruitment persistRecruitment(int term, LocalDateTime start, LocalDateTime end) {
+        Recruitment r = Recruitment.create(term, start, end, "{}", null);
+        return em.persistFlushFind(r);
+    }
+
+    // ──────────────────────────────────────────────
+    // findActiveRecruitment: start_date <= now <= end_date
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("findActiveRecruitment")
+    class FindActiveRecruitment {
+
+        @Test
+        @DisplayName("now 가 모집 기간 내면 해당 공고 반환")
+        void within() {
+            LocalDateTime now = LocalDateTime.now();
+            persistRecruitment(27, now.minusDays(1), now.plusDays(1));
+
+            Optional<Recruitment> result = recruitmentRepository.findActiveRecruitment(now);
+
+            assertThat(result).isPresent();
+            assertThat(result.get().getTerm()).isEqualTo(27);
+        }
+
+        @Test
+        @DisplayName("now 가 모집 종료 이후면 empty")
+        void afterEnd() {
+            LocalDateTime now = LocalDateTime.now();
+            persistRecruitment(27, now.minusDays(10), now.minusDays(1));
+
+            assertThat(recruitmentRepository.findActiveRecruitment(now)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("경계: start_date 정각도 모집 중 포함")
+        void startBoundaryInclusive() {
+            LocalDateTime now = LocalDateTime.now();
+            persistRecruitment(27, now, now.plusDays(7));
+
+            assertThat(recruitmentRepository.findActiveRecruitment(now)).isPresent();
+        }
+
+        @Test
+        @DisplayName("경계: end_date 정각도 모집 중 포함")
+        void endBoundaryInclusive() {
+            LocalDateTime now = LocalDateTime.now();
+            persistRecruitment(27, now.minusDays(7), now);
+
+            assertThat(recruitmentRepository.findActiveRecruitment(now)).isPresent();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByTerm / existsByTerm")
+    class ByTerm {
+
+        @Test
+        @DisplayName("기수로 공고 조회")
+        void findByTerm() {
+            LocalDateTime now = LocalDateTime.now();
+            persistRecruitment(26, now.minusDays(1), now.plusDays(1));
+
+            assertThat(recruitmentRepository.findByTerm(26)).isPresent();
+            assertThat(recruitmentRepository.findByTerm(99)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("existsByTerm: 존재/미존재")
+        void existsByTerm() {
+            LocalDateTime now = LocalDateTime.now();
+            persistRecruitment(26, now.minusDays(1), now.plusDays(1));
+
+            assertThat(recruitmentRepository.existsByTerm(26)).isTrue();
+            assertThat(recruitmentRepository.existsByTerm(27)).isFalse();
+        }
+
+        @Test
+        @DisplayName("existsByTermAndIdNot: 자기 자신은 중복으로 보지 않음")
+        void existsByTermAndIdNot() {
+            LocalDateTime now = LocalDateTime.now();
+            Recruitment r = persistRecruitment(26, now.minusDays(1), now.plusDays(1));
+
+            // 같은 term 이지만 자기 자신(id) 제외 → 중복 아님
+            assertThat(recruitmentRepository.existsByTermAndIdNot(26, r.getId())).isFalse();
+            // 다른 id 기준으로 보면 중복
+            assertThat(recruitmentRepository.existsByTermAndIdNot(26, r.getId() + 1)).isTrue();
+        }
+    }
+
+    @Test
+    @DisplayName("findAllByOrderByTermDesc: term 내림차순 정렬")
+    void findAllByOrderByTermDesc() {
+        LocalDateTime now = LocalDateTime.now();
+        persistRecruitment(25, now.minusDays(1), now.plusDays(1));
+        persistRecruitment(27, now.minusDays(1), now.plusDays(1));
+        persistRecruitment(26, now.minusDays(1), now.plusDays(1));
+
+        List<Recruitment> result = recruitmentRepository.findAllByOrderByTermDesc();
+
+        assertThat(result).extracting(Recruitment::getTerm).containsExactly(27, 26, 25);
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/recruitment/repository/SubscriptionRepositoryTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/repository/SubscriptionRepositoryTest.java
@@ -1,0 +1,83 @@
+package com.boaz.backend.domain.recruitment.repository;
+
+import com.boaz.backend.domain.recruitment.entity.Subscription;
+import com.boaz.backend.global.config.JpaConfig;
+import com.boaz.backend.support.TestcontainersBase;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(JpaConfig.class)
+@ActiveProfiles("test")
+class SubscriptionRepositoryTest extends TestcontainersBase {
+
+    @Autowired SubscriptionRepository subscriptionRepository;
+    @Autowired TestEntityManager em;
+
+    @Test
+    @DisplayName("existsByEmail / unique 제약 위반")
+    void existsAndUnique() {
+        subscriptionRepository.saveAndFlush(Subscription.builder().email("a@example.com").build());
+
+        assertThat(subscriptionRepository.existsByEmail("a@example.com")).isTrue();
+        assertThat(subscriptionRepository.existsByEmail("none@example.com")).isFalse();
+
+        // 동일 email 중복 저장 → unique 제약 위반
+        assertThatThrownBy(() ->
+                subscriptionRepository.saveAndFlush(Subscription.builder().email("a@example.com").build()))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("findAllByOrderByCreatedAtDesc: created_at 내림차순(최신순)")
+    void orderByCreatedAtDesc() {
+        Subscription s1 = subscriptionRepository.saveAndFlush(Subscription.builder().email("old@example.com").build());
+        Subscription s2 = subscriptionRepository.saveAndFlush(Subscription.builder().email("mid@example.com").build());
+        Subscription s3 = subscriptionRepository.saveAndFlush(Subscription.builder().email("new@example.com").build());
+
+        // @CreatedDate 는 동일 트랜잭션에서 같은 값이 될 수 있으므로 created_at 을 네이티브로 명시 세팅
+        EntityManager entityManager = em.getEntityManager();
+        setCreatedAt(entityManager, s1.getId(), "2026-03-01 10:00:00");
+        setCreatedAt(entityManager, s2.getId(), "2026-03-10 10:00:00");
+        setCreatedAt(entityManager, s3.getId(), "2026-03-15 10:00:00");
+        em.clear();
+
+        List<Subscription> result = subscriptionRepository.findAllByOrderByCreatedAtDesc();
+
+        assertThat(result).extracting(Subscription::getEmail)
+                .containsExactly("new@example.com", "mid@example.com", "old@example.com");
+    }
+
+    @Test
+    @DisplayName("deleteAll: 전체 삭제")
+    void deleteAll() {
+        subscriptionRepository.saveAndFlush(Subscription.builder().email("a@example.com").build());
+        subscriptionRepository.saveAndFlush(Subscription.builder().email("b@example.com").build());
+
+        subscriptionRepository.deleteAll();
+        em.flush();
+
+        assertThat(subscriptionRepository.count()).isZero();
+    }
+
+    private void setCreatedAt(EntityManager entityManager, Long id, String createdAt) {
+        entityManager.createNativeQuery("UPDATE subscription SET created_at = ?1 WHERE id = ?2")
+                .setParameter(1, createdAt)
+                .setParameter(2, id)
+                .executeUpdate();
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/service/RecruitmentServiceTest.java
@@ -1,0 +1,1094 @@
+package com.boaz.backend.domain.recruitment.service;
+
+import com.boaz.backend.domain.recruitment.dto.request.AnswerRequest;
+import com.boaz.backend.domain.recruitment.dto.request.ApplicationRequest;
+import com.boaz.backend.domain.recruitment.dto.request.DraftApplicationRequest;
+import com.boaz.backend.domain.recruitment.dto.request.SubscriptionRequest;
+import com.boaz.backend.domain.recruitment.dto.response.*;
+import com.boaz.backend.domain.recruitment.entity.*;
+import com.boaz.backend.domain.recruitment.repository.*;
+import com.boaz.backend.domain.user.entity.User;
+import com.boaz.backend.domain.user.repository.UserRepository;
+import com.boaz.backend.global.common.enums.MemberType;
+import com.boaz.backend.global.common.enums.Track;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import com.boaz.backend.global.util.S3Service;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RecruitmentServiceTest {
+
+    @InjectMocks
+    RecruitmentService recruitmentService;
+
+    @Mock RecruitmentRepository recruitmentRepository;
+    @Mock ApplicationQuestionRepository applicationQuestionRepository;
+    @Mock ApplicantRepository applicantRepository;
+    @Mock ApplicantAnswerRepository applicantAnswerRepository;
+    @Mock UserRepository userRepository;
+    @Mock SubscriptionRepository subscriptionRepository;
+    @Mock S3Service s3Service;
+    @Mock CsvService csvService;
+    @Spy  ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(recruitmentService, "recruitmentBucket", "test-bucket");
+    }
+
+    // ──────────────────────────────────────────────
+    // 헬퍼
+    // ──────────────────────────────────────────────
+
+    private Recruitment createActiveRecruitment() {
+        Recruitment r = Recruitment.create(27,
+                LocalDateTime.now().minusDays(1), LocalDateTime.now().plusDays(1),
+                "[]", "https://example.com/brochure.pdf");
+        ReflectionTestUtils.setField(r, "id", 1L);
+        return r;
+    }
+
+    private Recruitment createExpiredRecruitment() {
+        Recruitment r = Recruitment.create(26,
+                LocalDateTime.now().minusDays(10), LocalDateTime.now().minusDays(1),
+                "[]", null);
+        ReflectionTestUtils.setField(r, "id", 2L);
+        return r;
+    }
+
+    private User createUser(Long id) {
+        User u = User.builder()
+                .provider("kakao").providerId("test-" + id)
+                .nickname("홍길동").memberType(MemberType.OUTSIDER)
+                .build();
+        ReflectionTestUtils.setField(u, "id", id);
+        return u;
+    }
+
+    private ApplicationQuestion createTextQuestion(Long id, Recruitment r,
+            ApplicationQuestion.Category category, int orderNum, boolean required) {
+        ApplicationQuestion q = ApplicationQuestion.create(
+                r, "label-" + id, category,
+                ApplicationQuestion.Type.TEXT, "질문내용 " + id,
+                500, null, orderNum, required);
+        ReflectionTestUtils.setField(q, "id", id);
+        return q;
+    }
+
+    private ApplicationQuestion createTableQuestion(Long id, Recruitment r,
+            ApplicationQuestion.Category category, int orderNum, boolean required) {
+        ApplicationQuestion q = ApplicationQuestion.create(
+                r, "label-t-" + id, category,
+                ApplicationQuestion.Type.TABLE, "테이블질문 " + id,
+                null, "{\"rows\":[\"A\"],\"columns\":[\"B\"]}", orderNum, required);
+        ReflectionTestUtils.setField(q, "id", id);
+        return q;
+    }
+
+    private Applicant createDraftApplicant(Recruitment r, User u) {
+        Applicant a = Applicant.builder()
+                .recruitment(r).user(u)
+                .status(Applicant.ApplicantStatus.DRAFT)
+                .track(Track.ENGINEERING)
+                .name("홍길동").email("hong@example.com")
+                .build();
+        ReflectionTestUtils.setField(a, "id", 42L);
+        return a;
+    }
+
+    private Applicant createSubmittedApplicant(Recruitment r, User u) {
+        Applicant a = Applicant.builder()
+                .recruitment(r).user(u)
+                .status(Applicant.ApplicantStatus.SUBMITTED)
+                .track(Track.ENGINEERING)
+                .name("홍길동").email("hong@example.com")
+                .phone("01012345678").university("한국대")
+                .major("컴공").build();
+        ReflectionTestUtils.setField(a, "id", 42L);
+        ReflectionTestUtils.setField(a, "submittedAt", LocalDateTime.now());
+        return a;
+    }
+
+    private ApplicationRequest buildApplicationRequest(List<AnswerRequest> answers) {
+        ApplicationRequest req = new ApplicationRequest();
+        ReflectionTestUtils.setField(req, "track", Track.ENGINEERING);
+        ReflectionTestUtils.setField(req, "name", "홍길동");
+        ReflectionTestUtils.setField(req, "email", "hong@example.com");
+        ReflectionTestUtils.setField(req, "phone", "01012345678");
+        ReflectionTestUtils.setField(req, "university", "한국대학교");
+        ReflectionTestUtils.setField(req, "major", "컴퓨터공학");
+        ReflectionTestUtils.setField(req, "lastSemester", 6);
+        ReflectionTestUtils.setField(req, "militaryStatus", Applicant.MilitaryStatus.COMPLETED_OR_EXEMPT);
+        ReflectionTestUtils.setField(req, "birthDate", "2000-01-01");
+        ReflectionTestUtils.setField(req, "graduationDate", "2026-02");
+        ReflectionTestUtils.setField(req, "gradSchoolPlan", false);
+        ReflectionTestUtils.setField(req, "answers", answers);
+        return req;
+    }
+
+    private AnswerRequest buildTextAnswer(Long questionId, String text) {
+        AnswerRequest a = new AnswerRequest();
+        ReflectionTestUtils.setField(a, "questionId", questionId);
+        ReflectionTestUtils.setField(a, "answer", TextNode.valueOf(text));
+        return a;
+    }
+
+    private AnswerRequest buildJsonAnswer(Long questionId, JsonNode node) {
+        AnswerRequest a = new AnswerRequest();
+        ReflectionTestUtils.setField(a, "questionId", questionId);
+        ReflectionTestUtils.setField(a, "answer", node);
+        return a;
+    }
+
+    private Subscription createSubscription(Long id, String email) {
+        Subscription s = Subscription.builder().email(email).build();
+        ReflectionTestUtils.setField(s, "id", id);
+        return s;
+    }
+
+    // ══════════════════════════════════════════════
+    // REC-001: 모집 중 여부 조회
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("REC-001 모집 중 여부 조회")
+    class GetRecruitmentStatus {
+
+        @Test
+        @DisplayName("TC-001 모집 기간 중 → isActive:true, term 반환")
+        void active() {
+            Recruitment r = createActiveRecruitment();
+            when(recruitmentRepository.findActiveRecruitment(any())).thenReturn(Optional.of(r));
+
+            RecruitmentStatusResponse res = recruitmentService.getRecruitmentStatus();
+
+            assertThat(res.getIsActive()).isTrue();
+            assertThat(res.getTerm()).isEqualTo(27);
+        }
+
+        @Test
+        @DisplayName("TC-002 모집 기간 외 공고만 있을 때 → isActive:false")
+        void expiredRecruitment() {
+            when(recruitmentRepository.findActiveRecruitment(any())).thenReturn(Optional.empty());
+
+            RecruitmentStatusResponse res = recruitmentService.getRecruitmentStatus();
+
+            assertThat(res.getIsActive()).isFalse();
+            assertThat(res.getTerm()).isNull();
+        }
+
+        @Test
+        @DisplayName("TC-003 공고 데이터 없음 → isActive:false (예외 없음)")
+        void noData() {
+            when(recruitmentRepository.findActiveRecruitment(any())).thenReturn(Optional.empty());
+
+            RecruitmentStatusResponse res = recruitmentService.getRecruitmentStatus();
+
+            assertThat(res.getIsActive()).isFalse();
+        }
+
+        @Test
+        @DisplayName("TC-004 start_date 정각 → isActive:true")
+        void startDateBoundary() {
+            LocalDateTime now = LocalDateTime.now();
+            Recruitment r = Recruitment.create(27, now, now.plusDays(7), "[]", null);
+            ReflectionTestUtils.setField(r, "id", 1L);
+            when(recruitmentRepository.findActiveRecruitment(any())).thenReturn(Optional.of(r));
+
+            assertThat(recruitmentService.getRecruitmentStatus().getIsActive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("TC-005 end_date 1초 초과 → isActive:false")
+        void endDatePast() {
+            when(recruitmentRepository.findActiveRecruitment(any())).thenReturn(Optional.empty());
+
+            assertThat(recruitmentService.getRecruitmentStatus().getIsActive()).isFalse();
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // REC-002: 기수별 모집 공고 조회
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("REC-002 기수별 모집 공고 조회")
+    class GetRecruitment {
+
+        @Test
+        @DisplayName("TC-001 존재하는 기수 조회 → 공고 반환")
+        void found() {
+            Recruitment r = createActiveRecruitment();
+            when(recruitmentRepository.findByTerm(27)).thenReturn(Optional.of(r));
+
+            RecruitmentResponse res = recruitmentService.getRecruitment(27);
+
+            assertThat(res.getTerm()).isEqualTo(27);
+            assertThat(res.getIsActive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("TC-002 모집 마감된 공고 조회 → isActive:false (404 아님)")
+        void expiredRecruitment() {
+            Recruitment r = createExpiredRecruitment();
+            when(recruitmentRepository.findByTerm(26)).thenReturn(Optional.of(r));
+
+            RecruitmentResponse res = recruitmentService.getRecruitment(26);
+
+            assertThat(res.getIsActive()).isFalse();
+        }
+
+        @Test
+        @DisplayName("TC-003 존재하지 않는 기수 → RECRUITMENT_NOT_FOUND")
+        void notFound() {
+            when(recruitmentRepository.findByTerm(999)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> recruitmentService.getRecruitment(999))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.RECRUITMENT_NOT_FOUND);
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // REC-003: 지원서 질문 목록 조회
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("REC-003 지원서 질문 목록 조회")
+    class GetQuestions {
+
+        @Test
+        @DisplayName("TC-001 ENGINEERING 트랙 → COMMON + ENGINEERING 질문 반환 (order_num 오름차순)")
+        void engineering() {
+            Recruitment r = createActiveRecruitment();
+            ApplicationQuestion q1 = createTextQuestion(1L, r, ApplicationQuestion.Category.COMMON, 1, true);
+            ApplicationQuestion q2 = createTextQuestion(2L, r, ApplicationQuestion.Category.COMMON, 2, true);
+            ApplicationQuestion q3 = createTextQuestion(3L, r, ApplicationQuestion.Category.ENGINEERING, 3, true);
+
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(r));
+            when(applicationQuestionRepository.findByRecruitmentIdAndCategories(
+                    eq(1L), eq(ApplicationQuestion.Category.COMMON), eq(ApplicationQuestion.Category.ENGINEERING)))
+                    .thenReturn(List.of(q1, q2, q3));
+
+            List<QuestionResponse> result = recruitmentService.getQuestions(1L, Track.ENGINEERING);
+
+            assertThat(result).hasSize(3);
+            assertThat(result.get(0).getOrderNum()).isLessThanOrEqualTo(result.get(1).getOrderNum());
+        }
+
+        @Test
+        @DisplayName("TC-002 모집 기간 외 → RECRUITMENT_NOT_AVAILABLE")
+        void notInPeriod() {
+            Recruitment r = createExpiredRecruitment();
+            when(recruitmentRepository.findById(2L)).thenReturn(Optional.of(r));
+
+            assertThatThrownBy(() -> recruitmentService.getQuestions(2L, Track.ANALYSIS))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.RECRUITMENT_NOT_AVAILABLE);
+        }
+
+        @Test
+        @DisplayName("TC-003 존재하지 않는 공고 → RECRUITMENT_NOT_FOUND")
+        void noRecruitment() {
+            when(recruitmentRepository.findById(999L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> recruitmentService.getQuestions(999L, Track.ENGINEERING))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.RECRUITMENT_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("TC-004 질문 없음 → QUESTIONS_NOT_FOUND")
+        void noQuestions() {
+            Recruitment r = createActiveRecruitment();
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(r));
+            when(applicationQuestionRepository.findByRecruitmentIdAndCategories(any(), any(), any()))
+                    .thenReturn(Collections.emptyList());
+
+            assertThatThrownBy(() -> recruitmentService.getQuestions(1L, Track.ENGINEERING))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.QUESTIONS_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("TC-005 track=ALL → INVALID_TRACK_SELECTION")
+        void trackAll() {
+            Recruitment r = createActiveRecruitment();
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(r));
+
+            assertThatThrownBy(() -> recruitmentService.getQuestions(1L, Track.ALL))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_TRACK_SELECTION);
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // REC-004: 지원서 제출
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("REC-004 지원서 제출")
+    class SubmitApplication {
+
+        private Recruitment activeRecruitment;
+        private User user;
+        private ApplicationQuestion q1;
+
+        @BeforeEach
+        void setUp() {
+            activeRecruitment = createActiveRecruitment();
+            user = createUser(1L);
+            q1 = createTextQuestion(1L, activeRecruitment, ApplicationQuestion.Category.COMMON, 1, true);
+        }
+
+        @Test
+        @DisplayName("TC-001 신규 지원서 제출 → SUBMITTED 생성, 201")
+        void newSubmit() {
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(activeRecruitment));
+            when(applicantRepository.findByRecruitmentIdAndUserId(1L, 1L)).thenReturn(Optional.empty());
+            when(applicationQuestionRepository.findByRecruitmentIdAndCategories(any(), any(), any()))
+                    .thenReturn(List.of(q1));
+            when(applicantRepository.save(any())).thenAnswer(inv -> {
+                Applicant a = inv.getArgument(0);
+                ReflectionTestUtils.setField(a, "id", 42L);
+                return a;
+            });
+
+            ApplicationRequest req = buildApplicationRequest(List.of(buildTextAnswer(1L, "답변내용")));
+            ApplicationResponse res = recruitmentService.submitApplication(1L, 1L, req);
+
+            assertThat(res.getApplicantId()).isEqualTo(42L);
+            verify(applicantRepository).save(any(Applicant.class));
+        }
+
+        @Test
+        @DisplayName("TC-002 DRAFT 존재 시 제출 → SUBMITTED 전환 (새 레코드 생성 안 함)")
+        void draftToSubmitted() {
+            Applicant draft = createDraftApplicant(activeRecruitment, user);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(activeRecruitment));
+            when(applicantRepository.findByRecruitmentIdAndUserId(1L, 1L)).thenReturn(Optional.of(draft));
+            when(applicationQuestionRepository.findByRecruitmentIdAndCategories(any(), any(), any()))
+                    .thenReturn(List.of(q1));
+
+            ApplicationRequest req = buildApplicationRequest(List.of(buildTextAnswer(1L, "답변내용")));
+            ApplicationResponse res = recruitmentService.submitApplication(1L, 1L, req);
+
+            assertThat(res.getApplicantId()).isEqualTo(42L);
+            verify(applicantAnswerRepository).deleteByApplicantId(42L);
+            verify(applicantRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("TC-003 이미 SUBMITTED → ALREADY_SUBMITTED")
+        void alreadySubmitted() {
+            Applicant submitted = createSubmittedApplicant(activeRecruitment, user);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(activeRecruitment));
+            when(applicantRepository.findByRecruitmentIdAndUserId(1L, 1L)).thenReturn(Optional.of(submitted));
+
+            ApplicationRequest req = buildApplicationRequest(List.of(buildTextAnswer(1L, "답변")));
+
+            assertThatThrownBy(() -> recruitmentService.submitApplication(1L, 1L, req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.ALREADY_SUBMITTED);
+        }
+
+        @Test
+        @DisplayName("TC-004 모집 기간 외 → RECRUITMENT_CLOSED")
+        void closed() {
+            Recruitment expired = createExpiredRecruitment();
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(expired));
+
+            ApplicationRequest req = buildApplicationRequest(List.of(buildTextAnswer(1L, "답변")));
+
+            assertThatThrownBy(() -> recruitmentService.submitApplication(1L, 1L, req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.RECRUITMENT_CLOSED);
+        }
+
+        @Test
+        @DisplayName("TC-005 이메일 형식 오류 → INVALID_EMAIL_FORMAT")
+        void invalidEmail() {
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(activeRecruitment));
+            when(applicantRepository.findByRecruitmentIdAndUserId(1L, 1L)).thenReturn(Optional.empty());
+
+            ApplicationRequest req = buildApplicationRequest(List.of(buildTextAnswer(1L, "답변")));
+            ReflectionTestUtils.setField(req, "email", "invalidemail");
+
+            assertThatThrownBy(() -> recruitmentService.submitApplication(1L, 1L, req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_EMAIL_FORMAT);
+        }
+
+        @Test
+        @DisplayName("TC-006 전화번호 형식 오류(하이픈) → INVALID_PHONE_FORMAT")
+        void invalidPhoneHyphen() {
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(activeRecruitment));
+            when(applicantRepository.findByRecruitmentIdAndUserId(1L, 1L)).thenReturn(Optional.empty());
+
+            ApplicationRequest req = buildApplicationRequest(List.of(buildTextAnswer(1L, "답변")));
+            ReflectionTestUtils.setField(req, "phone", "010-1234-5678");
+
+            assertThatThrownBy(() -> recruitmentService.submitApplication(1L, 1L, req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_PHONE_FORMAT);
+        }
+
+        @Test
+        @DisplayName("TC-006 전화번호 형식 오류(9자리) → INVALID_PHONE_FORMAT")
+        void invalidPhoneTooShort() {
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(activeRecruitment));
+            when(applicantRepository.findByRecruitmentIdAndUserId(1L, 1L)).thenReturn(Optional.empty());
+
+            ApplicationRequest req = buildApplicationRequest(List.of(buildTextAnswer(1L, "답변")));
+            ReflectionTestUtils.setField(req, "phone", "010123456");
+
+            assertThatThrownBy(() -> recruitmentService.submitApplication(1L, 1L, req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_PHONE_FORMAT);
+        }
+
+        @Test
+        @DisplayName("TC-007 생년월일 형식 오류 → INVALID_BIRTH_DATE_FORMAT")
+        void invalidBirthDate() {
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(activeRecruitment));
+            when(applicantRepository.findByRecruitmentIdAndUserId(1L, 1L)).thenReturn(Optional.empty());
+
+            ApplicationRequest req = buildApplicationRequest(List.of(buildTextAnswer(1L, "답변")));
+            ReflectionTestUtils.setField(req, "birthDate", "20000101");
+
+            assertThatThrownBy(() -> recruitmentService.submitApplication(1L, 1L, req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_BIRTH_DATE_FORMAT);
+        }
+
+        @Test
+        @DisplayName("TC-008 필수 질문 답변 누락 → ANSWER_REQUIRED")
+        void missingRequired() {
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(activeRecruitment));
+            when(applicantRepository.findByRecruitmentIdAndUserId(1L, 1L)).thenReturn(Optional.empty());
+            ApplicationQuestion q2 = createTextQuestion(2L, activeRecruitment, ApplicationQuestion.Category.COMMON, 2, true);
+            when(applicationQuestionRepository.findByRecruitmentIdAndCategories(any(), any(), any()))
+                    .thenReturn(List.of(q1, q2));
+
+            // q2(필수) 답변 누락
+            ApplicationRequest req = buildApplicationRequest(List.of(buildTextAnswer(1L, "답변")));
+
+            assertThatThrownBy(() -> recruitmentService.submitApplication(1L, 1L, req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.ANSWER_REQUIRED);
+        }
+
+        @Test
+        @DisplayName("TC-009 유효하지 않은 questionId → INVALID_INPUT_VALUE")
+        void invalidQuestionId() {
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(activeRecruitment));
+            when(applicantRepository.findByRecruitmentIdAndUserId(1L, 1L)).thenReturn(Optional.empty());
+            when(applicationQuestionRepository.findByRecruitmentIdAndCategories(any(), any(), any()))
+                    .thenReturn(List.of(q1));
+
+            // q1 답변 + 유효하지 않은 999번 답변 포함
+            ApplicationRequest req = buildApplicationRequest(
+                    List.of(buildTextAnswer(1L, "답변"), buildTextAnswer(999L, "잘못된답변")));
+
+            assertThatThrownBy(() -> recruitmentService.submitApplication(1L, 1L, req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        @Test
+        @DisplayName("TC-010 중복 questionId → INVALID_INPUT_VALUE")
+        void duplicateQuestionId() {
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(activeRecruitment));
+            when(applicantRepository.findByRecruitmentIdAndUserId(1L, 1L)).thenReturn(Optional.empty());
+            when(applicationQuestionRepository.findByRecruitmentIdAndCategories(any(), any(), any()))
+                    .thenReturn(List.of(q1));
+
+            ApplicationRequest req = buildApplicationRequest(
+                    List.of(buildTextAnswer(1L, "첫번째"), buildTextAnswer(1L, "중복")));
+
+            assertThatThrownBy(() -> recruitmentService.submitApplication(1L, 1L, req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        @Test
+        @DisplayName("TC-011 TEXT 질문(is_required=false)에 객체 답변 → INVALID_ANSWER_TYPE")
+        void invalidAnswerType() throws Exception {
+            ApplicationQuestion optional = createTextQuestion(2L, activeRecruitment,
+                    ApplicationQuestion.Category.COMMON, 2, false);
+
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(activeRecruitment));
+            when(applicantRepository.findByRecruitmentIdAndUserId(1L, 1L)).thenReturn(Optional.empty());
+            when(applicationQuestionRepository.findByRecruitmentIdAndCategories(any(), any(), any()))
+                    .thenReturn(List.of(q1, optional));
+
+            JsonNode objNode = objectMapper.readTree("{\"key\":\"value\"}");
+            ApplicationRequest req = buildApplicationRequest(
+                    List.of(buildTextAnswer(1L, "정상답변"),
+                            buildJsonAnswer(2L, objNode))); // TEXT 질문에 객체
+
+            assertThatThrownBy(() -> recruitmentService.submitApplication(1L, 1L, req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_ANSWER_TYPE);
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // REC-005: 모집 사전 알림 신청
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("REC-005 모집 사전 알림 신청")
+    class Subscribe {
+
+        @Test
+        @DisplayName("TC-001 신규 이메일 → 201, Subscription 저장")
+        void newEmail() {
+            Subscription s = createSubscription(1L, "new@example.com");
+            when(subscriptionRepository.existsByEmail("new@example.com")).thenReturn(false);
+            when(subscriptionRepository.saveAndFlush(any())).thenReturn(s);
+
+            SubscriptionRequest req = new SubscriptionRequest();
+            ReflectionTestUtils.setField(req, "email", "new@example.com");
+
+            SubscriptionResponse res = recruitmentService.subscribe(req);
+
+            assertThat(res.getEmail()).isEqualTo("new@example.com");
+        }
+
+        @Test
+        @DisplayName("TC-002 중복 이메일 → DUPLICATE_EMAIL")
+        void duplicateEmail() {
+            when(subscriptionRepository.existsByEmail("dup@example.com")).thenReturn(true);
+
+            SubscriptionRequest req = new SubscriptionRequest();
+            ReflectionTestUtils.setField(req, "email", "dup@example.com");
+
+            assertThatThrownBy(() -> recruitmentService.subscribe(req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.DUPLICATE_EMAIL);
+        }
+
+        @Test
+        @DisplayName("TC-003 이메일 형식 오류 → INVALID_EMAIL_FORMAT")
+        void invalidFormat() {
+            SubscriptionRequest req = new SubscriptionRequest();
+            ReflectionTestUtils.setField(req, "email", "notanemail");
+
+            assertThatThrownBy(() -> recruitmentService.subscribe(req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_EMAIL_FORMAT);
+        }
+
+        @Test
+        @DisplayName("TC-004 레이스 컨디션(DataIntegrityViolation) → DUPLICATE_EMAIL")
+        void racingCondition() {
+            when(subscriptionRepository.existsByEmail("race@example.com")).thenReturn(false);
+            when(subscriptionRepository.saveAndFlush(any()))
+                    .thenThrow(new DataIntegrityViolationException("unique constraint"));
+
+            SubscriptionRequest req = new SubscriptionRequest();
+            ReflectionTestUtils.setField(req, "email", "race@example.com");
+
+            assertThatThrownBy(() -> recruitmentService.subscribe(req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.DUPLICATE_EMAIL);
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // REC-006: 모집 마감 일시 조회
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("REC-006 모집 마감 일시 조회")
+    class GetDeadline {
+
+        @Test
+        @DisplayName("TC-001 모집 중인 공고 존재 → deadline 반환")
+        void found() {
+            Recruitment r = createActiveRecruitment();
+            when(recruitmentRepository.findActiveRecruitment(any())).thenReturn(Optional.of(r));
+
+            DeadlineResponse res = recruitmentService.getDeadline();
+
+            assertThat(res.getDeadline()).isEqualTo(r.getEndDate());
+        }
+
+        @Test
+        @DisplayName("TC-002 모집 중인 공고 없음 → RECRUITMENT_NOT_FOUND")
+        void notFound() {
+            when(recruitmentRepository.findActiveRecruitment(any())).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> recruitmentService.getDeadline())
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.RECRUITMENT_NOT_FOUND);
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // REC-007: 지원서 임시저장
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("REC-007 지원서 임시저장")
+    class SaveDraft {
+
+        private Recruitment active;
+        private User user;
+
+        @BeforeEach
+        void setUp() {
+            active = createActiveRecruitment();
+            user = createUser(1L);
+        }
+
+        @Test
+        @DisplayName("TC-001 기존 지원서 없음 → DRAFT 신규 생성")
+        void createNew() {
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(active));
+            when(applicantRepository.findByRecruitmentIdAndUserId(1L, 1L)).thenReturn(Optional.empty());
+            when(applicantRepository.save(any())).thenAnswer(inv -> {
+                Applicant a = inv.getArgument(0);
+                ReflectionTestUtils.setField(a, "id", 42L);
+                return a;
+            });
+
+            DraftApplicationRequest req = new DraftApplicationRequest();
+            ReflectionTestUtils.setField(req, "name", "홍길동");
+            ReflectionTestUtils.setField(req, "email", "hong@example.com");
+
+            DraftApplicationResponse res = recruitmentService.saveDraft(1L, 1L, req);
+
+            assertThat(res.getApplicantId()).isEqualTo(42L);
+            verify(applicantRepository).save(any(Applicant.class));
+        }
+
+        @Test
+        @DisplayName("TC-002 기존 DRAFT 존재 → 부분 업데이트 (null 필드 유지)")
+        void updateDraft() {
+            Applicant draft = createDraftApplicant(active, user);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(active));
+            when(applicantRepository.findByRecruitmentIdAndUserId(1L, 1L)).thenReturn(Optional.of(draft));
+
+            DraftApplicationRequest req = new DraftApplicationRequest();
+            ReflectionTestUtils.setField(req, "name", "새이름");
+
+            DraftApplicationResponse res = recruitmentService.saveDraft(1L, 1L, req);
+
+            assertThat(res.getApplicantId()).isEqualTo(42L);
+            verify(applicantRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("TC-003 answers=null → 기존 answers 변경 없음")
+        void answersNull() {
+            Applicant draft = createDraftApplicant(active, user);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(active));
+            when(applicantRepository.findByRecruitmentIdAndUserId(1L, 1L)).thenReturn(Optional.of(draft));
+
+            DraftApplicationRequest req = new DraftApplicationRequest();
+            ReflectionTestUtils.setField(req, "answers", null);
+
+            recruitmentService.saveDraft(1L, 1L, req);
+
+            verify(applicantAnswerRepository, never()).deleteByApplicantId(any());
+        }
+
+        @Test
+        @DisplayName("TC-004 answers=[] → 기존 answers 전부 삭제")
+        void answersEmpty() {
+            Applicant draft = createDraftApplicant(active, user);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(active));
+            when(applicantRepository.findByRecruitmentIdAndUserId(1L, 1L)).thenReturn(Optional.of(draft));
+
+            DraftApplicationRequest req = new DraftApplicationRequest();
+            ReflectionTestUtils.setField(req, "answers", Collections.emptyList());
+
+            recruitmentService.saveDraft(1L, 1L, req);
+
+            verify(applicantAnswerRepository).deleteByApplicantId(42L);
+            verify(applicantAnswerRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("TC-005 유효한 answers → 기존 삭제 후 새 답변 교체")
+        void answersReplaced() {
+            Applicant draft = createDraftApplicant(active, user);
+            ApplicationQuestion q1 = createTextQuestion(1L, active, ApplicationQuestion.Category.COMMON, 1, true);
+
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(active));
+            when(applicantRepository.findByRecruitmentIdAndUserId(1L, 1L)).thenReturn(Optional.of(draft));
+            when(applicationQuestionRepository.findByRecruitmentIdOrderByOrderNumAsc(1L))
+                    .thenReturn(List.of(q1));
+
+            DraftApplicationRequest req = new DraftApplicationRequest();
+            ReflectionTestUtils.setField(req, "answers",
+                    List.of(buildTextAnswer(1L, "새 답변")));
+
+            recruitmentService.saveDraft(1L, 1L, req);
+
+            verify(applicantAnswerRepository).deleteByApplicantId(42L);
+            verify(applicantAnswerRepository).save(any(ApplicantAnswer.class));
+        }
+
+        @Test
+        @DisplayName("TC-006 알 수 없는 questionId → skip (예외 없음)")
+        void unknownQuestionIdSkipped() {
+            Applicant draft = createDraftApplicant(active, user);
+            ApplicationQuestion q1 = createTextQuestion(1L, active, ApplicationQuestion.Category.COMMON, 1, true);
+
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(active));
+            when(applicantRepository.findByRecruitmentIdAndUserId(1L, 1L)).thenReturn(Optional.of(draft));
+            when(applicationQuestionRepository.findByRecruitmentIdOrderByOrderNumAsc(1L))
+                    .thenReturn(List.of(q1));
+
+            DraftApplicationRequest req = new DraftApplicationRequest();
+            ReflectionTestUtils.setField(req, "answers",
+                    List.of(buildTextAnswer(999L, "알 수 없는 질문"))); // valid IDs: [1]
+
+            recruitmentService.saveDraft(1L, 1L, req);
+
+            // 예외 없이 정상 완료, answers 저장 안 됨
+            verify(applicantAnswerRepository).deleteByApplicantId(42L);
+            verify(applicantAnswerRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("TC-007 이미 SUBMITTED → APPLICATION_ALREADY_SUBMITTED")
+        void alreadySubmitted() {
+            Applicant submitted = createSubmittedApplicant(active, user);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(active));
+            when(applicantRepository.findByRecruitmentIdAndUserId(1L, 1L)).thenReturn(Optional.of(submitted));
+
+            DraftApplicationRequest req = new DraftApplicationRequest();
+
+            assertThatThrownBy(() -> recruitmentService.saveDraft(1L, 1L, req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.APPLICATION_ALREADY_SUBMITTED);
+        }
+
+        @Test
+        @DisplayName("TC-008 모집 기간 외 → RECRUITMENT_CLOSED")
+        void closed() {
+            Recruitment expired = createExpiredRecruitment();
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(expired));
+
+            DraftApplicationRequest req = new DraftApplicationRequest();
+
+            assertThatThrownBy(() -> recruitmentService.saveDraft(1L, 1L, req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.RECRUITMENT_CLOSED);
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // REC-008: 내 지원서 조회
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("REC-008 내 지원서 조회")
+    class GetMyApplication {
+
+        private Recruitment active;
+        private User user;
+
+        @BeforeEach
+        void setUp() {
+            active = createActiveRecruitment();
+            user = createUser(1L);
+        }
+
+        @Test
+        @DisplayName("TC-001 DRAFT 지원서 → 200, null 필드 포함 반환")
+        void draft() {
+            Applicant draft = createDraftApplicant(active, user);
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(active));
+            when(applicantRepository.findByRecruitmentIdAndUserId(1L, 1L)).thenReturn(Optional.of(draft));
+            when(applicantAnswerRepository.findByApplicantIds(List.of(42L))).thenReturn(Collections.emptyList());
+
+            MyApplicationResponse res = recruitmentService.getMyApplication(1L, 1L);
+
+            assertThat(res.getStatus()).isEqualTo(Applicant.ApplicantStatus.DRAFT);
+            assertThat(res.getPhone()).isNull();
+        }
+
+        @Test
+        @DisplayName("TC-002 일부 필드 null인 DRAFT → null 포함 정상 반환")
+        void draftWithNulls() {
+            Applicant draft = createDraftApplicant(active, user);
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(active));
+            when(applicantRepository.findByRecruitmentIdAndUserId(1L, 1L)).thenReturn(Optional.of(draft));
+            when(applicantAnswerRepository.findByApplicantIds(any())).thenReturn(Collections.emptyList());
+
+            MyApplicationResponse res = recruitmentService.getMyApplication(1L, 1L);
+
+            assertThat(res).isNotNull();
+            assertThat(res.getUniversity()).isNull();
+        }
+
+        @Test
+        @DisplayName("TC-003 지원서 없음 → APPLICATION_NOT_FOUND")
+        void noApplication() {
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(active));
+            when(applicantRepository.findByRecruitmentIdAndUserId(1L, 1L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> recruitmentService.getMyApplication(1L, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.APPLICATION_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("TC-004 SUBMITTED 상태 → APPLICATION_ALREADY_SUBMITTED")
+        void submitted() {
+            Applicant submitted = createSubmittedApplicant(active, user);
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(active));
+            when(applicantRepository.findByRecruitmentIdAndUserId(1L, 1L)).thenReturn(Optional.of(submitted));
+
+            assertThatThrownBy(() -> recruitmentService.getMyApplication(1L, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.APPLICATION_ALREADY_SUBMITTED);
+        }
+
+        @Test
+        @DisplayName("TC-005 공고 없음 → RECRUITMENT_NOT_FOUND (지원서 조회 전)")
+        void noRecruitment() {
+            when(recruitmentRepository.findById(999L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> recruitmentService.getMyApplication(1L, 999L))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.RECRUITMENT_NOT_FOUND);
+
+            verify(applicantRepository, never()).findByRecruitmentIdAndUserId(any(), any());
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // REC-ADMIN-001: 지원서 CSV 파일 생성
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("REC-ADMIN-001 지원서 CSV 파일 생성")
+    class DownloadApplications {
+
+        @Test
+        @DisplayName("TC-001 지원자 있는 공고 → 부문별 CSV 3개 S3 업로드")
+        void uploadThreeCsvFiles() throws Exception {
+            Recruitment r = createActiveRecruitment();
+            User u = createUser(1L);
+            Applicant eng = createSubmittedApplicant(r, u);
+
+            when(recruitmentRepository.findByTerm(27)).thenReturn(Optional.of(r));
+            when(applicantRepository.findSubmittedByRecruitmentIdAndTrackOrderBySubmittedAt(
+                    eq(1L), eq(Track.ENGINEERING), any())).thenReturn(List.of(eng));
+            when(applicantRepository.findSubmittedByRecruitmentIdAndTrackOrderBySubmittedAt(
+                    eq(1L), eq(Track.ANALYSIS), any())).thenReturn(Collections.emptyList());
+            when(applicantRepository.findSubmittedByRecruitmentIdAndTrackOrderBySubmittedAt(
+                    eq(1L), eq(Track.VISUALIZATION), any())).thenReturn(Collections.emptyList());
+            when(applicationQuestionRepository.findByRecruitmentIdAndCategories(any(), any(), any()))
+                    .thenReturn(Collections.emptyList());
+            when(applicantAnswerRepository.findByApplicantIds(any())).thenReturn(Collections.emptyList());
+            when(csvService.generateCsv(any(), any(), any())).thenReturn(new byte[0]);
+
+            recruitmentService.downloadApplications(27);
+
+            verify(s3Service, times(3)).uploadCsv(eq("test-bucket"), any(), any());
+        }
+
+        @Test
+        @DisplayName("TC-002 지원자 없는 공고 → 헤더만 있는 빈 CSV 3개 (예외 없음)")
+        void emptyApplicants() throws Exception {
+            Recruitment r = createActiveRecruitment();
+            when(recruitmentRepository.findByTerm(27)).thenReturn(Optional.of(r));
+            when(applicantRepository.findSubmittedByRecruitmentIdAndTrackOrderBySubmittedAt(any(), any(), any()))
+                    .thenReturn(Collections.emptyList());
+            when(applicationQuestionRepository.findByRecruitmentIdAndCategories(any(), any(), any()))
+                    .thenReturn(Collections.emptyList());
+            when(csvService.generateCsv(any(), any(), any())).thenReturn(new byte[0]);
+
+            recruitmentService.downloadApplications(27);
+
+            verify(s3Service, times(3)).uploadCsv(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("TC-003 존재하지 않는 term → RECRUITMENT_NOT_FOUND")
+        void notFound() {
+            when(recruitmentRepository.findByTerm(999)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> recruitmentService.downloadApplications(999))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.RECRUITMENT_NOT_FOUND);
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // REC-ADMIN-010: 지원서 전체 삭제
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("REC-ADMIN-010 지원서 전체 삭제")
+    class DeleteApplicants {
+
+        @Test
+        @DisplayName("TC-001 모집 마감 후 삭제 → answer 먼저, applicant 나중 삭제")
+        void deleteInOrder() {
+            Recruitment r = createExpiredRecruitment();
+            when(recruitmentRepository.findById(2L)).thenReturn(Optional.of(r));
+
+            recruitmentService.deleteApplicants(2L);
+
+            var inOrder = inOrder(applicantAnswerRepository, applicantRepository);
+            inOrder.verify(applicantAnswerRepository).deleteByRecruitmentId(2L);
+            inOrder.verify(applicantRepository).deleteByRecruitmentId(2L);
+        }
+
+        @Test
+        @DisplayName("TC-002 지원서 없어도 → 200 (예외 없음)")
+        void emptyData() {
+            Recruitment r = createExpiredRecruitment();
+            when(recruitmentRepository.findById(2L)).thenReturn(Optional.of(r));
+
+            recruitmentService.deleteApplicants(2L);
+
+            verify(applicantAnswerRepository).deleteByRecruitmentId(2L);
+        }
+
+        @Test
+        @DisplayName("TC-003 모집 진행 중 → RECRUITMENT_NOT_CLOSED")
+        void recruitingNow() {
+            Recruitment r = createActiveRecruitment();
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(r));
+
+            assertThatThrownBy(() -> recruitmentService.deleteApplicants(1L))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.RECRUITMENT_NOT_CLOSED);
+        }
+
+        @Test
+        @DisplayName("TC-004 존재하지 않는 공고 → RECRUITMENT_NOT_FOUND")
+        void notFound() {
+            when(recruitmentRepository.findById(999L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> recruitmentService.deleteApplicants(999L))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.RECRUITMENT_NOT_FOUND);
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // REC-ADMIN-011: 사전 알림 신청 전체 조회
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("REC-ADMIN-011 모든 모집 사전 알림 신청 조회")
+    class GetAllSubscriptions {
+
+        @Test
+        @DisplayName("TC-001 데이터 있을 때 → created_at 내림차순 반환")
+        void withData() {
+            Subscription s1 = createSubscription(3L, "user3@example.com");
+            Subscription s2 = createSubscription(2L, "user2@example.com");
+            when(subscriptionRepository.findAllByOrderByCreatedAtDesc()).thenReturn(List.of(s1, s2));
+
+            List<SubscriptionResponse> result = recruitmentService.getAllSubscriptions();
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).getEmail()).isEqualTo("user3@example.com");
+        }
+
+        @Test
+        @DisplayName("TC-002 데이터 없을 때 → 빈 배열 (예외 없음)")
+        void noData() {
+            when(subscriptionRepository.findAllByOrderByCreatedAtDesc()).thenReturn(Collections.emptyList());
+
+            List<SubscriptionResponse> result = recruitmentService.getAllSubscriptions();
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // REC-ADMIN-012: 사전 알림 신청 전체 삭제
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("REC-ADMIN-012 모든 모집 사전 알림 신청 삭제")
+    class DeleteAllSubscriptions {
+
+        @Test
+        @DisplayName("TC-001 데이터 있을 때 → deleteAll 호출")
+        void withData() {
+            recruitmentService.deleteAllSubscriptions();
+            verify(subscriptionRepository).deleteAll();
+        }
+
+        @Test
+        @DisplayName("TC-002 데이터 없을 때도 → 예외 없음")
+        void noData() {
+            doNothing().when(subscriptionRepository).deleteAll();
+            recruitmentService.deleteAllSubscriptions();
+            verify(subscriptionRepository).deleteAll();
+        }
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/service/RecruitmentServiceTest.java
@@ -603,7 +603,7 @@ class RecruitmentServiceTest {
         }
 
         @Test
-        @DisplayName("TC-004b track=ALL → INVALID_TRACK_SELECTION")
+        @DisplayName("TC-011c track=ALL → INVALID_TRACK_SELECTION")
         void submitWithTrackAll() {
             when(userRepository.findById(1L)).thenReturn(Optional.of(user));
             when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(activeRecruitment));

--- a/src/test/java/com/boaz/backend/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/service/RecruitmentServiceTest.java
@@ -454,7 +454,7 @@ class RecruitmentServiceTest {
         }
 
         @Test
-        @DisplayName("TC-006 전화번호 형식 오류(하이픈) → INVALID_PHONE_FORMAT")
+        @DisplayName("TC-006a 전화번호 형식 오류(하이픈 포함) → INVALID_PHONE_FORMAT")
         void invalidPhoneHyphen() {
             when(userRepository.findById(1L)).thenReturn(Optional.of(user));
             when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(activeRecruitment));
@@ -470,7 +470,7 @@ class RecruitmentServiceTest {
         }
 
         @Test
-        @DisplayName("TC-006 전화번호 형식 오류(9자리) → INVALID_PHONE_FORMAT")
+        @DisplayName("TC-006b 전화번호 형식 오류(9자리 이하) → INVALID_PHONE_FORMAT")
         void invalidPhoneTooShort() {
             when(userRepository.findById(1L)).thenReturn(Optional.of(user));
             when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(activeRecruitment));
@@ -558,7 +558,7 @@ class RecruitmentServiceTest {
         }
 
         @Test
-        @DisplayName("TC-011 TEXT 질문(is_required=false)에 객체 답변 → INVALID_ANSWER_TYPE")
+        @DisplayName("TC-011a TEXT 질문(is_required=false)에 객체 답변 → INVALID_ANSWER_TYPE")
         void invalidAnswerType() throws Exception {
             ApplicationQuestion optional = createTextQuestion(2L, activeRecruitment,
                     ApplicationQuestion.Category.COMMON, 2, false);
@@ -572,12 +572,50 @@ class RecruitmentServiceTest {
             JsonNode objNode = objectMapper.readTree("{\"key\":\"value\"}");
             ApplicationRequest req = buildApplicationRequest(
                     List.of(buildTextAnswer(1L, "정상답변"),
-                            buildJsonAnswer(2L, objNode))); // TEXT 질문에 객체
+                            buildJsonAnswer(2L, objNode)));
 
             assertThatThrownBy(() -> recruitmentService.submitApplication(1L, 1L, req))
                     .isInstanceOf(CustomException.class)
                     .extracting(e -> ((CustomException) e).getErrorCode())
                     .isEqualTo(ErrorCode.INVALID_ANSWER_TYPE);
+        }
+
+        @Test
+        @DisplayName("TC-011b TABLE 질문(is_required=false)에 텍스트 답변 → INVALID_ANSWER_TYPE")
+        void tableQuestionWithTextAnswer() {
+            ApplicationQuestion tableQ = createTableQuestion(2L, activeRecruitment,
+                    ApplicationQuestion.Category.COMMON, 2, false);
+
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(activeRecruitment));
+            when(applicantRepository.findByRecruitmentIdAndUserId(1L, 1L)).thenReturn(Optional.empty());
+            when(applicationQuestionRepository.findByRecruitmentIdAndCategories(any(), any(), any()))
+                    .thenReturn(List.of(q1, tableQ));
+
+            ApplicationRequest req = buildApplicationRequest(
+                    List.of(buildTextAnswer(1L, "정상답변"),
+                            buildTextAnswer(2L, "텍스트 답변"))); // TABLE 질문에 텍스트
+
+            assertThatThrownBy(() -> recruitmentService.submitApplication(1L, 1L, req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_ANSWER_TYPE);
+        }
+
+        @Test
+        @DisplayName("TC-004b track=ALL → INVALID_TRACK_SELECTION")
+        void submitWithTrackAll() {
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(activeRecruitment));
+            when(applicantRepository.findByRecruitmentIdAndUserId(1L, 1L)).thenReturn(Optional.empty());
+
+            ApplicationRequest req = buildApplicationRequest(List.of(buildTextAnswer(1L, "답변")));
+            ReflectionTestUtils.setField(req, "track", Track.ALL);
+
+            assertThatThrownBy(() -> recruitmentService.submitApplication(1L, 1L, req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_TRACK_SELECTION);
         }
     }
 

--- a/src/test/java/com/boaz/backend/support/TestSecurityConfig.java
+++ b/src/test/java/com/boaz/backend/support/TestSecurityConfig.java
@@ -1,0 +1,47 @@
+package com.boaz.backend.support;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+@EnableWebSecurity
+public class TestSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/v1/admin/**").hasAnyRole("SUPER", "TEAM")
+                .requestMatchers("/api/v1/auth/admin/logout").hasAnyRole("SUPER", "TEAM")
+                .requestMatchers("/api/v1/auth/user/logout").hasRole("USER")
+                .requestMatchers(HttpMethod.POST, "/api/v1/recruitment/*/applications").hasRole("USER")
+                .requestMatchers(HttpMethod.PUT, "/api/v1/recruitment/*/applications/draft").hasRole("USER")
+                .requestMatchers(HttpMethod.GET, "/api/v1/recruitment/*/applications/me").hasRole("USER")
+                .requestMatchers(HttpMethod.GET, "/api/v1/users/me").hasRole("USER")
+                .anyRequest().permitAll()
+            )
+            .exceptionHandling(ex -> ex
+                .authenticationEntryPoint((req, res, e) -> {
+                    res.setStatus(401);
+                    res.setContentType("application/json;charset=UTF-8");
+                    res.getWriter().write(
+                        "{\"status\":401,\"error_code\":\"TOKEN_NOT_FOUND\",\"message\":\"토큰이 존재하지 않습니다.\"}");
+                })
+                .accessDeniedHandler((req, res, e) -> {
+                    res.setStatus(403);
+                    res.setContentType("application/json;charset=UTF-8");
+                    res.getWriter().write(
+                        "{\"status\":403,\"error_code\":\"ACCESS_DENIED\",\"message\":\"해당 리소스에 접근할 권한이 없습니다.\"}");
+                })
+            );
+        return http.build();
+    }
+}


### PR DESCRIPTION
## 💡 개요

* Issue Number: #136

Recruitment 도메인의 4계층(Service / Controller / Repository / Integration) 테스트 코드를 작성

## 🪐 주요 변경 사항

- **Service 단위 테스트** (`RecruitmentServiceTest`, Mockito): REC-001~008, ADMIN-001/010/011/012 비즈니스 로직 검증
- **Controller 테스트** (`@WebMvcTest` + `TestSecurityConfig`): HTTP 상태코드, 인가(401/403) 검증
- **Repository 테스트** (`@DataJpaTest` + Testcontainers MySQL): 커스텀 쿼리·정렬·제약 검증
- **Integration 테스트** (`@SpringBootTest` + Testcontainers): HTTP→Service→DB 전체 흐름 e2e 검증

## ✅ 상세 내용

- REC-002/003/006/007/008, ADMIN-001의 end-to-end 통합 테스트 구현
- REC-004 TABLE 답변 JSON 컬럼 직렬화 통합 테스트 구현
- REC-004 서비스 누락 케이스 보완 (TC-011b TABLE+텍스트, TC-011c track=ALL)
- deprecated `@MockBean` → `@MockitoBean` 교체 (Spring Boot 3.4 대응)
- `./gradlew test` 전체 통과 (Testcontainers 기반 Repository·Integration 포함)

## 🔔 참고 사항

- 공통 테스트 설정(build.gradle 의존성, `TestcontainersBase`, `application-test.yml`, CI)은 #137(PR #138)에서 선반영됨
- 본 PR은 recruitment 도메인 전용이며, User 도메인 테스트는 별도 이슈/브랜치에서 진행 예정
- Repository 테스트의 `findByUserIdAndStatus`, `existsByQuestionId`는 향후 승격/질문삭제 기능용 선행 쿼리 검증 (해당 기능 명세서는 추후 작성 예정)
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 변경 목적
Issue `#136` 관련으로 Recruitment 도메인의 테스트 코드를 Service, Controller, Repository, Integration 4계층 전반에 걸쳐 작성하였습니다. REC-001~008, ADMIN-001/010/011/012 명세에 대해 비즈니스 로직, HTTP 상태코드, 인증·인가, DB 조회/변경을 end-to-end로 검증합니다.

## 주요 변경 내용

**Service 계층**
- `RecruitmentServiceTest`: REC-001~008, ADMIN-001/010/011/012 비즈니스 로직 검증 (모집 상태/공고/질문 조회, 지원서 제출/임시저장, 구독, CSV 생성/삭제, 구독 목록 조회 및 삭제)
- Mockito 기반으로 리포지토리 모킹하여 비즈니스 예외(`CustomException`, `ErrorCode`) 검증

**Controller 계층**
- `RecruitmentControllerTest`: `@WebMvcTest로` RecruitmentController 엔드포인트 검증 (HTTP 상태코드, 응답 JSON 필드, 에러코드 매핑, 미인증 401/403)
- `RecruitmentAdminControllerTest`: 관리자 API 검증 (인증/인가 시나리오, S3 업로드 실패 케이스)
- RecruitmentService를 `@MockitoBean으로` 모킹

**Repository 계층**
- `RecruitmentRepositoryTest`: 활성 기간 조회, 기수 기반 조회/중복 검증, 정렬 확인
- `ApplicantRepositoryTest`: (공고ID, 사용자ID) 조회, 트랙별/상태별 정렬, 존재성/삭제 검증
- `ApplicationQuestionRepositoryTest`: 카테고리별 필터링, 정렬, 중복 검증
- `ApplicantAnswerRepositoryTest`: 존재성 확인, 지원자/공고 단위 벌크 삭제 검증
- `SubscriptionRepositoryTest`: 이메일 존재성, 최신순 정렬, 전체 삭제, unique 제약 확인
- `@DataJpaTest` + Testcontainers MySQL로 실제 DB 조회/변경 검증

**Integration 계층**
- `RecruitmentIntegrationTest`: HTTP → Service → DB 전체 흐름 e2e 검증 (모집 상태/공고/질문 조회, 지원서 제출/임시저장/조회, TABLE 답변 JSON 직렬화, CSV 생성 및 S3 호출 횟수, 지원서/답변 삭제, 구독 조회/삭제)
- `@SpringBootTest` + Testcontainers로 전체 애플리케이션 컨텍스트와 실제 DB 사용

**공통 설정**
- `TestSecurityConfig`: 테스트용 보안 설정 (CSRF 비활성화, 상태비저장, 경로별 역할 제약, 401/403 JSON 응답)

## 영향 범위
- **API 변경**: 없음 (테스트 코드 추가만)
- **DB 스키마 변경**: 없음
- **설정 변경**: 테스트용 보안 설정(TestSecurityConfig) 추가; application-test.yml 및 테스트 의존성 설정은 별도 PR에서 선반영됨
- **마이그레이션**: deprecated `@MockBean` → `@MockitoBean` 교체 (Spring Boot 3.4 대응)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->