### PR TITLE
#149 test: Review 도메인 테스트 코드 작성

### DIFF
--- a/src/test/java/com/boaz/backend/domain/review/controller/ReviewAdminControllerTest.java
+++ b/src/test/java/com/boaz/backend/domain/review/controller/ReviewAdminControllerTest.java
@@ -1,0 +1,234 @@
+package com.boaz.backend.domain.review.controller;
+
+import com.boaz.backend.domain.review.dto.response.ReviewResponse;
+import com.boaz.backend.domain.review.entity.Review;
+import com.boaz.backend.domain.review.service.ReviewService;
+import com.boaz.backend.global.common.enums.Track;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import com.boaz.backend.support.TestSecurityConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@WebMvcTest(
+        value = ReviewAdminController.class,
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class}
+)
+@Import(TestSecurityConfig.class)
+class ReviewAdminControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @MockitoBean ReviewService reviewService;
+
+    private UsernamePasswordAuthenticationToken adminAuth() {
+        return new UsernamePasswordAuthenticationToken(
+                "admin", null,
+                List.of(new SimpleGrantedAuthority("ROLE_SUPER")));
+    }
+
+    private ReviewResponse makeReviewResponse(Long id, Track track, int term) {
+        Review r = Review.create("홍길동", track, term, "후기 내용", null);
+        ReflectionTestUtils.setField(r, "id", id);
+        return ReviewResponse.from(r);
+    }
+
+    private String createBody(String track) {
+        return objectMapper.createObjectNode()
+                .put("name", "홍길동")
+                .put("track", track)
+                .put("term", 26)
+                .put("content", "좋은 경험이었습니다.")
+                .toString();
+    }
+
+    // ──────────────────────────────────────────────
+    // REV-002: POST /api/v1/admin/reviews
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("REV-002 POST /api/v1/admin/reviews")
+    class CreateReview {
+
+        @Test
+        @DisplayName("TC-007 후기 등록 성공 → 201 Created")
+        void success() throws Exception {
+            when(reviewService.createReview(any()))
+                    .thenReturn(makeReviewResponse(1L, Track.ANALYSIS, 26));
+
+            mockMvc.perform(post("/api/v1/admin/reviews")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(createBody("ANALYSIS")))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.status").value(201))
+                    .andExpect(jsonPath("$.data.track").value("ANALYSIS"))
+                    .andExpect(jsonPath("$.data.term").value(26));
+        }
+
+        @Test
+        @DisplayName("TC-008 track=ALL → 400 INVALID_TRACK_SELECTION")
+        void trackAll() throws Exception {
+            when(reviewService.createReview(any()))
+                    .thenThrow(new CustomException(ErrorCode.INVALID_TRACK_SELECTION));
+
+            mockMvc.perform(post("/api/v1/admin/reviews")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(createBody("ALL")))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error_code").value("INVALID_TRACK_SELECTION"));
+        }
+
+        @Test
+        @DisplayName("필수 필드 누락 (name 없음) → 400")
+        void missingRequiredField() throws Exception {
+            String body = objectMapper.createObjectNode()
+                    .put("track", "ANALYSIS")
+                    .put("term", 26)
+                    .put("content", "내용")
+                    .toString();
+
+            mockMvc.perform(post("/api/v1/admin/reviews")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("[Security] 미인증 요청 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(post("/api/v1/admin/reviews")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(createBody("ANALYSIS")))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // REV-003: PATCH /api/v1/admin/reviews/{reviewId}
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("REV-003 PATCH /api/v1/admin/reviews/{reviewId}")
+    class UpdateReview {
+
+        @Test
+        @DisplayName("TC-009 부분 수정 성공 → 200 OK")
+        void success() throws Exception {
+            when(reviewService.updateReview(eq(1L), any()))
+                    .thenReturn(makeReviewResponse(1L, Track.ANALYSIS, 26));
+
+            String body = objectMapper.createObjectNode()
+                    .put("content", "수정된 후기")
+                    .toString();
+
+            mockMvc.perform(patch("/api/v1/admin/reviews/1")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200));
+        }
+
+        @Test
+        @DisplayName("TC-010 존재하지 않는 reviewId → 404 REVIEW_NOT_FOUND")
+        void notFound() throws Exception {
+            when(reviewService.updateReview(eq(999L), any()))
+                    .thenThrow(new CustomException(ErrorCode.REVIEW_NOT_FOUND));
+
+            mockMvc.perform(patch("/api/v1/admin/reviews/999")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{}"))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.error_code").value("REVIEW_NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("TC-011 track=ALL로 수정 시도 → 400 INVALID_TRACK_SELECTION")
+        void trackAll() throws Exception {
+            when(reviewService.updateReview(eq(1L), any()))
+                    .thenThrow(new CustomException(ErrorCode.INVALID_TRACK_SELECTION));
+
+            String body = objectMapper.createObjectNode().put("track", "ALL").toString();
+
+            mockMvc.perform(patch("/api/v1/admin/reviews/1")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error_code").value("INVALID_TRACK_SELECTION"));
+        }
+
+        @Test
+        @DisplayName("[Security] 미인증 요청 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(patch("/api/v1/admin/reviews/1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{}"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // REV-004: DELETE /api/v1/admin/reviews/{reviewId}
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("REV-004 DELETE /api/v1/admin/reviews/{reviewId}")
+    class DeleteReview {
+
+        @Test
+        @DisplayName("TC-012 삭제 성공 → 200 OK")
+        void success() throws Exception {
+            mockMvc.perform(delete("/api/v1/admin/reviews/1")
+                            .with(authentication(adminAuth())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200));
+        }
+
+        @Test
+        @DisplayName("TC-013 존재하지 않는 reviewId → 404 REVIEW_NOT_FOUND")
+        void notFound() throws Exception {
+            doThrow(new CustomException(ErrorCode.REVIEW_NOT_FOUND))
+                    .when(reviewService).deleteReview(999L);
+
+            mockMvc.perform(delete("/api/v1/admin/reviews/999")
+                            .with(authentication(adminAuth())))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.error_code").value("REVIEW_NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("[Security] 미인증 요청 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(delete("/api/v1/admin/reviews/1"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/boaz/backend/domain/review/controller/ReviewControllerTest.java
@@ -1,0 +1,151 @@
+package com.boaz.backend.domain.review.controller;
+
+import com.boaz.backend.domain.review.dto.response.ReviewResponse;
+import com.boaz.backend.domain.review.entity.Review;
+import com.boaz.backend.domain.review.service.ReviewService;
+import com.boaz.backend.global.common.enums.Track;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import com.boaz.backend.support.TestSecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@WebMvcTest(
+        value = ReviewController.class,
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class}
+)
+@Import(TestSecurityConfig.class)
+class ReviewControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @MockitoBean ReviewService reviewService;
+
+    private ReviewResponse makeReviewResponse(Long id, Track track, int term) {
+        Review r = Review.create("홍길동", track, term, "후기 내용", null);
+        ReflectionTestUtils.setField(r, "id", id);
+        return ReviewResponse.from(r);
+    }
+
+    // ──────────────────────────────────────────────
+    // REV-001: GET /api/v1/reviews
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("REV-001 GET /api/v1/reviews")
+    class GetReviews {
+
+        @Test
+        @DisplayName("TC-001 파라미터 없음 → 200 + term 내림차순 전체 목록")
+        void allReviews() throws Exception {
+            when(reviewService.getReviews(isNull(), isNull())).thenReturn(List.of(
+                    makeReviewResponse(1L, Track.ENGINEERING, 26),
+                    makeReviewResponse(2L, Track.ANALYSIS, 25)
+            ));
+
+            mockMvc.perform(get("/api/v1/reviews"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.length()").value(2))
+                    .andExpect(jsonPath("$.data[0].term").value(26))
+                    .andExpect(jsonPath("$.data[1].term").value(25));
+        }
+
+        @Test
+        @DisplayName("TC-002 track=ANALYSIS 필터 → 200 + 해당 트랙만")
+        void byTrack() throws Exception {
+            when(reviewService.getReviews(Track.ANALYSIS, null))
+                    .thenReturn(List.of(makeReviewResponse(1L, Track.ANALYSIS, 26)));
+
+            mockMvc.perform(get("/api/v1/reviews").param("track", "ANALYSIS"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data[0].track").value("ANALYSIS"));
+        }
+
+        @Test
+        @DisplayName("TC-003 term=26 필터 → 200 + 26기만")
+        void byTerm() throws Exception {
+            when(reviewService.getReviews(null, 26)).thenReturn(List.of(
+                    makeReviewResponse(1L, Track.ANALYSIS, 26),
+                    makeReviewResponse(2L, Track.ENGINEERING, 26)
+            ));
+
+            mockMvc.perform(get("/api/v1/reviews").param("term", "26"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.length()").value(2));
+        }
+
+        @Test
+        @DisplayName("TC-004 track+term 동시 필터 → 200 + 교집합")
+        void byTrackAndTerm() throws Exception {
+            when(reviewService.getReviews(Track.ANALYSIS, 26))
+                    .thenReturn(List.of(makeReviewResponse(1L, Track.ANALYSIS, 26)));
+
+            mockMvc.perform(get("/api/v1/reviews")
+                            .param("track", "ANALYSIS")
+                            .param("term", "26"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.length()").value(1));
+        }
+
+        @Test
+        @DisplayName("TC-005 track=ALL → 400 INVALID_TRACK_SELECTION")
+        void trackAll() throws Exception {
+            when(reviewService.getReviews(Track.ALL, null))
+                    .thenThrow(new CustomException(ErrorCode.INVALID_TRACK_SELECTION));
+
+            mockMvc.perform(get("/api/v1/reviews").param("track", "ALL"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error_code").value("INVALID_TRACK_SELECTION"));
+        }
+
+        @Test
+        @DisplayName("TC-006 결과 없을 때 → 200 + 빈 배열")
+        void emptyResult() throws Exception {
+            when(reviewService.getReviews(any(), any())).thenReturn(List.of());
+
+            mockMvc.perform(get("/api/v1/reviews").param("term", "99"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.length()").value(0));
+        }
+
+        @Test
+        @DisplayName("[Security] 인증 없이 접근 가능 (공개 API)")
+        void publicApi() throws Exception {
+            when(reviewService.getReviews(any(), any())).thenReturn(List.of());
+
+            mockMvc.perform(get("/api/v1/reviews"))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("image_url 필드명 확인 → snake_case")
+        void imageUrlFieldName() throws Exception {
+            Review r = Review.create("홍길동", Track.ANALYSIS, 26, "내용", "https://img.url");
+            ReflectionTestUtils.setField(r, "id", 1L);
+            when(reviewService.getReviews(isNull(), isNull()))
+                    .thenReturn(List.of(ReviewResponse.from(r)));
+
+            mockMvc.perform(get("/api/v1/reviews"))
+                    .andExpect(jsonPath("$.data[0].image_url").value("https://img.url"));
+        }
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/review/integration/ReviewIntegrationTest.java
+++ b/src/test/java/com/boaz/backend/domain/review/integration/ReviewIntegrationTest.java
@@ -1,0 +1,265 @@
+package com.boaz.backend.domain.review.integration;
+
+import com.boaz.backend.domain.review.dto.request.ReviewCreateRequest;
+import com.boaz.backend.domain.review.dto.request.ReviewUpdateRequest;
+import com.boaz.backend.domain.review.dto.response.ReviewResponse;
+import com.boaz.backend.domain.review.entity.Review;
+import com.boaz.backend.domain.review.repository.ReviewRepository;
+import com.boaz.backend.domain.review.service.ReviewService;
+import com.boaz.backend.global.common.enums.Track;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import com.boaz.backend.support.TestcontainersBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class ReviewIntegrationTest extends TestcontainersBase {
+
+    @Autowired ReviewService reviewService;
+    @Autowired ReviewRepository reviewRepository;
+
+    // ──────────────────────────────────────────────
+    // 헬퍼
+    // ──────────────────────────────────────────────
+
+    private Review saveReview(Track track, int term) {
+        return reviewRepository.save(Review.create("홍길동", track, term, "후기 내용", null));
+    }
+
+    private ReviewCreateRequest makeCreateRequest(Track track, int term) {
+        ReviewCreateRequest req = new ReviewCreateRequest();
+        ReflectionTestUtils.setField(req, "name", "홍길동");
+        ReflectionTestUtils.setField(req, "track", track);
+        ReflectionTestUtils.setField(req, "term", term);
+        ReflectionTestUtils.setField(req, "content", "좋은 경험이었습니다.");
+        ReflectionTestUtils.setField(req, "imageUrl", null);
+        return req;
+    }
+
+    private ReviewUpdateRequest makeUpdateRequest(String name, Track track, Integer term,
+                                                  String content, String imageUrl) {
+        ReviewUpdateRequest req = new ReviewUpdateRequest();
+        ReflectionTestUtils.setField(req, "name", name);
+        ReflectionTestUtils.setField(req, "track", track);
+        ReflectionTestUtils.setField(req, "term", term);
+        ReflectionTestUtils.setField(req, "content", content);
+        ReflectionTestUtils.setField(req, "imageUrl", imageUrl);
+        return req;
+    }
+
+    // ══════════════════════════════════════════════
+    // REV-001: 후기 조회
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("후기 조회 end-to-end (REV-001)")
+    class GetReviews {
+
+        @Test
+        @DisplayName("TC-001 파라미터 없음 → term 내림차순 전체 반환")
+        void allReviews() {
+            saveReview(Track.ANALYSIS, 24);
+            saveReview(Track.ENGINEERING, 26);
+            saveReview(Track.VISUALIZATION, 25);
+
+            List<ReviewResponse> result = reviewService.getReviews(null, null);
+
+            assertThat(result).hasSize(3);
+            assertThat(result.get(0).getTerm()).isEqualTo(26);
+            assertThat(result.get(1).getTerm()).isEqualTo(25);
+            assertThat(result.get(2).getTerm()).isEqualTo(24);
+        }
+
+        @Test
+        @DisplayName("TC-002 track=ANALYSIS 필터 → 해당 트랙만 반환")
+        void byTrack() {
+            saveReview(Track.ANALYSIS, 26);
+            saveReview(Track.ENGINEERING, 26);
+
+            List<ReviewResponse> result = reviewService.getReviews(Track.ANALYSIS, null);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getTrack()).isEqualTo("ANALYSIS");
+        }
+
+        @Test
+        @DisplayName("TC-003 term=26 필터 → 26기만 반환")
+        void byTerm() {
+            saveReview(Track.ANALYSIS, 26);
+            saveReview(Track.ENGINEERING, 26);
+            saveReview(Track.ANALYSIS, 25);
+
+            List<ReviewResponse> result = reviewService.getReviews(null, 26);
+
+            assertThat(result).hasSize(2);
+            assertThat(result).noneMatch(r -> r.getTerm() != 26);
+        }
+
+        @Test
+        @DisplayName("TC-004 track+term 동시 필터 → 교집합 반환")
+        void byTrackAndTerm() {
+            saveReview(Track.ANALYSIS, 26);
+            saveReview(Track.ENGINEERING, 26);
+            saveReview(Track.ANALYSIS, 25);
+
+            List<ReviewResponse> result = reviewService.getReviews(Track.ANALYSIS, 26);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getTrack()).isEqualTo("ANALYSIS");
+            assertThat(result.get(0).getTerm()).isEqualTo(26);
+        }
+
+        @Test
+        @DisplayName("TC-005 track=ALL → INVALID_TRACK_SELECTION")
+        void trackAll() {
+            assertThatThrownBy(() -> reviewService.getReviews(Track.ALL, null))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.INVALID_TRACK_SELECTION);
+        }
+
+        @Test
+        @DisplayName("TC-006 결과 없을 때 → 빈 배열")
+        void emptyResult() {
+            List<ReviewResponse> result = reviewService.getReviews(null, 99);
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // REV-002: 후기 등록
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("후기 등록 end-to-end (REV-002)")
+    class CreateReview {
+
+        @Test
+        @DisplayName("TC-007 후기 등록 성공 → DB에 저장됨")
+        void success() {
+            ReviewResponse res = reviewService.createReview(makeCreateRequest(Track.ANALYSIS, 26));
+
+            assertThat(res.getTrack()).isEqualTo("ANALYSIS");
+            assertThat(reviewRepository.count()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("TC-008 track=ALL → INVALID_TRACK_SELECTION, DB 미저장")
+        void trackAll() {
+            assertThatThrownBy(() -> reviewService.createReview(makeCreateRequest(Track.ALL, 26)))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.INVALID_TRACK_SELECTION);
+
+            assertThat(reviewRepository.count()).isZero();
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // REV-003: 후기 수정
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("후기 수정 end-to-end (REV-003)")
+    class UpdateReview {
+
+        @Test
+        @DisplayName("TC-009 content만 부분 수정 → 나머지 필드 기존 값 유지")
+        void partialUpdate() {
+            Review saved = saveReview(Track.ANALYSIS, 26);
+
+            ReviewResponse res = reviewService.updateReview(saved.getId(),
+                    makeUpdateRequest(null, null, null, "수정된 후기", null));
+
+            assertThat(res.getContent()).isEqualTo("수정된 후기");
+            assertThat(res.getName()).isEqualTo("홍길동");
+            assertThat(res.getTrack()).isEqualTo("ANALYSIS");
+            assertThat(res.getTerm()).isEqualTo(26);
+        }
+
+        @Test
+        @DisplayName("TC-010 존재하지 않는 reviewId → REVIEW_NOT_FOUND")
+        void notFound() {
+            assertThatThrownBy(() -> reviewService.updateReview(999L,
+                    makeUpdateRequest(null, null, null, "수정", null)))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.REVIEW_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("TC-011 track=ALL로 수정 시도 → INVALID_TRACK_SELECTION")
+        void trackAll() {
+            Review saved = saveReview(Track.ANALYSIS, 26);
+
+            assertThatThrownBy(() -> reviewService.updateReview(saved.getId(),
+                    makeUpdateRequest(null, Track.ALL, null, null, null)))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.INVALID_TRACK_SELECTION);
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // REV-004: 후기 삭제
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("후기 삭제 end-to-end (REV-004)")
+    class DeleteReview {
+
+        @Test
+        @DisplayName("TC-012 삭제 성공 → DB에서 제거됨")
+        void success() {
+            Review saved = saveReview(Track.ANALYSIS, 26);
+
+            reviewService.deleteReview(saved.getId());
+
+            assertThat(reviewRepository.findById(saved.getId())).isEmpty();
+        }
+
+        @Test
+        @DisplayName("TC-013 존재하지 않는 reviewId → REVIEW_NOT_FOUND")
+        void notFound() {
+            assertThatThrownBy(() -> reviewService.deleteReview(999L))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.REVIEW_NOT_FOUND);
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // 생명주기 통합 시나리오
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("후기 전체 생명주기 시나리오")
+    class Lifecycle {
+
+        @Test
+        @DisplayName("등록 → 필터 조회 → 수정 → 삭제 흐름이 DB와 일치")
+        void fullLifecycle() {
+            ReviewResponse created = reviewService.createReview(
+                    makeCreateRequest(Track.ENGINEERING, 26));
+            assertThat(reviewRepository.count()).isEqualTo(1);
+
+            List<ReviewResponse> list = reviewService.getReviews(Track.ENGINEERING, 26);
+            assertThat(list).hasSize(1);
+            assertThat(list.get(0).getContent()).isEqualTo("좋은 경험이었습니다.");
+
+            ReviewResponse updated = reviewService.updateReview(created.getId(),
+                    makeUpdateRequest(null, null, null, "수정된 후기", null));
+            assertThat(updated.getContent()).isEqualTo("수정된 후기");
+            assertThat(updated.getTrack()).isEqualTo("ENGINEERING");
+
+            reviewService.deleteReview(created.getId());
+            assertThat(reviewRepository.findById(created.getId())).isEmpty();
+            assertThat(reviewService.getReviews(Track.ENGINEERING, 26)).isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/boaz/backend/domain/review/service/ReviewServiceTest.java
@@ -1,0 +1,272 @@
+package com.boaz.backend.domain.review.service;
+
+import com.boaz.backend.domain.review.dto.request.ReviewCreateRequest;
+import com.boaz.backend.domain.review.dto.request.ReviewUpdateRequest;
+import com.boaz.backend.domain.review.dto.response.ReviewResponse;
+import com.boaz.backend.domain.review.entity.Review;
+import com.boaz.backend.domain.review.repository.ReviewRepository;
+import com.boaz.backend.global.common.enums.Track;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewServiceTest {
+
+    @InjectMocks ReviewService reviewService;
+    @Mock ReviewRepository reviewRepository;
+
+    // ──────────────────────────────────────────────
+    // 헬퍼
+    // ──────────────────────────────────────────────
+
+    private Review makeReview(Long id, Track track, int term) {
+        Review r = Review.create("홍길동", track, term, "후기 내용", null);
+        ReflectionTestUtils.setField(r, "id", id);
+        return r;
+    }
+
+    private ReviewCreateRequest makeCreateRequest(Track track) {
+        ReviewCreateRequest req = new ReviewCreateRequest();
+        ReflectionTestUtils.setField(req, "name", "홍길동");
+        ReflectionTestUtils.setField(req, "track", track);
+        ReflectionTestUtils.setField(req, "term", 26);
+        ReflectionTestUtils.setField(req, "content", "좋은 경험이었습니다.");
+        ReflectionTestUtils.setField(req, "imageUrl", null);
+        return req;
+    }
+
+    private ReviewUpdateRequest makeUpdateRequest(String name, Track track, Integer term,
+                                                  String content, String imageUrl) {
+        ReviewUpdateRequest req = new ReviewUpdateRequest();
+        ReflectionTestUtils.setField(req, "name", name);
+        ReflectionTestUtils.setField(req, "track", track);
+        ReflectionTestUtils.setField(req, "term", term);
+        ReflectionTestUtils.setField(req, "content", content);
+        ReflectionTestUtils.setField(req, "imageUrl", imageUrl);
+        return req;
+    }
+
+    // ══════════════════════════════════════════════
+    // REV-001: 후기 조회
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("REV-001 후기 조회")
+    class GetReviews {
+
+        @Test
+        @DisplayName("TC-001 파라미터 없음 → 전체 term 내림차순 반환")
+        void allReviews() {
+            Review r1 = makeReview(1L, Track.ENGINEERING, 26);
+            Review r2 = makeReview(2L, Track.ANALYSIS, 25);
+            when(reviewRepository.findAllByOrderByTermDesc()).thenReturn(List.of(r1, r2));
+
+            List<ReviewResponse> result = reviewService.getReviews(null, null);
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).getTerm()).isEqualTo(26);
+            assertThat(result.get(1).getTerm()).isEqualTo(25);
+        }
+
+        @Test
+        @DisplayName("TC-002 track=ANALYSIS 필터 → 해당 트랙만 반환")
+        void byTrack() {
+            when(reviewRepository.findAllByTrackOrderByTermDesc(Track.ANALYSIS))
+                    .thenReturn(List.of(makeReview(1L, Track.ANALYSIS, 26)));
+
+            List<ReviewResponse> result = reviewService.getReviews(Track.ANALYSIS, null);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getTrack()).isEqualTo("ANALYSIS");
+        }
+
+        @Test
+        @DisplayName("TC-003 term=26 필터 → 26기만 반환")
+        void byTerm() {
+            when(reviewRepository.findAllByTermOrderByTermDesc(26))
+                    .thenReturn(List.of(
+                            makeReview(1L, Track.ANALYSIS, 26),
+                            makeReview(2L, Track.ENGINEERING, 26)
+                    ));
+
+            List<ReviewResponse> result = reviewService.getReviews(null, 26);
+
+            assertThat(result).hasSize(2);
+            assertThat(result).extracting(r -> r.getTerm()).containsOnly(26);
+        }
+
+        @Test
+        @DisplayName("TC-004 track+term 동시 필터 → 교집합 반환")
+        void byTrackAndTerm() {
+            when(reviewRepository.findAllByTrackAndTermOrderByTermDesc(Track.ANALYSIS, 26))
+                    .thenReturn(List.of(makeReview(1L, Track.ANALYSIS, 26)));
+
+            List<ReviewResponse> result = reviewService.getReviews(Track.ANALYSIS, 26);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getTrack()).isEqualTo("ANALYSIS");
+            assertThat(result.get(0).getTerm()).isEqualTo(26);
+        }
+
+        @Test
+        @DisplayName("TC-005 track=ALL → INVALID_TRACK_SELECTION")
+        void trackAll() {
+            assertThatThrownBy(() -> reviewService.getReviews(Track.ALL, null))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_TRACK_SELECTION);
+        }
+
+        @Test
+        @DisplayName("TC-006 조회 결과 없을 때 → 빈 배열 반환")
+        void emptyResult() {
+            when(reviewRepository.findAllByTermOrderByTermDesc(99)).thenReturn(List.of());
+
+            List<ReviewResponse> result = reviewService.getReviews(null, 99);
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // REV-002: 후기 등록
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("REV-002 후기 등록")
+    class CreateReview {
+
+        @Test
+        @DisplayName("TC-007 후기 등록 성공 → 저장 후 응답 반환")
+        void success() {
+            when(reviewRepository.save(any())).thenAnswer(inv -> {
+                Review r = inv.getArgument(0);
+                ReflectionTestUtils.setField(r, "id", 1L);
+                return r;
+            });
+
+            ReviewResponse res = reviewService.createReview(makeCreateRequest(Track.ANALYSIS));
+
+            assertThat(res.getTrack()).isEqualTo("ANALYSIS");
+            assertThat(res.getTerm()).isEqualTo(26);
+            verify(reviewRepository).save(any(Review.class));
+        }
+
+        @Test
+        @DisplayName("TC-008 track=ALL → INVALID_TRACK_SELECTION, 저장 안 함")
+        void trackAll() {
+            assertThatThrownBy(() -> reviewService.createReview(makeCreateRequest(Track.ALL)))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_TRACK_SELECTION);
+
+            verify(reviewRepository, never()).save(any());
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // REV-003: 후기 수정
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("REV-003 후기 수정")
+    class UpdateReview {
+
+        @Test
+        @DisplayName("TC-009 content만 부분 수정 → name·track·term·imageUrl 기존 값 유지")
+        void partialUpdate() {
+            Review review = makeReview(1L, Track.ANALYSIS, 26);
+            when(reviewRepository.findById(1L)).thenReturn(Optional.of(review));
+
+            ReviewResponse res = reviewService.updateReview(1L,
+                    makeUpdateRequest(null, null, null, "수정된 후기", null));
+
+            assertThat(res.getContent()).isEqualTo("수정된 후기");
+            assertThat(res.getName()).isEqualTo("홍길동");
+            assertThat(res.getTrack()).isEqualTo("ANALYSIS");
+            assertThat(res.getTerm()).isEqualTo(26);
+        }
+
+        @Test
+        @DisplayName("TC-010 존재하지 않는 reviewId → REVIEW_NOT_FOUND")
+        void notFound() {
+            when(reviewRepository.findById(999L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> reviewService.updateReview(999L,
+                    makeUpdateRequest(null, null, null, "수정", null)))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.REVIEW_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("TC-011 track=ALL로 수정 시도 → INVALID_TRACK_SELECTION")
+        void trackAll() {
+            Review review = makeReview(1L, Track.ANALYSIS, 26);
+            when(reviewRepository.findById(1L)).thenReturn(Optional.of(review));
+
+            assertThatThrownBy(() -> reviewService.updateReview(1L,
+                    makeUpdateRequest(null, Track.ALL, null, null, null)))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_TRACK_SELECTION);
+        }
+
+        @Test
+        @DisplayName("track=null로 수정 시 validateNotAll 미호출 → 기존 track 유지")
+        void trackNullNoValidation() {
+            Review review = makeReview(1L, Track.ANALYSIS, 26);
+            when(reviewRepository.findById(1L)).thenReturn(Optional.of(review));
+
+            ReviewResponse res = reviewService.updateReview(1L,
+                    makeUpdateRequest(null, null, null, null, null));
+
+            assertThat(res.getTrack()).isEqualTo("ANALYSIS");
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // REV-004: 후기 삭제
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("REV-004 후기 삭제")
+    class DeleteReview {
+
+        @Test
+        @DisplayName("TC-012 삭제 성공 → repository.delete 호출")
+        void success() {
+            Review review = makeReview(1L, Track.ANALYSIS, 26);
+            when(reviewRepository.findById(1L)).thenReturn(Optional.of(review));
+
+            reviewService.deleteReview(1L);
+
+            verify(reviewRepository).delete(review);
+        }
+
+        @Test
+        @DisplayName("TC-013 존재하지 않는 reviewId → REVIEW_NOT_FOUND, 삭제 안 함")
+        void notFound() {
+            when(reviewRepository.findById(999L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> reviewService.deleteReview(999L))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.REVIEW_NOT_FOUND);
+
+            verify(reviewRepository, never()).delete(any());
+        }
+    }
+}


### PR DESCRIPTION
## 💡 개요

* Issue Number: #149

## 🪐 주요 변경 사항
- Review 도메인 전체 API 테스트 코드 작성 (Service / Controller / Integration)

## ✅ 상세 내용
- [Unit] `ReviewServiceTest`: getReviews, createReview, updateReview, deleteReview 서비스 레이어 단위 테스트 (13 cases)
  - track=ALL 입력 시 INVALID_TRACK_SELECTION 예외 확인 (조회/등록/수정 모두)
  - track=null PATCH 시 validateNotAll 미호출, 기존 track 유지 확인
  - track·term 필터 조합 4가지 (없음 / track만 / term만 / track+term) 동작 확인
  - 존재하지 않는 reviewId 수정/삭제 시 REVIEW_NOT_FOUND 예외 확인
- [Unit] `ReviewControllerTest`: GET /api/v1/reviews 공개 API 슬라이스 테스트 (8 cases)
  - image_url snake_case 필드명 확인
- [Unit] `ReviewAdminControllerTest`: POST, PATCH, DELETE /api/v1/admin/reviews 슬라이스 테스트 (9 cases)
  - 미인증 요청 401 확인
  - 필수 필드 누락 시 400 확인
- [Integration] `ReviewIntegrationTest`: 실제 DB 기반 통합 테스트 (13 cases)
  - 전체 생명주기 (등록 → 필터 조회 → 수정 → 삭제) 시나리오 포함

## 🔔 참고 사항
- 통합 테스트는 Testcontainers(MySQL) 기반이며 Docker 환경에서 실행 필요
- 연관 명세서: REV-001 ~ REV-004