### PR TITLE
[Feat] admin archive 등록 시 contentDate 필수 입력 검증 추가 

### DIFF
--- a/src/main/java/com/boaz/backend/domain/archive/dto/request/ArchiveCreateRequest.java
+++ b/src/main/java/com/boaz/backend/domain/archive/dto/request/ArchiveCreateRequest.java
@@ -37,6 +37,7 @@ public class ArchiveCreateRequest {
 
     @Schema(description = "콘텐츠 날짜", example = "2024-07-01")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    @NotNull(message = "contentDate를 입력해주세요.")
     @PastOrPresent(message = "미래 날짜는 입력할 수 없습니다.")
     private LocalDate contentDate;
 

--- a/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/boaz/backend/global/exception/ErrorCode.java
@@ -73,10 +73,6 @@ public enum ErrorCode {
     // Archive Admin
     ARCHIVE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARCHIVE_NOT_FOUND", "해당 아카이브를 찾을 수 없습니다."),
     UNSUPPORTED_ARCHIVE_CATEGORY(HttpStatus.BAD_REQUEST, "UNSUPPORTED_ARCHIVE_CATEGORY", "해당 카테고리는 지원하지 않는 작업입니다."),
-    MISSING_TERM(HttpStatus.BAD_REQUEST, "MISSING_TERM", "term이 누락되었습니다."),
-    MISSING_TITLE(HttpStatus.BAD_REQUEST, "MISSING_TITLE", "title이 누락되었습니다."),
-    MISSING_TRACK(HttpStatus.BAD_REQUEST, "MISSING_TRACK", "track이 누락되었습니다."),
-    MISSING_LINKS(HttpStatus.BAD_REQUEST, "MISSING_LINKS", "links가 누락되었습니다."),
     MISSING_HALF(HttpStatus.BAD_REQUEST, "MISSING_HALF", "half가 누락되었습니다."),
     INVALID_URL_FORMAT(HttpStatus.BAD_REQUEST, "INVALID_URL_FORMAT", "링크 URL 형식이 올바르지 않습니다."),
     FUTURE_DATE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "FUTURE_DATE_NOT_ALLOWED", "미래 날짜는 입력할 수 없습니다."),


### PR DESCRIPTION
## 💡 개요

* Issue Number: #95 

## 🪐 주요 변경 사항
- contentDate 필수 입력 검증 추가
- 미사용 에러코드 제거

## ✅ 상세 내용
- ArchiveCreateRequest.contentDate에 @NotNull 추가 → 등록 요청 시 contentDate 누락되면 400 반환
- 기존 DB 컬럼은 nullable 유지 (기존 데이터 영향 없음)
- @Valid로 이미 처리되어 실제로 사용되지 않던 MISSING_TERM, MISSING_TITLE, MISSING_TRACK, MISSING_LINKS 에러코드 제거

## 🔔 참고 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **변경 목적**: Admin에서 archive 등록 시 contentDate 필드를 필수 입력으로 강제하기 위해 검증 로직을 추가하고, 이에 따라 미사용되는 에러 코드를 정리합니다.

- **주요 변경 내용**:
  - `ArchiveCreateRequest.java`: `contentDate` 필드에 `@NotNull(message = "contentDate를 입력해주세요.")` 검증 어노테이션 추가
  - `ErrorCode.java`: 미사용 enum 상수 4개 제거 (`MISSING_TERM`, `MISSING_TITLE`, `MISSING_TRACK`, `MISSING_LINKS`)

- **영향 범위**: 
  - **API 변경**: Archive 등록 요청 시 contentDate 누락 시 HTTP 400 반환 (기존에는 null 허용)
  - **DB 스키마 변경**: 없음 (컬럼은 nullable 유지)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->