### PR TITLE
[Test] User 도메인 테스트 코드 작성

### DIFF
--- a/src/test/java/com/boaz/backend/domain/user/controller/UserAdminControllerTest.java
+++ b/src/test/java/com/boaz/backend/domain/user/controller/UserAdminControllerTest.java
@@ -1,0 +1,98 @@
+package com.boaz.backend.domain.user.controller;
+
+import com.boaz.backend.domain.user.dto.response.PromoteUsersResponse;
+import com.boaz.backend.domain.user.service.UserAdminService;
+import com.boaz.backend.global.security.UserPrincipal;
+import com.boaz.backend.support.TestSecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ActiveProfiles("test")
+@WebMvcTest(
+    value = UserAdminController.class,
+    excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class}
+)
+@Import(TestSecurityConfig.class)
+class UserAdminControllerTest {
+
+    @Autowired MockMvc mockMvc;
+
+    @MockitoBean UserAdminService userAdminService;
+
+    private UsernamePasswordAuthenticationToken adminAuth() {
+        return new UsernamePasswordAuthenticationToken(
+                "admin", null,
+                List.of(new SimpleGrantedAuthority("ROLE_SUPER")));
+    }
+
+    private UsernamePasswordAuthenticationToken userAuth() {
+        return new UsernamePasswordAuthenticationToken(
+                new UserPrincipal(1L), null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+    }
+
+    @Test
+    @DisplayName("정상 승격 요청 → 200")
+    void success() throws Exception {
+        when(userAdminService.bulkPromote(any())).thenReturn(PromoteUsersResponse.of(Collections.emptyList()));
+
+        mockMvc.perform(patch("/api/v1/admin/users/promote")
+                        .with(authentication(adminAuth()))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"user_ids\":[1,2,3]}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200));
+    }
+
+    @Test
+    @DisplayName("빈 userIds(@NotEmpty) → 400 INVALID_INPUT_VALUE")
+    void emptyUserIds() throws Exception {
+        mockMvc.perform(patch("/api/v1/admin/users/promote")
+                        .with(authentication(adminAuth()))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"user_ids\":[]}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error_code").value("INVALID_INPUT_VALUE"));
+    }
+
+    @Test
+    @DisplayName("TC-008 미인증 요청 → 401 TOKEN_NOT_FOUND")
+    void unauthorized() throws Exception {
+        mockMvc.perform(patch("/api/v1/admin/users/promote")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"user_ids\":[1]}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error_code").value("TOKEN_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("TC-009 User 권한으로 접근 → 403 ACCESS_DENIED")
+    void forbidden() throws Exception {
+        mockMvc.perform(patch("/api/v1/admin/users/promote")
+                        .with(authentication(userAuth()))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"user_ids\":[1]}"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error_code").value("ACCESS_DENIED"));
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/boaz/backend/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,63 @@
+package com.boaz.backend.domain.user.controller;
+
+import com.boaz.backend.domain.user.dto.response.UserInfoResponse;
+import com.boaz.backend.domain.user.service.UserService;
+import com.boaz.backend.global.security.UserPrincipal;
+import com.boaz.backend.support.TestSecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ActiveProfiles("test")
+@WebMvcTest(
+    value = UserController.class,
+    excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class}
+)
+@Import(TestSecurityConfig.class)
+class UserControllerTest {
+
+    @Autowired MockMvc mockMvc;
+
+    @MockitoBean UserService userService;
+
+    private UsernamePasswordAuthenticationToken userAuth() {
+        return new UsernamePasswordAuthenticationToken(
+                new UserPrincipal(1L), null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+    }
+
+    @Test
+    @DisplayName("TC-006 정상 조회 → 200 + nickname")
+    void success() throws Exception {
+        when(userService.getMyInfo(1L)).thenReturn(UserInfoResponse.builder().nickname("홍길동").build());
+
+        mockMvc.perform(get("/api/v1/users/me").with(authentication(userAuth())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.nickname").value("홍길동"));
+    }
+
+    @Test
+    @DisplayName("TC-003 미인증 요청 → 401 TOKEN_NOT_FOUND")
+    void unauthorized() throws Exception {
+        mockMvc.perform(get("/api/v1/users/me"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error_code").value("TOKEN_NOT_FOUND"));
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/user/integration/UserIntegrationTest.java
+++ b/src/test/java/com/boaz/backend/domain/user/integration/UserIntegrationTest.java
@@ -1,0 +1,134 @@
+package com.boaz.backend.domain.user.integration;
+
+import com.boaz.backend.domain.recruitment.entity.Applicant;
+import com.boaz.backend.domain.recruitment.entity.Recruitment;
+import com.boaz.backend.domain.recruitment.repository.ApplicantRepository;
+import com.boaz.backend.domain.recruitment.repository.RecruitmentRepository;
+import com.boaz.backend.domain.user.dto.response.PromoteUsersResponse;
+import com.boaz.backend.domain.user.dto.response.UserInfoResponse;
+import com.boaz.backend.domain.user.entity.User;
+import com.boaz.backend.domain.user.repository.UserRepository;
+import com.boaz.backend.domain.user.service.UserAdminService;
+import com.boaz.backend.domain.user.service.UserService;
+import com.boaz.backend.global.common.enums.MemberType;
+import com.boaz.backend.global.common.enums.Track;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import com.boaz.backend.support.TestcontainersBase;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class UserIntegrationTest extends TestcontainersBase {
+
+    @Autowired UserService userService;
+    @Autowired UserAdminService userAdminService;
+    @Autowired UserRepository userRepository;
+    @Autowired RecruitmentRepository recruitmentRepository;
+    @Autowired ApplicantRepository applicantRepository;
+
+    @PersistenceContext EntityManager em;
+
+    private int seq = 0;
+
+    private User saveUser(String nickname) {
+        return userRepository.save(User.builder()
+                .provider("kakao").providerId("p" + (++seq)).nickname(nickname)
+                .memberType(MemberType.OUTSIDER).build());
+    }
+
+    private Applicant saveSubmittedApplicant(User u, Recruitment r) {
+        return applicantRepository.save(Applicant.builder()
+                .recruitment(r).user(u).status(Applicant.ApplicantStatus.SUBMITTED)
+                .track(Track.ENGINEERING).name("홍길동").email("hong@example.com")
+                .phone("01012345678").university("한국대").major("컴공")
+                .build());
+    }
+
+    @Nested
+    @DisplayName("내 정보 조회 end-to-end (USER-001)")
+    class GetMyInfo {
+
+        @Test
+        @DisplayName("저장된 유저 → nickname 반환")
+        void found() {
+            User u = saveUser("홍길동");
+            em.flush();
+            em.clear();
+
+            UserInfoResponse res = userService.getMyInfo(u.getId());
+
+            assertThat(res.getNickname()).isEqualTo("홍길동");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 userId → USER_NOT_FOUND")
+        void notFound() {
+            assertThatThrownBy(() -> userService.getMyInfo(999L))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.USER_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("합격자 승격 end-to-end (USER-ADMIN-001)")
+    class BulkPromote {
+
+        @Test
+        @DisplayName("SUBMITTED 지원서 보유 → MEMBER 전환 + 개인정보가 실제 DB에 영속")
+        void promotePersists() {
+            User u = saveUser("닉네임");
+            Recruitment r = recruitmentRepository.save(Recruitment.create(27,
+                    LocalDateTime.now().minusDays(1), LocalDateTime.now().plusDays(1), "[]", null));
+            saveSubmittedApplicant(u, r);
+            em.flush();
+            em.clear();
+
+            PromoteUsersResponse res = userAdminService.bulkPromote(List.of(u.getId()));
+            em.flush();
+            em.clear();
+
+            assertThat(res.getFailedUserIds()).isEmpty();
+            User promoted = userRepository.findById(u.getId()).orElseThrow();
+            assertThat(promoted.getMemberType()).isEqualTo(MemberType.MEMBER);
+            assertThat(promoted.getName()).isEqualTo("홍길동");
+            assertThat(promoted.getPhone()).isEqualTo("01012345678");
+            assertThat(promoted.getUniversity()).isEqualTo("한국대");
+            assertThat(promoted.getMajor()).isEqualTo("컴공");
+            assertThat(promoted.getTrack()).isEqualTo(Track.ENGINEERING);
+            assertThat(promoted.getTerm()).isEqualTo(27);
+        }
+
+        @Test
+        @DisplayName("SUBMITTED 지원서 없음 → APPLICATION_NOT_FOUND, 승격 안 됨")
+        void noApplication() {
+            User u = saveUser("닉네임");
+            em.flush();
+            em.clear();
+
+            PromoteUsersResponse res = userAdminService.bulkPromote(List.of(u.getId()));
+            em.flush();
+            em.clear();
+
+            assertThat(res.getFailedUserIds()).hasSize(1);
+            assertThat(res.getFailedUserIds().get(0).getErrorCode()).isEqualTo("APPLICATION_NOT_FOUND");
+            assertThat(userRepository.findById(u.getId()).orElseThrow().getMemberType())
+                    .isEqualTo(MemberType.OUTSIDER);
+        }
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/user/service/UserAdminServiceTest.java
+++ b/src/test/java/com/boaz/backend/domain/user/service/UserAdminServiceTest.java
@@ -1,0 +1,194 @@
+package com.boaz.backend.domain.user.service;
+
+import com.boaz.backend.domain.recruitment.entity.Applicant;
+import com.boaz.backend.domain.recruitment.entity.Recruitment;
+import com.boaz.backend.domain.recruitment.repository.ApplicantRepository;
+import com.boaz.backend.domain.user.dto.response.PromoteUsersResponse;
+import com.boaz.backend.domain.user.entity.User;
+import com.boaz.backend.domain.user.repository.UserRepository;
+import com.boaz.backend.global.common.enums.MemberType;
+import com.boaz.backend.global.common.enums.Track;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserAdminServiceTest {
+
+    @InjectMocks
+    UserAdminService userAdminService;
+
+    @Mock UserRepository userRepository;
+    @Mock ApplicantRepository applicantRepository;
+    @Mock TransactionTemplate transactionTemplate;
+
+    @BeforeEach
+    void setUp() {
+        // TransactionTemplate.execute(callback) → 콜백을 실제로 실행하도록 스텁
+        lenient().when(transactionTemplate.execute(any())).thenAnswer(invocation -> {
+            TransactionCallback<?> callback = invocation.getArgument(0);
+            return callback.doInTransaction(mock(TransactionStatus.class));
+        });
+    }
+
+    private User outsider(Long id) {
+        User u = User.builder()
+                .provider("kakao").providerId("p" + id)
+                .nickname("nick").memberType(MemberType.OUTSIDER)
+                .build();
+        ReflectionTestUtils.setField(u, "id", id);
+        return u;
+    }
+
+    private User member(Long id) {
+        User u = User.builder()
+                .provider("kakao").providerId("p" + id)
+                .nickname("nick").memberType(MemberType.MEMBER)
+                .build();
+        ReflectionTestUtils.setField(u, "id", id);
+        return u;
+    }
+
+    private Applicant submittedApplicant(int term) {
+        Recruitment r = Recruitment.create(term,
+                LocalDateTime.now().minusDays(1), LocalDateTime.now().plusDays(1), "[]", null);
+        return Applicant.builder()
+                .recruitment(r)
+                .status(Applicant.ApplicantStatus.SUBMITTED)
+                .track(Track.ENGINEERING)
+                .name("홍길동").email("hong@example.com").phone("01012345678")
+                .university("한국대").major("컴공")
+                .build();
+    }
+
+    @Test
+    @DisplayName("TC-001 전체 성공 → failedUserIds 빈 배열")
+    void allSuccess() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(outsider(1L)));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(outsider(2L)));
+        when(userRepository.findById(3L)).thenReturn(Optional.of(outsider(3L)));
+        when(applicantRepository.findByUserIdAndStatus(anyLong(), eq(Applicant.ApplicantStatus.SUBMITTED)))
+                .thenReturn(Optional.of(submittedApplicant(27)));
+
+        PromoteUsersResponse res = userAdminService.bulkPromote(List.of(1L, 2L, 3L));
+
+        assertThat(res.getFailedUserIds()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("TC-002 일부 실패(USER_NOT_FOUND) → skip 후 failedUserIds 포함")
+    void partialFailUserNotFound() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(outsider(1L)));
+        when(userRepository.findById(999L)).thenReturn(Optional.empty());
+        when(userRepository.findById(2L)).thenReturn(Optional.of(outsider(2L)));
+        when(applicantRepository.findByUserIdAndStatus(anyLong(), eq(Applicant.ApplicantStatus.SUBMITTED)))
+                .thenReturn(Optional.of(submittedApplicant(27)));
+
+        PromoteUsersResponse res = userAdminService.bulkPromote(List.of(1L, 999L, 2L));
+
+        assertThat(res.getFailedUserIds()).hasSize(1);
+        assertThat(res.getFailedUserIds().get(0).getUserId()).isEqualTo(999L);
+        assertThat(res.getFailedUserIds().get(0).getErrorCode()).isEqualTo("USER_NOT_FOUND");
+    }
+
+    @Test
+    @DisplayName("TC-003 일부 실패(APPLICATION_NOT_FOUND) → skip")
+    void partialFailApplicationNotFound() {
+        when(userRepository.findById(5L)).thenReturn(Optional.of(outsider(5L)));
+        when(applicantRepository.findByUserIdAndStatus(5L, Applicant.ApplicantStatus.SUBMITTED))
+                .thenReturn(Optional.empty());
+
+        PromoteUsersResponse res = userAdminService.bulkPromote(List.of(5L));
+
+        assertThat(res.getFailedUserIds()).hasSize(1);
+        assertThat(res.getFailedUserIds().get(0).getUserId()).isEqualTo(5L);
+        assertThat(res.getFailedUserIds().get(0).getErrorCode()).isEqualTo("APPLICATION_NOT_FOUND");
+    }
+
+    @Test
+    @DisplayName("TC-004 이미 MEMBER → skip + ALREADY_MEMBER")
+    void alreadyMember() {
+        when(userRepository.findById(10L)).thenReturn(Optional.of(member(10L)));
+
+        PromoteUsersResponse res = userAdminService.bulkPromote(List.of(10L));
+
+        assertThat(res.getFailedUserIds()).hasSize(1);
+        assertThat(res.getFailedUserIds().get(0).getUserId()).isEqualTo(10L);
+        assertThat(res.getFailedUserIds().get(0).getErrorCode()).isEqualTo("ALREADY_MEMBER");
+        // 이미 MEMBER 면 지원서 조회 단계에 도달하지 않음
+        verify(applicantRepository, never()).findByUserIdAndStatus(anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("TC-005 승격 시 user 필드 복사 검증")
+    void promoteCopiesFields() {
+        User user = outsider(1L);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(applicantRepository.findByUserIdAndStatus(1L, Applicant.ApplicantStatus.SUBMITTED))
+                .thenReturn(Optional.of(submittedApplicant(27)));
+
+        userAdminService.bulkPromote(List.of(1L));
+
+        assertThat(user.getMemberType()).isEqualTo(MemberType.MEMBER);
+        assertThat(user.getName()).isEqualTo("홍길동");
+        assertThat(user.getPhone()).isEqualTo("01012345678");
+        assertThat(user.getUniversity()).isEqualTo("한국대");
+        assertThat(user.getMajor()).isEqualTo("컴공");
+        assertThat(user.getTrack()).isEqualTo(Track.ENGINEERING);
+        assertThat(user.getTerm()).isEqualTo(27);
+    }
+
+    @Test
+    @DisplayName("TC-006 여러 명 일부 실패 혼합 → 성공한 건만 처리")
+    void mixedResult() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(outsider(1L)));
+        when(userRepository.findById(2L)).thenReturn(Optional.empty());          // USER_NOT_FOUND
+        when(userRepository.findById(3L)).thenReturn(Optional.of(member(3L)));   // ALREADY_MEMBER
+        when(applicantRepository.findByUserIdAndStatus(1L, Applicant.ApplicantStatus.SUBMITTED))
+                .thenReturn(Optional.of(submittedApplicant(27)));
+
+        PromoteUsersResponse res = userAdminService.bulkPromote(List.of(1L, 2L, 3L));
+
+        assertThat(res.getFailedUserIds()).hasSize(2);
+        assertThat(res.getFailedUserIds()).extracting(PromoteUsersResponse.FailedUserInfo::getUserId)
+                .containsExactly(2L, 3L);
+        assertThat(res.getFailedUserIds()).extracting(PromoteUsersResponse.FailedUserInfo::getErrorCode)
+                .containsExactly("USER_NOT_FOUND", "ALREADY_MEMBER");
+    }
+
+    @Test
+    @DisplayName("TC-007 DB/서버 오류(RuntimeException) → 즉시 중단, 이후 userId 미처리")
+    void runtimeExceptionAborts() {
+        when(userRepository.findById(1L)).thenThrow(new RuntimeException("DB error"));
+
+        assertThatThrownBy(() -> userAdminService.bulkPromote(List.of(1L, 2L)))
+                .isInstanceOf(RuntimeException.class);
+
+        verify(userRepository, never()).findById(2L);
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/boaz/backend/domain/user/service/UserServiceTest.java
@@ -1,0 +1,60 @@
+package com.boaz.backend.domain.user.service;
+
+import com.boaz.backend.domain.user.dto.response.UserInfoResponse;
+import com.boaz.backend.domain.user.entity.User;
+import com.boaz.backend.domain.user.repository.UserRepository;
+import com.boaz.backend.global.common.enums.MemberType;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @InjectMocks
+    UserService userService;
+
+    @Mock UserRepository userRepository;
+
+    private User createUser(Long id, String nickname) {
+        User u = User.builder()
+                .provider("kakao").providerId("test-" + id)
+                .nickname(nickname).memberType(MemberType.OUTSIDER)
+                .build();
+        ReflectionTestUtils.setField(u, "id", id);
+        return u;
+    }
+
+    @Test
+    @DisplayName("TC-001 유효한 userId 로 조회 → nickname 반환")
+    void getMyInfo() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(createUser(1L, "홍길동")));
+
+        UserInfoResponse res = userService.getMyInfo(1L);
+
+        assertThat(res.getNickname()).isEqualTo("홍길동");
+    }
+
+    @Test
+    @DisplayName("TC-002 존재하지 않는 userId → USER_NOT_FOUND")
+    void getMyInfoNotFound() {
+        when(userRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userService.getMyInfo(999L))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
## 💡 개요

* Issue Number: #144

User 도메인의 4계층(Service / Controller / Repository / Integration) 테스트 코드를 작성했습니다.

## 🪐 주요 변경 사항

- **USER-001 내 정보 조회** (GET /api/v1/users/me): Service 단위 / Controller / 통합 테스트
- **USER-ADMIN-001 합격자 승격** (PATCH /api/v1/admin/users/promote): Service 단위 / Controller / 통합 테스트
- 명세서에 누락돼 있던 **통합(e2e) 테스트** 보완

## ✅ 상세 내용

- `UserServiceTest` (2): nickname 반환, USER_NOT_FOUND
- `UserAdminServiceTest` (7): 전체 성공 / 부분 실패(USER_NOT_FOUND·APPLICATION_NOT_FOUND·ALREADY_MEMBER) / 필드 복사 검증 / RuntimeException 즉시 중단
- `UserControllerTest` (2): 200 + nickname, 미인증 401
- `UserAdminControllerTest` (4): 정상 200, @NotEmpty 400, 미인증 401, User 권한 403
- `UserIntegrationTest` (4): getMyInfo e2e, bulkPromote e2e(MEMBER 전환·개인정보 영속·APPLICATION_NOT_FOUND skip)
- `./gradlew test` 전체 통과 (Testcontainers 기반 통합 테스트 포함)

## 🔔 참고 사항

- USER-001(getMyInfo)은 내장 findById 만 사용해 커스텀 쿼리가 없으므로 Repository 단위 테스트는 해당 없음
- USER-ADMIN-001의 Repository 쿼리(findByUserIdAndStatus)는 기존 `ApplicantRepositoryTest`에서 검증됨 (#136에서 선반영)
- 토큰 자체 검증(EXPIRED_TOKEN/INVALID_TOKEN)·OAuth 소셜 로그인 플로우는 auth 인프라 영역으로 본 PR 범위 밖