### PR TITLE
#147 test: Curriculum 도메인 테스트 코드 작성

### DIFF
--- a/src/test/java/com/boaz/backend/domain/curriculum/controller/CurriculumAdminControllerTest.java
+++ b/src/test/java/com/boaz/backend/domain/curriculum/controller/CurriculumAdminControllerTest.java
@@ -1,0 +1,232 @@
+package com.boaz.backend.domain.curriculum.controller;
+
+import com.boaz.backend.domain.curriculum.dto.response.CurriculumResponse;
+import com.boaz.backend.domain.curriculum.dto.response.CurriculumStepResponse;
+import com.boaz.backend.domain.curriculum.entity.Curriculum;
+import com.boaz.backend.domain.curriculum.service.CurriculumService;
+import com.boaz.backend.global.common.enums.Track;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import com.boaz.backend.support.TestSecurityConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@WebMvcTest(
+        value = CurriculumAdminController.class,
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class}
+)
+@Import(TestSecurityConfig.class)
+class CurriculumAdminControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @MockitoBean CurriculumService curriculumService;
+
+    private UsernamePasswordAuthenticationToken adminAuth() {
+        return new UsernamePasswordAuthenticationToken(
+                "admin", null,
+                List.of(new SimpleGrantedAuthority("ROLE_SUPER")));
+    }
+
+    private CurriculumResponse makeCurriculumResponse(Long id, Track track) {
+        Curriculum c = Curriculum.create(track, "[]");
+        ReflectionTestUtils.setField(c, "id", id);
+        return CurriculumResponse.from(c, List.of(new CurriculumStepResponse(1, "제목", "설명")));
+    }
+
+    private String createBody(String track) {
+        ObjectNode body = objectMapper.createObjectNode();
+        body.put("track", track);
+        ArrayNode steps = body.putArray("curriculum_steps");
+        steps.addObject().put("step", 1).put("title", "제목").put("desc", "설명");
+        return body.toString();
+    }
+
+    private String updateBody() {
+        ObjectNode body = objectMapper.createObjectNode();
+        ArrayNode steps = body.putArray("curriculum_steps");
+        steps.addObject().put("step", 1).put("title", "교체됨").put("desc", "새설명");
+        return body.toString();
+    }
+
+    // ──────────────────────────────────────────────
+    // CUR-002: POST /api/v1/admin/curriculums
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("CUR-002 POST /api/v1/admin/curriculums")
+    class CreateCurriculum {
+
+        @Test
+        @DisplayName("TC-005 등록 성공 → 201 Created")
+        void success() throws Exception {
+            when(curriculumService.createCurriculum(any()))
+                    .thenReturn(makeCurriculumResponse(1L, Track.ANALYSIS));
+
+            mockMvc.perform(post("/api/v1/admin/curriculums")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(createBody("ANALYSIS")))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.status").value(201))
+                    .andExpect(jsonPath("$.data.track").value("ANALYSIS"));
+        }
+
+        @Test
+        @DisplayName("TC-006 track=ALL → 400 INVALID_TRACK_SELECTION")
+        void trackAll() throws Exception {
+            when(curriculumService.createCurriculum(any()))
+                    .thenThrow(new CustomException(ErrorCode.INVALID_TRACK_SELECTION));
+
+            mockMvc.perform(post("/api/v1/admin/curriculums")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(createBody("ALL")))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error_code").value("INVALID_TRACK_SELECTION"));
+        }
+
+        @Test
+        @DisplayName("TC-007 동일 track 중복 등록 → 409 DUPLICATE_TRACK")
+        void duplicateTrack() throws Exception {
+            when(curriculumService.createCurriculum(any()))
+                    .thenThrow(new CustomException(ErrorCode.DUPLICATE_TRACK));
+
+            mockMvc.perform(post("/api/v1/admin/curriculums")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(createBody("ANALYSIS")))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.error_code").value("DUPLICATE_TRACK"));
+        }
+
+        @Test
+        @DisplayName("curriculum_steps 누락 → 400")
+        void missingSteps() throws Exception {
+            String body = objectMapper.createObjectNode().put("track", "ANALYSIS").toString();
+
+            mockMvc.perform(post("/api/v1/admin/curriculums")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("[Security] 미인증 요청 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(post("/api/v1/admin/curriculums")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(createBody("ANALYSIS")))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // CUR-003: PUT /api/v1/admin/curriculums/{id}
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("CUR-003 PUT /api/v1/admin/curriculums/{curriculumId}")
+    class UpdateCurriculum {
+
+        @Test
+        @DisplayName("TC-008 단계 전체 교체 성공 → 200 OK")
+        void success() throws Exception {
+            when(curriculumService.updateCurriculum(eq(1L), any()))
+                    .thenReturn(makeCurriculumResponse(1L, Track.ANALYSIS));
+
+            mockMvc.perform(put("/api/v1/admin/curriculums/1")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(updateBody()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200));
+        }
+
+        @Test
+        @DisplayName("TC-009 존재하지 않는 curriculumId → 404 CURRICULUM_NOT_FOUND")
+        void notFound() throws Exception {
+            when(curriculumService.updateCurriculum(eq(999L), any()))
+                    .thenThrow(new CustomException(ErrorCode.CURRICULUM_NOT_FOUND));
+
+            mockMvc.perform(put("/api/v1/admin/curriculums/999")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(updateBody()))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.error_code").value("CURRICULUM_NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("[Security] 미인증 요청 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(put("/api/v1/admin/curriculums/1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(updateBody()))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // CUR-004: DELETE /api/v1/admin/curriculums/{id}
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("CUR-004 DELETE /api/v1/admin/curriculums/{curriculumId}")
+    class DeleteCurriculum {
+
+        @Test
+        @DisplayName("TC-010 삭제 성공 → 200 OK")
+        void success() throws Exception {
+            mockMvc.perform(delete("/api/v1/admin/curriculums/1")
+                            .with(authentication(adminAuth())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200));
+        }
+
+        @Test
+        @DisplayName("TC-011 존재하지 않는 curriculumId → 404 CURRICULUM_NOT_FOUND")
+        void notFound() throws Exception {
+            doThrow(new CustomException(ErrorCode.CURRICULUM_NOT_FOUND))
+                    .when(curriculumService).deleteCurriculum(999L);
+
+            mockMvc.perform(delete("/api/v1/admin/curriculums/999")
+                            .with(authentication(adminAuth())))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.error_code").value("CURRICULUM_NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("[Security] 미인증 요청 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(delete("/api/v1/admin/curriculums/1"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/curriculum/controller/CurriculumControllerTest.java
+++ b/src/test/java/com/boaz/backend/domain/curriculum/controller/CurriculumControllerTest.java
@@ -1,0 +1,127 @@
+package com.boaz.backend.domain.curriculum.controller;
+
+import com.boaz.backend.domain.curriculum.dto.response.CurriculumResponse;
+import com.boaz.backend.domain.curriculum.dto.response.CurriculumStepResponse;
+import com.boaz.backend.domain.curriculum.entity.Curriculum;
+import com.boaz.backend.domain.curriculum.service.CurriculumService;
+import com.boaz.backend.global.common.enums.Track;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import com.boaz.backend.support.TestSecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@WebMvcTest(
+        value = CurriculumController.class,
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class}
+)
+@Import(TestSecurityConfig.class)
+class CurriculumControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @MockitoBean CurriculumService curriculumService;
+
+    private CurriculumResponse makeCurriculumResponse(Long id, Track track) {
+        Curriculum c = Curriculum.create(track, "[]");
+        ReflectionTestUtils.setField(c, "id", id);
+        return CurriculumResponse.from(c, List.of(new CurriculumStepResponse(1, "제목", "설명")));
+    }
+
+    // ──────────────────────────────────────────────
+    // CUR-001: GET /api/v1/curriculums
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("CUR-001 GET /api/v1/curriculums")
+    class GetCurriculums {
+
+        @Test
+        @DisplayName("TC-001 track 미입력 → 200 + 전체 목록")
+        void allTracks() throws Exception {
+            when(curriculumService.getCurriculums(isNull())).thenReturn(List.of(
+                    makeCurriculumResponse(1L, Track.ANALYSIS),
+                    makeCurriculumResponse(2L, Track.VISUALIZATION)
+            ));
+
+            mockMvc.perform(get("/api/v1/curriculums"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.length()").value(2));
+        }
+
+        @Test
+        @DisplayName("TC-002 track=ANALYSIS → 200 + 해당 트랙만 반환")
+        void specificTrack() throws Exception {
+            when(curriculumService.getCurriculums(Track.ANALYSIS))
+                    .thenReturn(List.of(makeCurriculumResponse(1L, Track.ANALYSIS)));
+
+            mockMvc.perform(get("/api/v1/curriculums")
+                            .param("track", "ANALYSIS"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.length()").value(1))
+                    .andExpect(jsonPath("$.data[0].track").value("ANALYSIS"));
+        }
+
+        @Test
+        @DisplayName("TC-003 track=ALL → 400 INVALID_TRACK_SELECTION")
+        void trackAll() throws Exception {
+            when(curriculumService.getCurriculums(Track.ALL))
+                    .thenThrow(new CustomException(ErrorCode.INVALID_TRACK_SELECTION));
+
+            mockMvc.perform(get("/api/v1/curriculums")
+                            .param("track", "ALL"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error_code").value("INVALID_TRACK_SELECTION"));
+        }
+
+        @Test
+        @DisplayName("TC-004 해당 track 데이터 없을 때 → 200 + 빈 배열")
+        void noData() throws Exception {
+            when(curriculumService.getCurriculums(Track.ENGINEERING)).thenReturn(List.of());
+
+            mockMvc.perform(get("/api/v1/curriculums")
+                            .param("track", "ENGINEERING"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.length()").value(0));
+        }
+
+        @Test
+        @DisplayName("[Security] 인증 없이 접근 가능 (공개 API)")
+        void publicApi() throws Exception {
+            when(curriculumService.getCurriculums(any())).thenReturn(List.of());
+
+            mockMvc.perform(get("/api/v1/curriculums"))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("curriculum_steps 필드명 확인 → snake_case")
+        void curriculumStepsFieldName() throws Exception {
+            when(curriculumService.getCurriculums(isNull()))
+                    .thenReturn(List.of(makeCurriculumResponse(1L, Track.ANALYSIS)));
+
+            mockMvc.perform(get("/api/v1/curriculums"))
+                    .andExpect(jsonPath("$.data[0].curriculum_steps").isArray())
+                    .andExpect(jsonPath("$.data[0].curriculum_steps[0].step").value(1));
+        }
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/curriculum/integration/CurriculumIntegrationTest.java
+++ b/src/test/java/com/boaz/backend/domain/curriculum/integration/CurriculumIntegrationTest.java
@@ -1,0 +1,249 @@
+package com.boaz.backend.domain.curriculum.integration;
+
+import com.boaz.backend.domain.curriculum.dto.request.CurriculumCreateRequest;
+import com.boaz.backend.domain.curriculum.dto.request.CurriculumStepRequest;
+import com.boaz.backend.domain.curriculum.dto.request.CurriculumUpdateRequest;
+import com.boaz.backend.domain.curriculum.dto.response.CurriculumResponse;
+import com.boaz.backend.domain.curriculum.entity.Curriculum;
+import com.boaz.backend.domain.curriculum.repository.CurriculumRepository;
+import com.boaz.backend.domain.curriculum.service.CurriculumService;
+import com.boaz.backend.global.common.enums.Track;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import com.boaz.backend.support.TestcontainersBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class CurriculumIntegrationTest extends TestcontainersBase {
+
+    @Autowired CurriculumService curriculumService;
+    @Autowired CurriculumRepository curriculumRepository;
+
+    // ──────────────────────────────────────────────
+    // 헬퍼
+    // ──────────────────────────────────────────────
+
+    private Curriculum saveCurriculum(Track track) {
+        String stepsJson = "[{\"step\":1,\"title\":\"제목\",\"desc\":\"설명\"}]";
+        return curriculumRepository.save(Curriculum.create(track, stepsJson));
+    }
+
+    private CurriculumStepRequest makeStep(int step, String title, String desc) {
+        CurriculumStepRequest s = new CurriculumStepRequest();
+        ReflectionTestUtils.setField(s, "step", step);
+        ReflectionTestUtils.setField(s, "title", title);
+        ReflectionTestUtils.setField(s, "desc", desc);
+        return s;
+    }
+
+    private CurriculumCreateRequest makeCreateRequest(Track track, List<CurriculumStepRequest> steps) {
+        CurriculumCreateRequest req = new CurriculumCreateRequest();
+        ReflectionTestUtils.setField(req, "track", track);
+        ReflectionTestUtils.setField(req, "curriculumSteps", steps);
+        return req;
+    }
+
+    private CurriculumUpdateRequest makeUpdateRequest(List<CurriculumStepRequest> steps) {
+        CurriculumUpdateRequest req = new CurriculumUpdateRequest();
+        ReflectionTestUtils.setField(req, "curriculumSteps", steps);
+        return req;
+    }
+
+    // ══════════════════════════════════════════════
+    // CUR-001: 커리큘럼 조회
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("커리큘럼 조회 end-to-end (CUR-001)")
+    class GetCurriculums {
+
+        @Test
+        @DisplayName("TC-001 track 미입력 → 저장된 전체 반환")
+        void allTracks() {
+            saveCurriculum(Track.ANALYSIS);
+            saveCurriculum(Track.VISUALIZATION);
+
+            List<CurriculumResponse> result = curriculumService.getCurriculums(null);
+
+            assertThat(result).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("TC-002 track=ANALYSIS 필터 → 해당 트랙만 반환")
+        void specificTrack() {
+            saveCurriculum(Track.ANALYSIS);
+            saveCurriculum(Track.ENGINEERING);
+
+            List<CurriculumResponse> result = curriculumService.getCurriculums(Track.ANALYSIS);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getTrack()).isEqualTo("ANALYSIS");
+        }
+
+        @Test
+        @DisplayName("TC-003 track=ALL → INVALID_TRACK_SELECTION")
+        void trackAll() {
+            assertThatThrownBy(() -> curriculumService.getCurriculums(Track.ALL))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.INVALID_TRACK_SELECTION);
+        }
+
+        @Test
+        @DisplayName("TC-004 해당 track 데이터 없을 때 → 빈 배열")
+        void noData() {
+            List<CurriculumResponse> result = curriculumService.getCurriculums(Track.ENGINEERING);
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // CUR-002: 커리큘럼 등록
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("커리큘럼 등록 end-to-end (CUR-002)")
+    class CreateCurriculum {
+
+        @Test
+        @DisplayName("TC-005 등록 성공 → step 오름차순 정렬 후 DB 저장")
+        void successWithStepSorting() {
+            List<CurriculumStepRequest> steps = List.of(
+                    makeStep(3, "세번째", "설명3"),
+                    makeStep(1, "첫번째", "설명1"),
+                    makeStep(2, "두번째", "설명2")
+            );
+
+            CurriculumResponse res = curriculumService.createCurriculum(
+                    makeCreateRequest(Track.ANALYSIS, steps));
+
+            assertThat(res.getCurriculumSteps()).hasSize(3);
+            assertThat(res.getCurriculumSteps().get(0).getStep()).isEqualTo(1);
+            assertThat(res.getCurriculumSteps().get(2).getStep()).isEqualTo(3);
+            assertThat(curriculumRepository.existsByTrack(Track.ANALYSIS)).isTrue();
+        }
+
+        @Test
+        @DisplayName("TC-006 track=ALL → INVALID_TRACK_SELECTION")
+        void trackAll() {
+            assertThatThrownBy(() -> curriculumService.createCurriculum(
+                    makeCreateRequest(Track.ALL, List.of(makeStep(1, "제목", "설명")))))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.INVALID_TRACK_SELECTION);
+
+            assertThat(curriculumRepository.count()).isZero();
+        }
+
+        @Test
+        @DisplayName("TC-007 동일 track 중복 등록 → DUPLICATE_TRACK")
+        void duplicateTrack() {
+            saveCurriculum(Track.ANALYSIS);
+
+            assertThatThrownBy(() -> curriculumService.createCurriculum(
+                    makeCreateRequest(Track.ANALYSIS, List.of(makeStep(1, "제목", "설명")))))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.DUPLICATE_TRACK);
+
+            assertThat(curriculumRepository.count()).isEqualTo(1);
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // CUR-003: 커리큘럼 수정
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("커리큘럼 수정 end-to-end (CUR-003)")
+    class UpdateCurriculum {
+
+        @Test
+        @DisplayName("TC-008 단계 전체 교체 성공 → 새 단계로 대체, track 유지")
+        void success() {
+            Curriculum saved = saveCurriculum(Track.ANALYSIS);
+
+            CurriculumResponse res = curriculumService.updateCurriculum(saved.getId(),
+                    makeUpdateRequest(List.of(
+                            makeStep(1, "교체됨", "새설명1"),
+                            makeStep(2, "추가됨", "새설명2")
+                    )));
+
+            assertThat(res.getCurriculumSteps()).hasSize(2);
+            assertThat(res.getCurriculumSteps().get(0).getTitle()).isEqualTo("교체됨");
+            assertThat(res.getTrack()).isEqualTo("ANALYSIS");
+        }
+
+        @Test
+        @DisplayName("TC-009 존재하지 않는 curriculumId → CURRICULUM_NOT_FOUND")
+        void notFound() {
+            assertThatThrownBy(() -> curriculumService.updateCurriculum(999L,
+                    makeUpdateRequest(List.of(makeStep(1, "제목", "설명")))))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.CURRICULUM_NOT_FOUND);
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // CUR-004: 커리큘럼 삭제
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("커리큘럼 삭제 end-to-end (CUR-004)")
+    class DeleteCurriculum {
+
+        @Test
+        @DisplayName("TC-010 삭제 성공 → DB에서 제거됨")
+        void success() {
+            Curriculum saved = saveCurriculum(Track.ANALYSIS);
+
+            curriculumService.deleteCurriculum(saved.getId());
+
+            assertThat(curriculumRepository.findById(saved.getId())).isEmpty();
+        }
+
+        @Test
+        @DisplayName("TC-011 존재하지 않는 curriculumId → CURRICULUM_NOT_FOUND")
+        void notFound() {
+            assertThatThrownBy(() -> curriculumService.deleteCurriculum(999L))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.CURRICULUM_NOT_FOUND);
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // 생명주기 통합 시나리오
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("커리큘럼 전체 생명주기 시나리오")
+    class Lifecycle {
+
+        @Test
+        @DisplayName("등록 → 조회 → 수정 → 삭제 흐름이 DB와 일치")
+        void fullLifecycle() {
+            CurriculumResponse created = curriculumService.createCurriculum(
+                    makeCreateRequest(Track.VISUALIZATION, List.of(makeStep(1, "초기", "초기설명"))));
+            assertThat(curriculumRepository.count()).isEqualTo(1);
+
+            List<CurriculumResponse> list = curriculumService.getCurriculums(Track.VISUALIZATION);
+            assertThat(list).hasSize(1);
+            assertThat(list.get(0).getCurriculumSteps().get(0).getTitle()).isEqualTo("초기");
+
+            CurriculumResponse updated = curriculumService.updateCurriculum(created.getId(),
+                    makeUpdateRequest(List.of(makeStep(1, "수정됨", "수정설명"))));
+            assertThat(updated.getCurriculumSteps().get(0).getTitle()).isEqualTo("수정됨");
+
+            curriculumService.deleteCurriculum(created.getId());
+            assertThat(curriculumRepository.findById(created.getId())).isEmpty();
+            assertThat(curriculumService.getCurriculums(Track.VISUALIZATION)).isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/curriculum/service/CurriculumServiceTest.java
+++ b/src/test/java/com/boaz/backend/domain/curriculum/service/CurriculumServiceTest.java
@@ -1,0 +1,247 @@
+package com.boaz.backend.domain.curriculum.service;
+
+import com.boaz.backend.domain.curriculum.dto.request.CurriculumCreateRequest;
+import com.boaz.backend.domain.curriculum.dto.request.CurriculumStepRequest;
+import com.boaz.backend.domain.curriculum.dto.request.CurriculumUpdateRequest;
+import com.boaz.backend.domain.curriculum.dto.response.CurriculumResponse;
+import com.boaz.backend.domain.curriculum.entity.Curriculum;
+import com.boaz.backend.domain.curriculum.repository.CurriculumRepository;
+import com.boaz.backend.global.common.enums.Track;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CurriculumServiceTest {
+
+    @InjectMocks CurriculumService curriculumService;
+    @Mock CurriculumRepository curriculumRepository;
+    @Spy ObjectMapper objectMapper;
+
+    // ──────────────────────────────────────────────
+    // 헬퍼
+    // ──────────────────────────────────────────────
+
+    private Curriculum makeCurriculum(Long id, Track track) {
+        String stepsJson = "[{\"step\":1,\"title\":\"제목\",\"desc\":\"설명\"}]";
+        Curriculum c = Curriculum.create(track, stepsJson);
+        ReflectionTestUtils.setField(c, "id", id);
+        return c;
+    }
+
+    private CurriculumStepRequest makeStep(int step, String title, String desc) {
+        CurriculumStepRequest s = new CurriculumStepRequest();
+        ReflectionTestUtils.setField(s, "step", step);
+        ReflectionTestUtils.setField(s, "title", title);
+        ReflectionTestUtils.setField(s, "desc", desc);
+        return s;
+    }
+
+    private CurriculumCreateRequest makeCreateRequest(Track track, List<CurriculumStepRequest> steps) {
+        CurriculumCreateRequest req = new CurriculumCreateRequest();
+        ReflectionTestUtils.setField(req, "track", track);
+        ReflectionTestUtils.setField(req, "curriculumSteps", steps);
+        return req;
+    }
+
+    private CurriculumUpdateRequest makeUpdateRequest(List<CurriculumStepRequest> steps) {
+        CurriculumUpdateRequest req = new CurriculumUpdateRequest();
+        ReflectionTestUtils.setField(req, "curriculumSteps", steps);
+        return req;
+    }
+
+    // ══════════════════════════════════════════════
+    // CUR-001: 커리큘럼 조회
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("CUR-001 커리큘럼 조회")
+    class GetCurriculums {
+
+        @Test
+        @DisplayName("TC-001 track 미입력 → 전체 반환")
+        void allTracks() {
+            when(curriculumRepository.findAll()).thenReturn(List.of(
+                    makeCurriculum(1L, Track.ANALYSIS),
+                    makeCurriculum(2L, Track.VISUALIZATION)
+            ));
+
+            List<CurriculumResponse> result = curriculumService.getCurriculums(null);
+
+            assertThat(result).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("TC-002 track=ANALYSIS → 해당 트랙만 반환")
+        void specificTrack() {
+            Curriculum c = makeCurriculum(1L, Track.ANALYSIS);
+            when(curriculumRepository.findByTrack(Track.ANALYSIS)).thenReturn(Optional.of(c));
+
+            List<CurriculumResponse> result = curriculumService.getCurriculums(Track.ANALYSIS);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getTrack()).isEqualTo("ANALYSIS");
+        }
+
+        @Test
+        @DisplayName("TC-003 track=ALL → INVALID_TRACK_SELECTION")
+        void trackAll() {
+            assertThatThrownBy(() -> curriculumService.getCurriculums(Track.ALL))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_TRACK_SELECTION);
+        }
+
+        @Test
+        @DisplayName("TC-004 해당 track 데이터 없음 → 빈 배열 반환")
+        void noData() {
+            when(curriculumRepository.findByTrack(Track.ENGINEERING)).thenReturn(Optional.empty());
+
+            List<CurriculumResponse> result = curriculumService.getCurriculums(Track.ENGINEERING);
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // CUR-002: 커리큘럼 등록
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("CUR-002 커리큘럼 등록")
+    class CreateCurriculum {
+
+        @Test
+        @DisplayName("TC-005 등록 성공 → step 오름차순 정렬 후 저장")
+        void successWithStepSorting() {
+            when(curriculumRepository.existsByTrack(Track.ANALYSIS)).thenReturn(false);
+            when(curriculumRepository.save(any())).thenAnswer(inv -> {
+                Curriculum c = inv.getArgument(0);
+                ReflectionTestUtils.setField(c, "id", 1L);
+                return c;
+            });
+
+            List<CurriculumStepRequest> steps = List.of(
+                    makeStep(3, "세번째", "설명3"),
+                    makeStep(1, "첫번째", "설명1"),
+                    makeStep(2, "두번째", "설명2")
+            );
+
+            CurriculumResponse res = curriculumService.createCurriculum(
+                    makeCreateRequest(Track.ANALYSIS, steps));
+
+            assertThat(res.getCurriculumSteps()).hasSize(3);
+            assertThat(res.getCurriculumSteps().get(0).getStep()).isEqualTo(1);
+            assertThat(res.getCurriculumSteps().get(1).getStep()).isEqualTo(2);
+            assertThat(res.getCurriculumSteps().get(2).getStep()).isEqualTo(3);
+            verify(curriculumRepository).save(any(Curriculum.class));
+        }
+
+        @Test
+        @DisplayName("TC-006 track=ALL → INVALID_TRACK_SELECTION, 저장 안 함")
+        void trackAll() {
+            assertThatThrownBy(() -> curriculumService.createCurriculum(
+                    makeCreateRequest(Track.ALL, List.of(makeStep(1, "제목", "설명")))))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_TRACK_SELECTION);
+
+            verify(curriculumRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("TC-007 동일 track 중복 등록 → DUPLICATE_TRACK, 저장 안 함")
+        void duplicateTrack() {
+            when(curriculumRepository.existsByTrack(Track.ANALYSIS)).thenReturn(true);
+
+            assertThatThrownBy(() -> curriculumService.createCurriculum(
+                    makeCreateRequest(Track.ANALYSIS, List.of(makeStep(1, "제목", "설명")))))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.DUPLICATE_TRACK);
+
+            verify(curriculumRepository, never()).save(any());
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // CUR-003: 커리큘럼 수정
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("CUR-003 커리큘럼 수정")
+    class UpdateCurriculum {
+
+        @Test
+        @DisplayName("TC-008 단계 전체 교체 성공 → track 유지")
+        void success() {
+            Curriculum c = makeCurriculum(1L, Track.ANALYSIS);
+            when(curriculumRepository.findById(1L)).thenReturn(Optional.of(c));
+
+            CurriculumResponse res = curriculumService.updateCurriculum(1L,
+                    makeUpdateRequest(List.of(makeStep(1, "교체됨", "새설명"), makeStep(2, "추가됨", "설명2"))));
+
+            assertThat(res.getCurriculumSteps()).hasSize(2);
+            assertThat(res.getCurriculumSteps().get(0).getTitle()).isEqualTo("교체됨");
+            assertThat(res.getTrack()).isEqualTo("ANALYSIS");
+        }
+
+        @Test
+        @DisplayName("TC-009 존재하지 않는 curriculumId → CURRICULUM_NOT_FOUND")
+        void notFound() {
+            when(curriculumRepository.findById(999L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> curriculumService.updateCurriculum(999L,
+                    makeUpdateRequest(List.of(makeStep(1, "제목", "설명")))))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.CURRICULUM_NOT_FOUND);
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // CUR-004: 커리큘럼 삭제
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("CUR-004 커리큘럼 삭제")
+    class DeleteCurriculum {
+
+        @Test
+        @DisplayName("TC-010 삭제 성공 → repository.delete 호출")
+        void success() {
+            Curriculum c = makeCurriculum(1L, Track.ANALYSIS);
+            when(curriculumRepository.findById(1L)).thenReturn(Optional.of(c));
+
+            curriculumService.deleteCurriculum(1L);
+
+            verify(curriculumRepository).delete(c);
+        }
+
+        @Test
+        @DisplayName("TC-011 존재하지 않는 curriculumId → CURRICULUM_NOT_FOUND, 삭제 안 함")
+        void notFound() {
+            when(curriculumRepository.findById(999L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> curriculumService.deleteCurriculum(999L))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.CURRICULUM_NOT_FOUND);
+
+            verify(curriculumRepository, never()).delete(any());
+        }
+    }
+}


### PR DESCRIPTION
## 💡 개요

* Issue Number: #147

## 🪐 주요 변경 사항
- Curriculum 도메인 전체 API 테스트 코드 작성 (Service / Controller / Integration)

## ✅ 상세 내용
- [Unit] `CurriculumServiceTest`: getCurriculums, createCurriculum, updateCurriculum, deleteCurriculum 서비스 레이어 단위 테스트 (11 cases)
  - track=ALL 입력 시 INVALID_TRACK_SELECTION 예외 확인
  - 동일 track 중복 등록 시 DUPLICATE_TRACK 예외 확인
  - step 역순 입력 시 오름차순 정렬 후 저장 확인
  - 존재하지 않는 curriculumId 수정/삭제 시 CURRICULUM_NOT_FOUND 예외 확인
- [Unit] `CurriculumControllerTest`: GET /api/v1/curriculums 공개 API 슬라이스 테스트 (6 cases)
  - curriculum_steps snake_case 필드명 확인
- [Unit] `CurriculumAdminControllerTest`: POST, PUT, DELETE /api/v1/admin/curriculums 슬라이스 테스트 (9 cases)
  - 미인증 요청 401 확인
  - curriculum_steps 누락 시 400 확인
- [Integration] `CurriculumIntegrationTest`: 실제 DB 기반 통합 테스트 (12 cases)
  - 전체 생명주기 (등록 → 조회 → 수정 → 삭제) 시나리오 포함

## 🔔 참고 사항
- 통합 테스트는 Testcontainers(MySQL) 기반이며 Docker 환경에서 실행 필요
- 연관 명세서: CUR-001 ~ CUR-004

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 변경 목적
Curriculum 도메인의 전체 API에 대한 테스트 커버리지를 확보하고, 서비스/컨트롤러/통합 레이어에서의 예외 처리, 데이터 정렬, 필드명 검증 등을 체계적으로 검증하기 위해 38개 테스트 케이스를 추가합니다.

## 주요 변경 내용

**서비스 레이어 테스트** (`CurriculumServiceTest.java`, 11개 케이스)
- 조회: track 파라미터 유무, `INVALID_TRACK_SELECTION` 예외, 빈 배열 처리 검증
- 등록: step 오름차순 정렬 저장, `INVALID_TRACK_SELECTION` 및 `DUPLICATE_TRACK` 예외 검증
- 수정/삭제: `CURRICULUM_NOT_FOUND` 예외 검증, 존재 시 변경/삭제 동작 확인

**공개 API 컨트롤러 테스트** (`CurriculumControllerTest.java`, 6개 케이스)
- GET `/api/v1/curriculums` 응답 검증
- 응답의 `curriculum_steps` 필드명이 snake_case인지 확인
- 인증 없이도 접근 가능한 공개 API 동작 검증

**관리자 API 컨트롤러 테스트** (`CurriculumAdminControllerTest.java`, 9개 케이스)
- POST/PUT/DELETE 엔드포인트 성공/실패 케이스 검증
- 미인증 요청에 대한 401 응답, 필수 필드 누락 시 400 응답 검증
- `CURRICULUM_NOT_FOUND`, `INVALID_TRACK_SELECTION`, `DUPLICATE_TRACK` 예외 및 HTTP 상태 코드 검증

**통합 테스트** (`CurriculumIntegrationTest.java`, 12개 케이스)
- Testcontainers MySQL을 사용한 실제 DB 기반 테스트
- 조회/등록/수정/삭제 각 작업별 DB 상태 변화 검증
- 전체 생명주기 시나리오(create → get → update → delete) end-to-end 검증

## 영향 범위
- API 변경 사항 없음 (테스트 코드만 추가)
- DB 스키마 변경 없음
- 설정 변경 없음

<!-- end of auto-generated comment: release notes by coderabbit.ai -->