### PR TITLE
#148 test: FAQ 도메인 테스트 코드 작성

### DIFF
--- a/src/test/java/com/boaz/backend/domain/faq/controller/FaqAdminControllerTest.java
+++ b/src/test/java/com/boaz/backend/domain/faq/controller/FaqAdminControllerTest.java
@@ -1,0 +1,232 @@
+package com.boaz.backend.domain.faq.controller;
+
+import com.boaz.backend.domain.faq.dto.response.FaqResponse;
+import com.boaz.backend.domain.faq.entity.Faq;
+import com.boaz.backend.domain.faq.service.FaqService;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import com.boaz.backend.support.TestSecurityConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@WebMvcTest(
+        value = FaqAdminController.class,
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class}
+)
+@Import(TestSecurityConfig.class)
+class FaqAdminControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @MockitoBean FaqService faqService;
+
+    private UsernamePasswordAuthenticationToken adminAuth() {
+        return new UsernamePasswordAuthenticationToken(
+                "admin", null,
+                List.of(new SimpleGrantedAuthority("ROLE_SUPER")));
+    }
+
+    private FaqResponse makeFaqResponse(Long id, Faq.Category category, int orderNum) {
+        Faq faq = Faq.create("질문", "답변", category, orderNum);
+        ReflectionTestUtils.setField(faq, "id", id);
+        return FaqResponse.from(faq);
+    }
+
+    private String createBody(String question, String answer, String category, int orderNum) {
+        return objectMapper.createObjectNode()
+                .put("question", question)
+                .put("answer", answer)
+                .put("category", category)
+                .put("order_num", orderNum)
+                .toString();
+    }
+
+    // ──────────────────────────────────────────────
+    // FAQ-002: POST /api/v1/admin/faqs
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("FAQ-002 POST /api/v1/admin/faqs")
+    class CreateFaq {
+
+        @Test
+        @DisplayName("TC-003 FAQ 등록 성공 → 201 Created")
+        void success() throws Exception {
+            when(faqService.createFaq(any())).thenReturn(makeFaqResponse(1L, Faq.Category.RECRUITMENT, 1));
+
+            mockMvc.perform(post("/api/v1/admin/faqs")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(createBody("지원 방법?", "홈페이지를 통해 지원", "RECRUITMENT", 1)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.status").value(201))
+                    .andExpect(jsonPath("$.data.order_num").value(1))
+                    .andExpect(jsonPath("$.data.category").value("RECRUITMENT"));
+        }
+
+        @Test
+        @DisplayName("TC-004 동일 카테고리 내 orderNum 중복 → 409 DUPLICATE_ORDER_NUM")
+        void duplicateOrderNum() throws Exception {
+            when(faqService.createFaq(any()))
+                    .thenThrow(new CustomException(ErrorCode.DUPLICATE_ORDER_NUM));
+
+            mockMvc.perform(post("/api/v1/admin/faqs")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(createBody("다른 질문", "다른 답변", "RECRUITMENT", 1)))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.error_code").value("DUPLICATE_ORDER_NUM"));
+        }
+
+        @Test
+        @DisplayName("필수 필드 누락 (question 없음) → 400 INVALID_INPUT_VALUE")
+        void missingRequiredField() throws Exception {
+            String body = objectMapper.createObjectNode()
+                    .put("answer", "답변")
+                    .put("category", "RECRUITMENT")
+                    .put("order_num", 1)
+                    .toString();
+
+            mockMvc.perform(post("/api/v1/admin/faqs")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("[Security] 미인증 요청 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(post("/api/v1/admin/faqs")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(createBody("질문", "답변", "RECRUITMENT", 1)))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // FAQ-003: PATCH /api/v1/admin/faqs/{faqId}
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("FAQ-003 PATCH /api/v1/admin/faqs/{faqId}")
+    class UpdateFaq {
+
+        @Test
+        @DisplayName("TC-005 부분 수정 성공 → 200 OK")
+        void success() throws Exception {
+            when(faqService.updateFaq(eq(1L), any())).thenReturn(makeFaqResponse(1L, Faq.Category.RECRUITMENT, 1));
+
+            String body = objectMapper.createObjectNode()
+                    .put("question", "변경된 질문")
+                    .toString();
+
+            mockMvc.perform(patch("/api/v1/admin/faqs/1")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200));
+        }
+
+        @Test
+        @DisplayName("TC-007 존재하지 않는 faqId → 404 FAQ_NOT_FOUND")
+        void notFound() throws Exception {
+            when(faqService.updateFaq(eq(999L), any()))
+                    .thenThrow(new CustomException(ErrorCode.FAQ_NOT_FOUND));
+
+            mockMvc.perform(patch("/api/v1/admin/faqs/999")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{}"))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.error_code").value("FAQ_NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("TC-008 수정 후 orderNum 충돌 → 409 DUPLICATE_ORDER_NUM")
+        void duplicateOnUpdate() throws Exception {
+            when(faqService.updateFaq(eq(2L), any()))
+                    .thenThrow(new CustomException(ErrorCode.DUPLICATE_ORDER_NUM));
+
+            String body = objectMapper.createObjectNode()
+                    .put("order_num", 1)
+                    .toString();
+
+            mockMvc.perform(patch("/api/v1/admin/faqs/2")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.error_code").value("DUPLICATE_ORDER_NUM"));
+        }
+
+        @Test
+        @DisplayName("[Security] 미인증 요청 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(patch("/api/v1/admin/faqs/1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{}"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // FAQ-004: DELETE /api/v1/admin/faqs/{faqId}
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("FAQ-004 DELETE /api/v1/admin/faqs/{faqId}")
+    class DeleteFaq {
+
+        @Test
+        @DisplayName("TC-009 FAQ 삭제 성공 → 200 OK")
+        void success() throws Exception {
+            mockMvc.perform(delete("/api/v1/admin/faqs/1")
+                            .with(authentication(adminAuth())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200));
+        }
+
+        @Test
+        @DisplayName("TC-010 존재하지 않는 faqId → 404 FAQ_NOT_FOUND")
+        void notFound() throws Exception {
+            org.mockito.Mockito.doThrow(new CustomException(ErrorCode.FAQ_NOT_FOUND))
+                    .when(faqService).deleteFaq(999L);
+
+            mockMvc.perform(delete("/api/v1/admin/faqs/999")
+                            .with(authentication(adminAuth())))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.error_code").value("FAQ_NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("[Security] 미인증 요청 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(delete("/api/v1/admin/faqs/1"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/faq/controller/FaqControllerTest.java
+++ b/src/test/java/com/boaz/backend/domain/faq/controller/FaqControllerTest.java
@@ -1,0 +1,109 @@
+package com.boaz.backend.domain.faq.controller;
+
+import com.boaz.backend.domain.faq.dto.response.FaqResponse;
+import com.boaz.backend.domain.faq.entity.Faq;
+import com.boaz.backend.domain.faq.service.FaqService;
+import com.boaz.backend.support.TestSecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@WebMvcTest(
+        value = FaqController.class,
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class}
+)
+@Import(TestSecurityConfig.class)
+class FaqControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @MockitoBean FaqService faqService;
+
+    private FaqResponse makeFaqResponse(Long id, Faq.Category category, int orderNum) {
+        Faq faq = Faq.create("질문 " + id, "답변 " + id, category, orderNum);
+        ReflectionTestUtils.setField(faq, "id", id);
+        return FaqResponse.from(faq);
+    }
+
+    // ──────────────────────────────────────────────
+    // FAQ-001: GET /api/v1/archiving/faqs
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("FAQ-001 GET /api/v1/archiving/faqs")
+    class GetFaqs {
+
+        @Test
+        @DisplayName("TC-001 정상 조회 → 200 + orderNum 오름차순 목록")
+        void success() throws Exception {
+            when(faqService.getFaqs(Faq.Category.RECRUITMENT))
+                    .thenReturn(List.of(
+                            makeFaqResponse(1L, Faq.Category.RECRUITMENT, 1),
+                            makeFaqResponse(2L, Faq.Category.RECRUITMENT, 2)
+                    ));
+
+            mockMvc.perform(get("/api/v1/archiving/faqs")
+                            .param("category", "RECRUITMENT"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data.length()").value(2))
+                    .andExpect(jsonPath("$.data[0].order_num").value(1))
+                    .andExpect(jsonPath("$.data[1].order_num").value(2))
+                    .andExpect(jsonPath("$.data[0].category").value("RECRUITMENT"));
+        }
+
+        @Test
+        @DisplayName("TC-002 해당 카테고리 데이터 없을 때 → 200 + 빈 배열")
+        void emptyResult() throws Exception {
+            when(faqService.getFaqs(Faq.Category.ETC)).thenReturn(List.of());
+
+            mockMvc.perform(get("/api/v1/archiving/faqs")
+                            .param("category", "ETC"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data.length()").value(0));
+        }
+
+        @Test
+        @DisplayName("[Security] 인증 없이 접근 가능 (공개 API)")
+        void publicApi() throws Exception {
+            when(faqService.getFaqs(any())).thenReturn(List.of());
+
+            mockMvc.perform(get("/api/v1/archiving/faqs")
+                            .param("category", "ACTIVITY"))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("category 파라미터 누락 → 400")
+        void missingCategory() throws Exception {
+            mockMvc.perform(get("/api/v1/archiving/faqs"))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 category 값 입력 → 400")
+        void invalidCategory() throws Exception {
+            mockMvc.perform(get("/api/v1/archiving/faqs")
+                            .param("category", "INVALID"))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/faq/integration/FaqIntegrationTest.java
+++ b/src/test/java/com/boaz/backend/domain/faq/integration/FaqIntegrationTest.java
@@ -1,0 +1,247 @@
+package com.boaz.backend.domain.faq.integration;
+
+import com.boaz.backend.domain.faq.dto.request.FaqCreateRequest;
+import com.boaz.backend.domain.faq.dto.request.FaqUpdateRequest;
+import com.boaz.backend.domain.faq.dto.response.FaqResponse;
+import com.boaz.backend.domain.faq.entity.Faq;
+import com.boaz.backend.domain.faq.repository.FaqRepository;
+import com.boaz.backend.domain.faq.service.FaqService;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import com.boaz.backend.support.TestcontainersBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class FaqIntegrationTest extends TestcontainersBase {
+
+    @Autowired FaqService faqService;
+    @Autowired FaqRepository faqRepository;
+
+    // ──────────────────────────────────────────────
+    // 헬퍼
+    // ──────────────────────────────────────────────
+
+    private Faq saveFaq(Faq.Category category, int orderNum) {
+        return faqRepository.save(Faq.create("질문 " + orderNum, "답변 " + orderNum, category, orderNum));
+    }
+
+    private FaqCreateRequest makeCreateRequest(String question, String answer,
+                                               Faq.Category category, int orderNum) {
+        FaqCreateRequest req = new FaqCreateRequest();
+        ReflectionTestUtils.setField(req, "question", question);
+        ReflectionTestUtils.setField(req, "answer", answer);
+        ReflectionTestUtils.setField(req, "category", category);
+        ReflectionTestUtils.setField(req, "orderNum", orderNum);
+        return req;
+    }
+
+    private FaqUpdateRequest makeUpdateRequest(String question, String answer,
+                                               Faq.Category category, Integer orderNum) {
+        FaqUpdateRequest req = new FaqUpdateRequest();
+        ReflectionTestUtils.setField(req, "question", question);
+        ReflectionTestUtils.setField(req, "answer", answer);
+        ReflectionTestUtils.setField(req, "category", category);
+        ReflectionTestUtils.setField(req, "orderNum", orderNum);
+        return req;
+    }
+
+    // ══════════════════════════════════════════════
+    // FAQ-001: FAQ 목록 조회
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("FAQ 목록 조회 end-to-end (FAQ-001)")
+    class GetFaqs {
+
+        @Test
+        @DisplayName("TC-001 RECRUITMENT 카테고리 → orderNum 오름차순 반환, 타 카테고리 미포함")
+        void orderedByOrderNum() {
+            saveFaq(Faq.Category.RECRUITMENT, 2);
+            saveFaq(Faq.Category.RECRUITMENT, 1);
+            saveFaq(Faq.Category.ACTIVITY, 1);  // 다른 카테고리
+
+            List<FaqResponse> result = faqService.getFaqs(Faq.Category.RECRUITMENT);
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).getOrderNum()).isEqualTo(1);
+            assertThat(result.get(1).getOrderNum()).isEqualTo(2);
+            assertThat(result).noneMatch(r -> r.getCategory().equals("ACTIVITY"));
+        }
+
+        @Test
+        @DisplayName("TC-002 해당 카테고리 데이터 없을 때 → 빈 배열 반환")
+        void emptyCategory() {
+            List<FaqResponse> result = faqService.getFaqs(Faq.Category.ETC);
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // FAQ-002: FAQ 등록
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("FAQ 등록 end-to-end (FAQ-002)")
+    class CreateFaq {
+
+        @Test
+        @DisplayName("TC-003 FAQ 등록 성공 → DB에 저장됨")
+        void success() {
+            FaqResponse res = faqService.createFaq(
+                    makeCreateRequest("지원 방법?", "홈페이지를 통해 지원", Faq.Category.RECRUITMENT, 1));
+
+            assertThat(res.getOrderNum()).isEqualTo(1);
+            assertThat(faqRepository.existsByCategoryAndOrderNum(Faq.Category.RECRUITMENT, 1)).isTrue();
+        }
+
+        @Test
+        @DisplayName("TC-004 동일 카테고리 내 orderNum 중복 → DUPLICATE_ORDER_NUM, DB 미저장")
+        void duplicateOrderNum() {
+            saveFaq(Faq.Category.RECRUITMENT, 1);
+
+            assertThatThrownBy(() -> faqService.createFaq(
+                    makeCreateRequest("다른 질문", "다른 답변", Faq.Category.RECRUITMENT, 1)))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.DUPLICATE_ORDER_NUM);
+
+            assertThat(faqRepository.findAllByCategoryOrderByOrderNumAsc(Faq.Category.RECRUITMENT)).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("다른 카테고리에 동일 orderNum 있어도 → 등록 성공")
+        void differentCategorySameOrderNum() {
+            saveFaq(Faq.Category.ACTIVITY, 1);
+
+            FaqResponse res = faqService.createFaq(
+                    makeCreateRequest("질문", "답변", Faq.Category.RECRUITMENT, 1));
+
+            assertThat(res).isNotNull();
+            assertThat(faqRepository.count()).isEqualTo(2);
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // FAQ-003: FAQ 수정
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("FAQ 수정 end-to-end (FAQ-003)")
+    class UpdateFaq {
+
+        @Test
+        @DisplayName("TC-005 question만 부분 수정 → answer·orderNum 기존 값 유지")
+        void partialUpdate() {
+            Faq saved = saveFaq(Faq.Category.RECRUITMENT, 1);
+
+            FaqResponse res = faqService.updateFaq(saved.getId(),
+                    makeUpdateRequest("변경된 질문", null, null, null));
+
+            assertThat(res.getQuestion()).isEqualTo("변경된 질문");
+            assertThat(res.getAnswer()).isEqualTo("답변 1");
+            assertThat(res.getOrderNum()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("TC-006 자기 자신의 orderNum으로 수정 → 중복 에러 미발생")
+        void selfOrderNum() {
+            Faq saved = saveFaq(Faq.Category.RECRUITMENT, 1);
+
+            FaqResponse res = faqService.updateFaq(saved.getId(),
+                    makeUpdateRequest(null, null, null, 1));
+
+            assertThat(res.getOrderNum()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("TC-007 존재하지 않는 faqId → FAQ_NOT_FOUND")
+        void notFound() {
+            assertThatThrownBy(() -> faqService.updateFaq(999L,
+                    makeUpdateRequest("수정", null, null, null)))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.FAQ_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("TC-008 수정 후 동일 카테고리 내 orderNum 충돌 → DUPLICATE_ORDER_NUM")
+        void duplicateOnUpdate() {
+            saveFaq(Faq.Category.RECRUITMENT, 1);
+            Faq target = saveFaq(Faq.Category.RECRUITMENT, 2);
+
+            assertThatThrownBy(() -> faqService.updateFaq(target.getId(),
+                    makeUpdateRequest(null, null, null, 1)))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.DUPLICATE_ORDER_NUM);
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // FAQ-004: FAQ 삭제
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("FAQ 삭제 end-to-end (FAQ-004)")
+    class DeleteFaq {
+
+        @Test
+        @DisplayName("TC-009 FAQ 삭제 성공 → DB에서 제거됨")
+        void success() {
+            Faq saved = saveFaq(Faq.Category.RECRUITMENT, 1);
+
+            faqService.deleteFaq(saved.getId());
+
+            assertThat(faqRepository.findById(saved.getId())).isEmpty();
+        }
+
+        @Test
+        @DisplayName("TC-010 존재하지 않는 faqId → FAQ_NOT_FOUND")
+        void notFound() {
+            assertThatThrownBy(() -> faqService.deleteFaq(999L))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.FAQ_NOT_FOUND);
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // 생명주기 통합 시나리오
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("FAQ 전체 생명주기 시나리오")
+    class Lifecycle {
+
+        @Test
+        @DisplayName("등록 → 조회 → 수정 → 삭제 흐름이 DB와 일치")
+        void fullLifecycle() {
+            // 등록
+            FaqResponse created = faqService.createFaq(
+                    makeCreateRequest("최초 질문", "최초 답변", Faq.Category.ACTIVITY, 1));
+            assertThat(faqRepository.count()).isEqualTo(1);
+
+            // 조회
+            List<FaqResponse> list = faqService.getFaqs(Faq.Category.ACTIVITY);
+            assertThat(list).hasSize(1);
+            assertThat(list.get(0).getQuestion()).isEqualTo("최초 질문");
+
+            // 수정
+            FaqResponse updated = faqService.updateFaq(created.getId(),
+                    makeUpdateRequest("수정된 질문", null, null, null));
+            assertThat(updated.getQuestion()).isEqualTo("수정된 질문");
+            assertThat(updated.getAnswer()).isEqualTo("최초 답변");  // 기존 값 유지
+
+            // 삭제
+            faqService.deleteFaq(created.getId());
+            assertThat(faqRepository.findById(created.getId())).isEmpty();
+            assertThat(faqService.getFaqs(Faq.Category.ACTIVITY)).isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/faq/service/FaqServiceTest.java
+++ b/src/test/java/com/boaz/backend/domain/faq/service/FaqServiceTest.java
@@ -1,0 +1,242 @@
+package com.boaz.backend.domain.faq.service;
+
+import com.boaz.backend.domain.faq.dto.request.FaqCreateRequest;
+import com.boaz.backend.domain.faq.dto.request.FaqUpdateRequest;
+import com.boaz.backend.domain.faq.dto.response.FaqResponse;
+import com.boaz.backend.domain.faq.entity.Faq;
+import com.boaz.backend.domain.faq.repository.FaqRepository;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FaqServiceTest {
+
+    @InjectMocks FaqService faqService;
+    @Mock FaqRepository faqRepository;
+
+    // ──────────────────────────────────────────────
+    // 헬퍼
+    // ──────────────────────────────────────────────
+
+    private Faq makeFaq(Long id, Faq.Category category, int orderNum) {
+        Faq faq = Faq.create("질문 " + id, "답변 " + id, category, orderNum);
+        ReflectionTestUtils.setField(faq, "id", id);
+        return faq;
+    }
+
+    private FaqCreateRequest makeCreateRequest(Faq.Category category, int orderNum) {
+        FaqCreateRequest req = new FaqCreateRequest();
+        ReflectionTestUtils.setField(req, "question", "테스트 질문");
+        ReflectionTestUtils.setField(req, "answer", "테스트 답변");
+        ReflectionTestUtils.setField(req, "category", category);
+        ReflectionTestUtils.setField(req, "orderNum", orderNum);
+        return req;
+    }
+
+    private FaqUpdateRequest makeUpdateRequest(String question, String answer,
+                                               Faq.Category category, Integer orderNum) {
+        FaqUpdateRequest req = new FaqUpdateRequest();
+        ReflectionTestUtils.setField(req, "question", question);
+        ReflectionTestUtils.setField(req, "answer", answer);
+        ReflectionTestUtils.setField(req, "category", category);
+        ReflectionTestUtils.setField(req, "orderNum", orderNum);
+        return req;
+    }
+
+    // ══════════════════════════════════════════════
+    // FAQ-001: FAQ 목록 조회
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("FAQ-001 FAQ 목록 조회")
+    class GetFaqs {
+
+        @Test
+        @DisplayName("TC-001 특정 카테고리 조회 → orderNum 오름차순 반환")
+        void success() {
+            Faq f1 = makeFaq(1L, Faq.Category.RECRUITMENT, 1);
+            Faq f2 = makeFaq(2L, Faq.Category.RECRUITMENT, 2);
+            when(faqRepository.findAllByCategoryOrderByOrderNumAsc(Faq.Category.RECRUITMENT))
+                    .thenReturn(List.of(f1, f2));
+
+            List<FaqResponse> result = faqService.getFaqs(Faq.Category.RECRUITMENT);
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).getOrderNum()).isEqualTo(1);
+            assertThat(result.get(1).getOrderNum()).isEqualTo(2);
+            assertThat(result).extracting(FaqResponse::getCategory).containsOnly("RECRUITMENT");
+        }
+
+        @Test
+        @DisplayName("TC-002 해당 카테고리 데이터 없을 때 → 빈 배열 반환 (예외 없음)")
+        void emptyCategory() {
+            when(faqRepository.findAllByCategoryOrderByOrderNumAsc(Faq.Category.ETC))
+                    .thenReturn(List.of());
+
+            List<FaqResponse> result = faqService.getFaqs(Faq.Category.ETC);
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // FAQ-002: FAQ 등록
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("FAQ-002 FAQ 등록")
+    class CreateFaq {
+
+        @Test
+        @DisplayName("TC-003 FAQ 등록 성공 → 저장 후 응답 반환")
+        void success() {
+            when(faqRepository.existsByCategoryAndOrderNum(Faq.Category.RECRUITMENT, 1)).thenReturn(false);
+            when(faqRepository.save(any())).thenAnswer(inv -> {
+                Faq f = inv.getArgument(0);
+                ReflectionTestUtils.setField(f, "id", 1L);
+                return f;
+            });
+
+            FaqResponse res = faqService.createFaq(makeCreateRequest(Faq.Category.RECRUITMENT, 1));
+
+            assertThat(res.getOrderNum()).isEqualTo(1);
+            assertThat(res.getCategory()).isEqualTo("RECRUITMENT");
+            verify(faqRepository).save(any(Faq.class));
+        }
+
+        @Test
+        @DisplayName("TC-004 동일 카테고리 내 orderNum 중복 → DUPLICATE_ORDER_NUM, 저장 안 함")
+        void duplicateOrderNum() {
+            when(faqRepository.existsByCategoryAndOrderNum(Faq.Category.RECRUITMENT, 1)).thenReturn(true);
+
+            assertThatThrownBy(() -> faqService.createFaq(makeCreateRequest(Faq.Category.RECRUITMENT, 1)))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.DUPLICATE_ORDER_NUM);
+
+            verify(faqRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("다른 카테고리에 동일 orderNum 있어도 → RECRUITMENT 등록 성공")
+        void differentCategorySameOrderNum() {
+            when(faqRepository.existsByCategoryAndOrderNum(Faq.Category.RECRUITMENT, 1)).thenReturn(false);
+            when(faqRepository.save(any())).thenAnswer(inv -> {
+                Faq f = inv.getArgument(0);
+                ReflectionTestUtils.setField(f, "id", 2L);
+                return f;
+            });
+
+            FaqResponse res = faqService.createFaq(makeCreateRequest(Faq.Category.RECRUITMENT, 1));
+
+            assertThat(res).isNotNull();
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // FAQ-003: FAQ 수정
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("FAQ-003 FAQ 수정")
+    class UpdateFaq {
+
+        @Test
+        @DisplayName("TC-005 question만 부분 수정 → answer·category·orderNum 기존 값 유지")
+        void partialUpdateQuestion() {
+            Faq faq = makeFaq(1L, Faq.Category.RECRUITMENT, 1);
+            when(faqRepository.findById(1L)).thenReturn(Optional.of(faq));
+            when(faqRepository.existsByCategoryAndOrderNumAndIdNot(Faq.Category.RECRUITMENT, 1, 1L))
+                    .thenReturn(false);
+
+            FaqResponse res = faqService.updateFaq(1L, makeUpdateRequest("변경된 질문", null, null, null));
+
+            assertThat(res.getQuestion()).isEqualTo("변경된 질문");
+            assertThat(res.getAnswer()).isEqualTo("답변 1");
+            assertThat(res.getOrderNum()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("TC-006 자기 자신의 orderNum으로 수정 → 중복 에러 미발생")
+        void selfOrderNum() {
+            Faq faq = makeFaq(1L, Faq.Category.RECRUITMENT, 1);
+            when(faqRepository.findById(1L)).thenReturn(Optional.of(faq));
+            when(faqRepository.existsByCategoryAndOrderNumAndIdNot(Faq.Category.RECRUITMENT, 1, 1L))
+                    .thenReturn(false);
+
+            FaqResponse res = faqService.updateFaq(1L, makeUpdateRequest(null, null, null, 1));
+
+            assertThat(res.getOrderNum()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("TC-007 존재하지 않는 faqId → FAQ_NOT_FOUND")
+        void notFound() {
+            when(faqRepository.findById(999L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> faqService.updateFaq(999L, makeUpdateRequest("수정", null, null, null)))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.FAQ_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("TC-008 수정 후 동일 카테고리 내 orderNum 충돌 → DUPLICATE_ORDER_NUM")
+        void duplicateOnUpdate() {
+            Faq faq = makeFaq(2L, Faq.Category.RECRUITMENT, 2);
+            when(faqRepository.findById(2L)).thenReturn(Optional.of(faq));
+            when(faqRepository.existsByCategoryAndOrderNumAndIdNot(Faq.Category.RECRUITMENT, 1, 2L))
+                    .thenReturn(true);
+
+            assertThatThrownBy(() -> faqService.updateFaq(2L, makeUpdateRequest(null, null, null, 1)))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.DUPLICATE_ORDER_NUM);
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // FAQ-004: FAQ 삭제
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("FAQ-004 FAQ 삭제")
+    class DeleteFaq {
+
+        @Test
+        @DisplayName("TC-009 FAQ 삭제 성공 → repository.delete 호출")
+        void success() {
+            Faq faq = makeFaq(1L, Faq.Category.RECRUITMENT, 1);
+            when(faqRepository.findById(1L)).thenReturn(Optional.of(faq));
+
+            faqService.deleteFaq(1L);
+
+            verify(faqRepository).delete(faq);
+        }
+
+        @Test
+        @DisplayName("TC-010 존재하지 않는 faqId → FAQ_NOT_FOUND, 삭제 미호출")
+        void notFound() {
+            when(faqRepository.findById(999L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> faqService.deleteFaq(999L))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.FAQ_NOT_FOUND);
+
+            verify(faqRepository, never()).delete(any());
+        }
+    }
+}


### PR DESCRIPTION
## 💡 개요

* Issue Number: #148

## 🪐 주요 변경 사항
- FAQ 도메인 전체 API 테스트 코드 작성 (Service / Controller / Integration)

## ✅ 상세 내용
- [Unit] `FaqServiceTest`: getFaqs, createFaq, updateFaq, deleteFaq 서비스 레이어 단위 테스트 (11 cases)
  - 동일 카테고리 내 orderNum 중복 시 DUPLICATE_ORDER_NUM 예외 확인
  - 수정 시 자기 자신의 orderNum은 중복 체크 제외 확인 (existsByCategoryAndOrderNumAndIdNot)
  - 존재하지 않는 faqId 수정/삭제 시 FAQ_NOT_FOUND 예외 확인
  - 타 카테고리 동일 orderNum 존재 시 정상 등록 확인
- [Unit] `FaqControllerTest`: GET /api/v1/archiving/faqs 공개 API 슬라이스 테스트 (5 cases)
  - category 파라미터 누락/유효하지 않은 값 입력 시 400 확인
- [Unit] `FaqAdminControllerTest`: POST, PATCH, DELETE /api/v1/admin/faqs 슬라이스 테스트 (9 cases)
  - 미인증 요청 401 확인
  - 필수 필드 누락 시 400 확인
- [Integration] `FaqIntegrationTest`: 실제 DB 기반 통합 테스트 (12 cases)
  - 전체 생명주기 (등록 → 조회 → 수정 → 삭제) 시나리오 포함

## 🔔 참고 사항
- 통합 테스트는 Testcontainers(MySQL) 기반이며 Docker 환경에서 실행 필요
- 연관 명세서: FAQ-001 ~ FAQ-004