### PR TITLE
[Test] 아카이빙 도메인 테스트 코드 작성

### DIFF
--- a/src/test/java/com/boaz/backend/domain/archive/controller/ArchiveControllerTest.java
+++ b/src/test/java/com/boaz/backend/domain/archive/controller/ArchiveControllerTest.java
@@ -1,0 +1,130 @@
+package com.boaz.backend.domain.archive.controller;
+
+import com.boaz.backend.domain.archive.dto.response.ArchivePageResponse;
+import com.boaz.backend.domain.archive.dto.response.ArchiveTermsResponse;
+import com.boaz.backend.domain.archive.service.ArchiveService;
+import com.boaz.backend.support.TestSecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ActiveProfiles("test")
+@WebMvcTest(
+        value = ArchiveController.class,
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class}
+)
+@Import(TestSecurityConfig.class)
+class ArchiveControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @MockitoBean ArchiveService archiveService;
+
+    private ArchivePageResponse mockPageResponse(int currentPage, long totalSize) {
+        return ArchivePageResponse.builder()
+                .currentPage(currentPage).totalPages(1).size(6)
+                .currentSize((int) totalSize).totalSize(totalSize)
+                .hasPrevious(false).hasNext(false).posts(List.of())
+                .build();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ARC-001 GET /api/v1/archiving/projects
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("ARC-001 GET /api/v1/archiving/projects")
+    class GetProjects {
+
+        @Test
+        @DisplayName("TC-012 인증 없이 기본 파라미터 → 200 OK")
+        void getProjects_200() throws Exception {
+            when(archiveService.searchArchives(any(), any(), any(), any(), anyInt(), anyInt()))
+                    .thenReturn(mockPageResponse(1, 3));
+
+            mockMvc.perform(get("/api/v1/archiving/projects"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.current_page").value(1))
+                    .andExpect(jsonPath("$.data.total_size").value(3));
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ARC-002 GET /api/v1/archiving/activities
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("ARC-002 GET /api/v1/archiving/activities")
+    class GetActivities {
+
+        @Test
+        @DisplayName("TC-011 인증 없이 기본 파라미터 → 200 OK")
+        void getActivities_200() throws Exception {
+            when(archiveService.searchArchives(any(), any(), any(), any(), anyInt(), anyInt()))
+                    .thenReturn(mockPageResponse(1, 3));
+
+            mockMvc.perform(get("/api/v1/archiving/activities"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.current_page").value(1))
+                    .andExpect(jsonPath("$.data.total_size").value(3));
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ARC-003 GET /api/v1/archiving/blogs
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("ARC-003 GET /api/v1/archiving/blogs")
+    class GetBlogs {
+
+        @Test
+        @DisplayName("TC-012 인증 없이 기본 파라미터 → 200 OK")
+        void getBlogs_200() throws Exception {
+            when(archiveService.searchArchives(any(), any(), any(), any(), anyInt(), anyInt()))
+                    .thenReturn(mockPageResponse(1, 3));
+
+            mockMvc.perform(get("/api/v1/archiving/blogs"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.current_page").value(1))
+                    .andExpect(jsonPath("$.data.total_size").value(3));
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ARC-004 GET /api/v1/archiving/terms
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("ARC-004 GET /api/v1/archiving/terms")
+    class GetTerms {
+
+        @Test
+        @DisplayName("TC-005 인증 없이 조회 → 200 OK + value/label 검증")
+        void getTerms_200() throws Exception {
+            when(archiveService.getTerms())
+                    .thenReturn(ArchiveTermsResponse.from(List.of(26, 0)));
+
+            mockMvc.perform(get("/api/v1/archiving/terms"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.terms[0].value").value(26))
+                    .andExpect(jsonPath("$.data.terms[0].label").value("26기"))
+                    .andExpect(jsonPath("$.data.terms[1].value").value(0))
+                    .andExpect(jsonPath("$.data.terms[1].label").value("7기 이전"));
+        }
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/archive/integration/ArchiveIntegrationTest.java
+++ b/src/test/java/com/boaz/backend/domain/archive/integration/ArchiveIntegrationTest.java
@@ -1,0 +1,575 @@
+package com.boaz.backend.domain.archive.integration;
+
+import com.boaz.backend.domain.archive.dto.response.ArchivePageResponse;
+import com.boaz.backend.domain.archive.dto.response.ArchiveTermsResponse;
+import com.boaz.backend.domain.archive.entity.Archive;
+import com.boaz.backend.domain.archive.entity.Archive.Category;
+import com.boaz.backend.domain.archive.repository.ArchiveRepository;
+import com.boaz.backend.domain.archive.service.ArchiveService;
+import com.boaz.backend.global.common.enums.Track;
+import com.boaz.backend.support.TestcontainersBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class ArchiveIntegrationTest extends TestcontainersBase {
+
+    @Autowired ArchiveService archiveService;
+    @Autowired ArchiveRepository archiveRepository;
+
+    private Archive save(int term, Category category, String title, Track track, LocalDate contentDate) {
+        return archiveRepository.save(Archive.builder()
+                .term(term).category(category).title(title)
+                .track(track).imageUrl("http://img.example.com/test.jpg")
+                .links("{}").contentDate(contentDate)
+                .build());
+    }
+
+    // ══════════════════════════════════════════════
+    // ARC-001 프로젝트 조회 end-to-end
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("프로젝트 조회 end-to-end (ARC-001)")
+    class ProjectSearch {
+
+        @Nested
+        @DisplayName("[그룹 A] keyword 검색 동작")
+        class KeywordSearch {
+
+            @Test
+            @DisplayName("TC-I-001 keyword 부분 일치 → 제목 중간에 검색어 포함 시 히트")
+            void partial_match() {
+                save(26, Category.PROJECT, "실시간 추천 시스템 구축", Track.ENGINEERING, LocalDate.of(2026, 1, 1));
+                save(26, Category.PROJECT, "이상 탐지 모델 개발", Track.ANALYSIS, LocalDate.of(2026, 1, 2));
+
+                ArchivePageResponse response = archiveService.searchArchives(
+                        Category.PROJECT, Track.ALL, null, "추천", 1, 10);
+
+                assertThat(response.getTotalSize()).isEqualTo(1);
+                assertThat(response.getPosts().get(0).getTitle()).isEqualTo("실시간 추천 시스템 구축");
+            }
+
+            @Test
+            @DisplayName("TC-I-002 keyword 대소문자 무시 → 영문 대소문자 관계 없이 히트")
+            void case_insensitive() {
+                save(26, Category.PROJECT, "BOAZ Project", Track.ENGINEERING, LocalDate.of(2026, 1, 1));
+                save(26, Category.PROJECT, "이상 탐지", Track.ANALYSIS, LocalDate.of(2026, 1, 2));
+
+                ArchivePageResponse response = archiveService.searchArchives(
+                        Category.PROJECT, Track.ALL, null, "boaz", 1, 10);
+
+                assertThat(response.getTotalSize()).isEqualTo(1);
+                assertThat(response.getPosts().get(0).getTitle()).isEqualTo("BOAZ Project");
+            }
+
+            @Test
+            @DisplayName("TC-I-003 keyword 공백 무시 → 검색어의 공백 제거 후 매칭")
+            void space_insensitive() {
+                save(26, Category.PROJECT, "딥러닝프로젝트", Track.ENGINEERING, LocalDate.of(2026, 1, 1));
+                save(26, Category.PROJECT, "이상탐지", Track.ANALYSIS, LocalDate.of(2026, 1, 2));
+
+                ArchivePageResponse response = archiveService.searchArchives(
+                        Category.PROJECT, Track.ALL, null, "딥 러 닝", 1, 10);
+
+                assertThat(response.getTotalSize()).isEqualTo(1);
+                assertThat(response.getPosts().get(0).getTitle()).isEqualTo("딥러닝프로젝트");
+            }
+
+            @Test
+            @DisplayName("TC-I-004 keyword=\"\" → LIKE '%%' → 전체 반환")
+            void empty_string_returns_all() {
+                save(26, Category.PROJECT, "프로젝트A", Track.ENGINEERING, LocalDate.of(2026, 1, 1));
+                save(26, Category.PROJECT, "프로젝트B", Track.ANALYSIS, LocalDate.of(2026, 1, 2));
+                save(26, Category.PROJECT, "프로젝트C", Track.VISUALIZATION, LocalDate.of(2026, 1, 3));
+
+                ArchivePageResponse response = archiveService.searchArchives(
+                        Category.PROJECT, Track.ALL, null, "", 1, 10);
+
+                assertThat(response.getTotalSize()).isEqualTo(3);
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 B] 정렬")
+        class Sorting {
+
+            @Test
+            @DisplayName("TC-I-005 contentDate=null → 맨 뒤 정렬")
+            void null_date_last() {
+                save(26, Category.PROJECT, "A", Track.ENGINEERING, LocalDate.of(2026, 1, 1));
+                save(26, Category.PROJECT, "B", Track.ENGINEERING, null);
+                save(26, Category.PROJECT, "C", Track.ENGINEERING, LocalDate.of(2026, 3, 1));
+
+                ArchivePageResponse response = archiveService.searchArchives(
+                        Category.PROJECT, Track.ALL, null, null, 1, 10);
+
+                List<String> titles = response.getPosts().stream()
+                        .map(p -> p.getTitle()).toList();
+                assertThat(titles).containsExactly("C", "A", "B");
+            }
+
+            @Test
+            @DisplayName("TC-I-006 contentDate 최신순 DESC 정렬")
+            void date_desc() {
+                save(26, Category.PROJECT, "A", Track.ENGINEERING, LocalDate.of(2025, 5, 1));
+                save(26, Category.PROJECT, "B", Track.ENGINEERING, LocalDate.of(2026, 3, 1));
+                save(26, Category.PROJECT, "C", Track.ENGINEERING, LocalDate.of(2024, 1, 1));
+
+                ArchivePageResponse response = archiveService.searchArchives(
+                        Category.PROJECT, Track.ALL, null, null, 1, 10);
+
+                List<String> titles = response.getPosts().stream()
+                        .map(p -> p.getTitle()).toList();
+                assertThat(titles).containsExactly("B", "A", "C");
+            }
+
+            @Test
+            @DisplayName("TC-I-007 contentDate 동일할 경우, title ASC tie-break")
+            void same_date_title_asc() {
+                LocalDate sameDate = LocalDate.of(2026, 1, 1);
+                save(26, Category.PROJECT, "나다라", Track.ENGINEERING, sameDate);
+                save(26, Category.PROJECT, "가나다", Track.ENGINEERING, sameDate);
+                save(26, Category.PROJECT, "다라마", Track.ENGINEERING, sameDate);
+
+                ArchivePageResponse response = archiveService.searchArchives(
+                        Category.PROJECT, Track.ALL, null, null, 1, 10);
+
+                List<String> titles = response.getPosts().stream()
+                        .map(p -> p.getTitle()).toList();
+                assertThat(titles).containsExactly("가나다", "나다라", "다라마");
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 C] 필터 후 totalSize")
+        class FilterTotalSize {
+
+            @Test
+            @DisplayName("TC-I-008 track 필터 적용 시 totalSize = 필터된 개수")
+            void track_filter_total_size() {
+                save(26, Category.PROJECT, "A", Track.ENGINEERING, LocalDate.of(2026, 1, 1));
+                save(26, Category.PROJECT, "B", Track.ENGINEERING, LocalDate.of(2026, 1, 2));
+                save(26, Category.PROJECT, "C", Track.VISUALIZATION, LocalDate.of(2026, 1, 3));
+
+                ArchivePageResponse response = archiveService.searchArchives(
+                        Category.PROJECT, Track.ENGINEERING, null, null, 1, 10);
+
+                assertThat(response.getTotalSize()).isEqualTo(2);
+                assertThat(response.getPosts()).hasSize(2);
+            }
+
+            @Test
+            @DisplayName("TC-I-009 keyword 필터 적용 시 totalSize = 매칭된 개수")
+            void keyword_filter_total_size() {
+                save(26, Category.PROJECT, "추천 시스템", Track.ENGINEERING, LocalDate.of(2026, 1, 1));
+                save(26, Category.PROJECT, "이상 탐지", Track.ANALYSIS, LocalDate.of(2026, 1, 2));
+                save(26, Category.PROJECT, "추천 알고리즘", Track.ENGINEERING, LocalDate.of(2026, 1, 3));
+
+                ArchivePageResponse response = archiveService.searchArchives(
+                        Category.PROJECT, Track.ALL, null, "추천", 1, 10);
+
+                assertThat(response.getTotalSize()).isEqualTo(2);
+                assertThat(response.getPosts()).hasSize(2);
+            }
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // ARC-002 활동사진 조회 end-to-end
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("활동사진 조회 end-to-end (ARC-002)")
+    class ActivitySearch {
+
+        @Nested
+        @DisplayName("[그룹 A] keyword 검색 동작")
+        class KeywordSearch {
+
+            @Test
+            @DisplayName("TC-I-001 keyword 부분 일치 → 제목 중간에 검색어 포함 시 히트")
+            void partial_match() {
+                save(26, Category.ACTIVITY, "26기 워크샵 활동", Track.ALL, LocalDate.of(2026, 1, 1));
+                save(26, Category.ACTIVITY, "MT 후기", Track.ALL, LocalDate.of(2026, 1, 2));
+
+                ArchivePageResponse response = archiveService.searchArchives(
+                        Category.ACTIVITY, null, null, "워크샵", 1, 10);
+
+                assertThat(response.getTotalSize()).isEqualTo(1);
+                assertThat(response.getPosts().get(0).getTitle()).isEqualTo("26기 워크샵 활동");
+            }
+
+            @Test
+            @DisplayName("TC-I-002 keyword 대소문자 무시 → 영문 대소문자 관계 없이 히트")
+            void case_insensitive() {
+                save(26, Category.ACTIVITY, "BOAZ MT 2025", Track.ALL, LocalDate.of(2026, 1, 1));
+                save(26, Category.ACTIVITY, "워크샵", Track.ALL, LocalDate.of(2026, 1, 2));
+
+                ArchivePageResponse response = archiveService.searchArchives(
+                        Category.ACTIVITY, null, null, "boaz", 1, 10);
+
+                assertThat(response.getTotalSize()).isEqualTo(1);
+                assertThat(response.getPosts().get(0).getTitle()).isEqualTo("BOAZ MT 2025");
+            }
+
+            @Test
+            @DisplayName("TC-I-003 keyword 공백 무시 → 검색어의 공백 제거 후 매칭")
+            void space_insensitive() {
+                save(26, Category.ACTIVITY, "종강파티활동", Track.ALL, LocalDate.of(2026, 1, 1));
+                save(26, Category.ACTIVITY, "MT후기", Track.ALL, LocalDate.of(2026, 1, 2));
+
+                ArchivePageResponse response = archiveService.searchArchives(
+                        Category.ACTIVITY, null, null, "종강 파티", 1, 10);
+
+                assertThat(response.getTotalSize()).isEqualTo(1);
+                assertThat(response.getPosts().get(0).getTitle()).isEqualTo("종강파티활동");
+            }
+
+            @Test
+            @DisplayName("TC-I-004 keyword=\"\" → LIKE '%%' → 전체 반환")
+            void empty_string_returns_all() {
+                save(26, Category.ACTIVITY, "활동A", Track.ALL, LocalDate.of(2026, 1, 1));
+                save(26, Category.ACTIVITY, "활동B", Track.ALL, LocalDate.of(2026, 1, 2));
+                save(26, Category.ACTIVITY, "활동C", Track.ALL, LocalDate.of(2026, 1, 3));
+
+                ArchivePageResponse response = archiveService.searchArchives(
+                        Category.ACTIVITY, null, null, "", 1, 10);
+
+                assertThat(response.getTotalSize()).isEqualTo(3);
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 B] 정렬")
+        class Sorting {
+
+            @Test
+            @DisplayName("TC-I-005 contentDate=null → 맨 뒤 정렬")
+            void null_date_last() {
+                save(26, Category.ACTIVITY, "A", Track.ALL, LocalDate.of(2026, 1, 1));
+                save(26, Category.ACTIVITY, "B", Track.ALL, null);
+                save(26, Category.ACTIVITY, "C", Track.ALL, LocalDate.of(2026, 3, 1));
+
+                ArchivePageResponse response = archiveService.searchArchives(
+                        Category.ACTIVITY, null, null, null, 1, 10);
+
+                List<String> titles = response.getPosts().stream()
+                        .map(p -> p.getTitle()).toList();
+                assertThat(titles).containsExactly("C", "A", "B");
+            }
+
+            @Test
+            @DisplayName("TC-I-006 contentDate 최신순 DESC 정렬")
+            void date_desc() {
+                save(26, Category.ACTIVITY, "A", Track.ALL, LocalDate.of(2025, 5, 1));
+                save(26, Category.ACTIVITY, "B", Track.ALL, LocalDate.of(2026, 3, 1));
+                save(26, Category.ACTIVITY, "C", Track.ALL, LocalDate.of(2024, 1, 1));
+
+                ArchivePageResponse response = archiveService.searchArchives(
+                        Category.ACTIVITY, null, null, null, 1, 10);
+
+                List<String> titles = response.getPosts().stream()
+                        .map(p -> p.getTitle()).toList();
+                assertThat(titles).containsExactly("B", "A", "C");
+            }
+
+            @Test
+            @DisplayName("TC-I-007 contentDate 동일할 경우, title ASC tie-break")
+            void same_date_title_asc() {
+                LocalDate sameDate = LocalDate.of(2026, 1, 1);
+                save(26, Category.ACTIVITY, "나다라", Track.ALL, sameDate);
+                save(26, Category.ACTIVITY, "가나다", Track.ALL, sameDate);
+                save(26, Category.ACTIVITY, "다라마", Track.ALL, sameDate);
+
+                ArchivePageResponse response = archiveService.searchArchives(
+                        Category.ACTIVITY, null, null, null, 1, 10);
+
+                List<String> titles = response.getPosts().stream()
+                        .map(p -> p.getTitle()).toList();
+                assertThat(titles).containsExactly("가나다", "나다라", "다라마");
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 C] 필터 후 totalSize")
+        class FilterTotalSize {
+
+            @Test
+            @DisplayName("TC-I-008 term 필터 적용 시 totalSize = 필터된 개수")
+            void term_filter_total_size() {
+                save(25, Category.ACTIVITY, "A", Track.ALL, LocalDate.of(2025, 1, 1));
+                save(25, Category.ACTIVITY, "B", Track.ALL, LocalDate.of(2025, 1, 2));
+                save(26, Category.ACTIVITY, "C", Track.ALL, LocalDate.of(2026, 1, 1));
+
+                ArchivePageResponse response = archiveService.searchArchives(
+                        Category.ACTIVITY, null, 25, null, 1, 10);
+
+                assertThat(response.getTotalSize()).isEqualTo(2);
+                assertThat(response.getPosts()).hasSize(2);
+            }
+
+            @Test
+            @DisplayName("TC-I-009 keyword 필터 적용 시 totalSize = 매칭된 개수")
+            void keyword_filter_total_size() {
+                save(26, Category.ACTIVITY, "워크샵 후기", Track.ALL, LocalDate.of(2026, 1, 1));
+                save(26, Category.ACTIVITY, "MT 일정", Track.ALL, LocalDate.of(2026, 1, 2));
+                save(26, Category.ACTIVITY, "종강 파티 워크샵", Track.ALL, LocalDate.of(2026, 1, 3));
+
+                ArchivePageResponse response = archiveService.searchArchives(
+                        Category.ACTIVITY, null, null, "워크샵", 1, 10);
+
+                assertThat(response.getTotalSize()).isEqualTo(2);
+                assertThat(response.getPosts()).hasSize(2);
+            }
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // ARC-003 기술블로그 조회 end-to-end
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("기술블로그 조회 end-to-end (ARC-003)")
+    class BlogSearch {
+
+        @Nested
+        @DisplayName("[그룹 A] keyword 검색 동작")
+        class KeywordSearch {
+
+            @Test
+            @DisplayName("TC-I-001 keyword 부분 일치 → 제목 중간에 검색어 포함 시 히트")
+            void partial_match() {
+                save(26, Category.BLOG, "Transformer 모델 구현기", Track.ENGINEERING, LocalDate.of(2026, 1, 1));
+                save(26, Category.BLOG, "데이터 전처리 가이드", Track.ANALYSIS, LocalDate.of(2026, 1, 2));
+
+                ArchivePageResponse response = archiveService.searchArchives(
+                        Category.BLOG, Track.ALL, null, "구현기", 1, 10);
+
+                assertThat(response.getTotalSize()).isEqualTo(1);
+                assertThat(response.getPosts().get(0).getTitle()).isEqualTo("Transformer 모델 구현기");
+            }
+
+            @Test
+            @DisplayName("TC-I-002 keyword 대소문자 무시 → 영문 대소문자 관계 없이 히트")
+            void case_insensitive() {
+                save(26, Category.BLOG, "Transformer 분석", Track.ENGINEERING, LocalDate.of(2026, 1, 1));
+                save(26, Category.BLOG, "데이터 전처리", Track.ANALYSIS, LocalDate.of(2026, 1, 2));
+
+                ArchivePageResponse response = archiveService.searchArchives(
+                        Category.BLOG, Track.ALL, null, "transformer", 1, 10);
+
+                assertThat(response.getTotalSize()).isEqualTo(1);
+                assertThat(response.getPosts().get(0).getTitle()).isEqualTo("Transformer 분석");
+            }
+
+            @Test
+            @DisplayName("TC-I-003 keyword 공백 무시 → 검색어의 공백 제거 후 매칭")
+            void space_insensitive() {
+                save(26, Category.BLOG, "딥러닝모델최적화", Track.ENGINEERING, LocalDate.of(2026, 1, 1));
+                save(26, Category.BLOG, "데이터전처리", Track.ANALYSIS, LocalDate.of(2026, 1, 2));
+
+                ArchivePageResponse response = archiveService.searchArchives(
+                        Category.BLOG, Track.ALL, null, "딥 러 닝", 1, 10);
+
+                assertThat(response.getTotalSize()).isEqualTo(1);
+                assertThat(response.getPosts().get(0).getTitle()).isEqualTo("딥러닝모델최적화");
+            }
+
+            @Test
+            @DisplayName("TC-I-004 keyword=\"\" → LIKE '%%' → 전체 반환")
+            void empty_string_returns_all() {
+                save(26, Category.BLOG, "블로그A", Track.ENGINEERING, LocalDate.of(2026, 1, 1));
+                save(26, Category.BLOG, "블로그B", Track.ANALYSIS, LocalDate.of(2026, 1, 2));
+                save(26, Category.BLOG, "블로그C", Track.VISUALIZATION, LocalDate.of(2026, 1, 3));
+
+                ArchivePageResponse response = archiveService.searchArchives(
+                        Category.BLOG, Track.ALL, null, "", 1, 10);
+
+                assertThat(response.getTotalSize()).isEqualTo(3);
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 B] 정렬")
+        class Sorting {
+
+            @Test
+            @DisplayName("TC-I-005 contentDate=null → 맨 뒤 정렬")
+            void null_date_last() {
+                save(26, Category.BLOG, "A", Track.ENGINEERING, LocalDate.of(2026, 1, 1));
+                save(26, Category.BLOG, "B", Track.ENGINEERING, null);
+                save(26, Category.BLOG, "C", Track.ENGINEERING, LocalDate.of(2026, 3, 1));
+
+                ArchivePageResponse response = archiveService.searchArchives(
+                        Category.BLOG, Track.ALL, null, null, 1, 10);
+
+                List<String> titles = response.getPosts().stream()
+                        .map(p -> p.getTitle()).toList();
+                assertThat(titles).containsExactly("C", "A", "B");
+            }
+
+            @Test
+            @DisplayName("TC-I-006 contentDate 최신순 DESC 정렬")
+            void date_desc() {
+                save(26, Category.BLOG, "A", Track.ENGINEERING, LocalDate.of(2025, 5, 1));
+                save(26, Category.BLOG, "B", Track.ENGINEERING, LocalDate.of(2026, 3, 1));
+                save(26, Category.BLOG, "C", Track.ENGINEERING, LocalDate.of(2024, 1, 1));
+
+                ArchivePageResponse response = archiveService.searchArchives(
+                        Category.BLOG, Track.ALL, null, null, 1, 10);
+
+                List<String> titles = response.getPosts().stream()
+                        .map(p -> p.getTitle()).toList();
+                assertThat(titles).containsExactly("B", "A", "C");
+            }
+
+            @Test
+            @DisplayName("TC-I-007 contentDate 동일할 경우, title ASC tie-break")
+            void same_date_title_asc() {
+                LocalDate sameDate = LocalDate.of(2026, 1, 1);
+                save(26, Category.BLOG, "나다라", Track.ENGINEERING, sameDate);
+                save(26, Category.BLOG, "가나다", Track.ENGINEERING, sameDate);
+                save(26, Category.BLOG, "다라마", Track.ENGINEERING, sameDate);
+
+                ArchivePageResponse response = archiveService.searchArchives(
+                        Category.BLOG, Track.ALL, null, null, 1, 10);
+
+                List<String> titles = response.getPosts().stream()
+                        .map(p -> p.getTitle()).toList();
+                assertThat(titles).containsExactly("가나다", "나다라", "다라마");
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 C] 필터 후 totalSize")
+        class FilterTotalSize {
+
+            @Test
+            @DisplayName("TC-I-008 track 필터 적용 시 totalSize = 필터된 개수")
+            void track_filter_total_size() {
+                save(26, Category.BLOG, "A", Track.ENGINEERING, LocalDate.of(2026, 1, 1));
+                save(26, Category.BLOG, "B", Track.ENGINEERING, LocalDate.of(2026, 1, 2));
+                save(26, Category.BLOG, "C", Track.VISUALIZATION, LocalDate.of(2026, 1, 3));
+
+                ArchivePageResponse response = archiveService.searchArchives(
+                        Category.BLOG, Track.ENGINEERING, null, null, 1, 10);
+
+                assertThat(response.getTotalSize()).isEqualTo(2);
+                assertThat(response.getPosts()).hasSize(2);
+            }
+
+            @Test
+            @DisplayName("TC-I-009 keyword 필터 적용 시 totalSize = 매칭된 개수")
+            void keyword_filter_total_size() {
+                save(26, Category.BLOG, "Transformer 구현기", Track.ENGINEERING, LocalDate.of(2026, 1, 1));
+                save(26, Category.BLOG, "데이터 전처리", Track.ANALYSIS, LocalDate.of(2026, 1, 2));
+                save(26, Category.BLOG, "Transformer 최적화", Track.ENGINEERING, LocalDate.of(2026, 1, 3));
+
+                ArchivePageResponse response = archiveService.searchArchives(
+                        Category.BLOG, Track.ALL, null, "Transformer", 1, 10);
+
+                assertThat(response.getTotalSize()).isEqualTo(2);
+                assertThat(response.getPosts()).hasSize(2);
+            }
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // ARC-004 기수 조회 end-to-end
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("기수 조회 end-to-end (ARC-004)")
+    class GetTerms {
+
+        @Nested
+        @DisplayName("[그룹 A] DISTINCT")
+        class Distinct {
+
+            @Test
+            @DisplayName("TC-I-001 같은 term인 데이터가 여러 개인 경우, 한 번만 반환")
+            void dedup_same_term() {
+                save(26, Category.BLOG, "A", Track.ENGINEERING, LocalDate.of(2026, 1, 1));
+                save(26, Category.BLOG, "B", Track.ENGINEERING, LocalDate.of(2026, 1, 2));
+                save(25, Category.BLOG, "C", Track.ENGINEERING, LocalDate.of(2025, 1, 1));
+
+                ArchiveTermsResponse response = archiveService.getTerms();
+
+                assertThat(response.terms()).hasSize(2);
+                assertThat(response.terms().get(0).value()).isEqualTo(26);
+                assertThat(response.terms().get(1).value()).isEqualTo(25);
+            }
+
+            @Test
+            @DisplayName("TC-I-002 여러 category에 같은 term이 있는 경우, 한 번만 반환")
+            void dedup_across_categories() {
+                save(26, Category.PROJECT, "A", Track.ENGINEERING, LocalDate.of(2026, 1, 1));
+                save(26, Category.ACTIVITY, "B", Track.ALL, LocalDate.of(2026, 1, 1));
+                save(26, Category.BLOG, "C", Track.ENGINEERING, LocalDate.of(2026, 1, 1));
+                save(25, Category.PROJECT, "D", Track.ENGINEERING, LocalDate.of(2025, 1, 1));
+
+                ArchiveTermsResponse response = archiveService.getTerms();
+
+                assertThat(response.terms()).hasSize(2);
+                assertThat(response.terms().get(0).value()).isEqualTo(26);
+                assertThat(response.terms().get(1).value()).isEqualTo(25);
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 B] 정렬")
+        class Sorting {
+
+            @Test
+            @DisplayName("TC-I-003 term DESC 정렬 → 최신 기수 먼저")
+            void term_desc() {
+                save(24, Category.BLOG, "A", Track.ENGINEERING, LocalDate.of(2024, 1, 1));
+                save(26, Category.BLOG, "B", Track.ENGINEERING, LocalDate.of(2026, 1, 1));
+                save(25, Category.BLOG, "C", Track.ENGINEERING, LocalDate.of(2025, 1, 1));
+
+                ArchiveTermsResponse response = archiveService.getTerms();
+
+                assertThat(response.terms().get(0).value()).isEqualTo(26);
+                assertThat(response.terms().get(1).value()).isEqualTo(25);
+                assertThat(response.terms().get(2).value()).isEqualTo(24);
+            }
+
+            @Test
+            @DisplayName("TC-I-004 term=0인 경우, 맨 뒤 정렬")
+            void term_zero_last() {
+                save(26, Category.BLOG, "A", Track.ENGINEERING, LocalDate.of(2026, 1, 1));
+                save(0, Category.BLOG, "B", Track.ENGINEERING, null);
+                save(25, Category.BLOG, "C", Track.ENGINEERING, LocalDate.of(2025, 1, 1));
+
+                ArchiveTermsResponse response = archiveService.getTerms();
+
+                assertThat(response.terms().get(0).value()).isEqualTo(26);
+                assertThat(response.terms().get(1).value()).isEqualTo(25);
+                assertThat(response.terms().get(2).value()).isEqualTo(0);
+                assertThat(response.terms().get(2).label()).isEqualTo("7기 이전");
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 C] 빈 결과")
+        class EmptyResult {
+
+            @Test
+            @DisplayName("TC-I-005 DB가 비어있는 경우, 빈 목록 반환")
+            void empty_db() {
+                ArchiveTermsResponse response = archiveService.getTerms();
+
+                assertThat(response.terms()).isEmpty();
+            }
+        }
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/archive/repository/ArchiveRepositoryTest.java
+++ b/src/test/java/com/boaz/backend/domain/archive/repository/ArchiveRepositoryTest.java
@@ -1,0 +1,631 @@
+package com.boaz.backend.domain.archive.repository;
+
+import com.boaz.backend.domain.archive.entity.Archive;
+import com.boaz.backend.domain.archive.entity.Archive.Category;
+import com.boaz.backend.global.common.enums.Track;
+import com.boaz.backend.global.config.JpaConfig;
+import com.boaz.backend.support.TestcontainersBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(JpaConfig.class)
+@ActiveProfiles("test")
+class ArchiveRepositoryTest extends TestcontainersBase {
+
+    @Autowired ArchiveRepository archiveRepository;
+    @Autowired TestEntityManager em;
+
+    private Archive buildArchive(int term, Category category, String title, Track track, LocalDate contentDate) {
+        return Archive.builder()
+                .term(term).category(category).title(title)
+                .track(track).imageUrl("http://img.example.com/test.jpg")
+                .links("{}").contentDate(contentDate)
+                .build();
+    }
+
+    private void saveAll(Archive... archives) {
+        for (Archive a : archives) {
+            em.persist(a);
+        }
+        em.flush();
+        em.clear();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ARC-001 searchArchives - PROJECT 통합 테스트
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("ARC-001 searchArchives(PROJECT) 통합 테스트")
+    class ProjectSearchIntegration {
+
+        @Nested
+        @DisplayName("[그룹 A] keyword 검색 동작")
+        class KeywordSearch {
+
+            @Test
+            @DisplayName("TC-I-001 keyword 부분 일치 → 제목 중간에 검색어 포함 시 히트")
+            void partial_match() {
+                saveAll(
+                        buildArchive(26, Category.PROJECT, "실시간 추천 시스템 구축", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.PROJECT, "이상 탐지 모델 개발", Track.ANALYSIS, LocalDate.of(2026, 1, 2))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.PROJECT, null, null, "추천", PageRequest.of(0, 10));
+
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getContent().get(0).getTitle()).isEqualTo("실시간 추천 시스템 구축");
+            }
+
+            @Test
+            @DisplayName("TC-I-002 keyword 대소문자 무시 → 영문 대소문자 관계 없이 히트")
+            void case_insensitive() {
+                saveAll(
+                        buildArchive(26, Category.PROJECT, "BOAZ Project", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.PROJECT, "이상 탐지", Track.ANALYSIS, LocalDate.of(2026, 1, 2))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.PROJECT, null, null, "boaz", PageRequest.of(0, 10));
+
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getContent().get(0).getTitle()).isEqualTo("BOAZ Project");
+            }
+
+            @Test
+            @DisplayName("TC-I-003 keyword 공백 무시 → 검색어의 공백 제거 후 매칭")
+            void space_insensitive() {
+                saveAll(
+                        buildArchive(26, Category.PROJECT, "딥러닝프로젝트", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.PROJECT, "이상탐지", Track.ANALYSIS, LocalDate.of(2026, 1, 2))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.PROJECT, null, null, "딥 러 닝", PageRequest.of(0, 10));
+
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getContent().get(0).getTitle()).isEqualTo("딥러닝프로젝트");
+            }
+
+            @Test
+            @DisplayName("TC-I-004 keyword=\"\" → LIKE '%%' → 전체 반환")
+            void empty_string_returns_all() {
+                saveAll(
+                        buildArchive(26, Category.PROJECT, "프로젝트A", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.PROJECT, "프로젝트B", Track.ANALYSIS, LocalDate.of(2026, 1, 2)),
+                        buildArchive(26, Category.PROJECT, "프로젝트C", Track.VISUALIZATION, LocalDate.of(2026, 1, 3))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.PROJECT, null, null, "", PageRequest.of(0, 10));
+
+                assertThat(result.getContent()).hasSize(3);
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 B] 정렬")
+        class Sorting {
+
+            @Test
+            @DisplayName("TC-I-005 contentDate=null → 맨 뒤 정렬")
+            void null_date_last() {
+                Archive a1 = buildArchive(26, Category.PROJECT, "A", Track.ENGINEERING, LocalDate.of(2026, 1, 1));
+                Archive a2 = buildArchive(26, Category.PROJECT, "B", Track.ENGINEERING, null);
+                Archive a3 = buildArchive(26, Category.PROJECT, "C", Track.ENGINEERING, LocalDate.of(2026, 3, 1));
+                em.persist(a1); em.persist(a2); em.persist(a3);
+                em.flush(); em.clear();
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.PROJECT, null, null, null, PageRequest.of(0, 10));
+
+                List<String> titles = result.getContent().stream().map(Archive::getTitle).toList();
+                assertThat(titles).containsExactly("C", "A", "B");
+            }
+
+            @Test
+            @DisplayName("TC-I-006 contentDate DESC 정렬 → 최신순")
+            void date_desc() {
+                Archive a1 = buildArchive(26, Category.PROJECT, "A", Track.ENGINEERING, LocalDate.of(2025, 5, 1));
+                Archive a2 = buildArchive(26, Category.PROJECT, "B", Track.ENGINEERING, LocalDate.of(2026, 3, 1));
+                Archive a3 = buildArchive(26, Category.PROJECT, "C", Track.ENGINEERING, LocalDate.of(2024, 1, 1));
+                em.persist(a1); em.persist(a2); em.persist(a3);
+                em.flush(); em.clear();
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.PROJECT, null, null, null, PageRequest.of(0, 10));
+
+                List<String> titles = result.getContent().stream().map(Archive::getTitle).toList();
+                assertThat(titles).containsExactly("B", "A", "C");
+            }
+
+            @Test
+            @DisplayName("TC-I-007 contentDate 동일 → title ASC tie-break")
+            void same_date_title_asc() {
+                LocalDate sameDate = LocalDate.of(2026, 1, 1);
+                Archive a1 = buildArchive(26, Category.PROJECT, "나다라", Track.ENGINEERING, sameDate);
+                Archive a2 = buildArchive(26, Category.PROJECT, "가나다", Track.ENGINEERING, sameDate);
+                Archive a3 = buildArchive(26, Category.PROJECT, "다라마", Track.ENGINEERING, sameDate);
+                em.persist(a1); em.persist(a2); em.persist(a3);
+                em.flush(); em.clear();
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.PROJECT, null, null, null, PageRequest.of(0, 10));
+
+                List<String> titles = result.getContent().stream().map(Archive::getTitle).toList();
+                assertThat(titles).containsExactly("가나다", "나다라", "다라마");
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 C] 필터 후 totalSize")
+        class FilterTotalSize {
+
+            @Test
+            @DisplayName("TC-I-008 track 필터 적용 시 totalSize = 필터된 개수")
+            void track_filter_total_size() {
+                saveAll(
+                        buildArchive(26, Category.PROJECT, "A", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.PROJECT, "B", Track.ENGINEERING, LocalDate.of(2026, 1, 2)),
+                        buildArchive(26, Category.PROJECT, "C", Track.VISUALIZATION, LocalDate.of(2026, 1, 3))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.PROJECT, Track.ENGINEERING, null, null, PageRequest.of(0, 10));
+
+                assertThat(result.getTotalElements()).isEqualTo(2);
+                assertThat(result.getContent()).hasSize(2);
+            }
+
+            @Test
+            @DisplayName("TC-I-009 keyword 필터 적용 시 totalSize = 매칭된 개수")
+            void keyword_filter_total_size() {
+                saveAll(
+                        buildArchive(26, Category.PROJECT, "추천 시스템", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.PROJECT, "이상 탐지", Track.ANALYSIS, LocalDate.of(2026, 1, 2)),
+                        buildArchive(26, Category.PROJECT, "추천 알고리즘", Track.ENGINEERING, LocalDate.of(2026, 1, 3))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.PROJECT, null, null, "추천", PageRequest.of(0, 10));
+
+                assertThat(result.getTotalElements()).isEqualTo(2);
+                assertThat(result.getContent()).hasSize(2);
+            }
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ARC-002 searchArchives - ACTIVITY 통합 테스트
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("ARC-002 searchArchives(ACTIVITY) 통합 테스트")
+    class ActivitySearchIntegration {
+
+        @Nested
+        @DisplayName("[그룹 A] keyword 검색 동작")
+        class KeywordSearch {
+
+            @Test
+            @DisplayName("TC-I-001 keyword 부분 일치 → 제목 중간에 검색어 포함 시 히트")
+            void partial_match() {
+                saveAll(
+                        buildArchive(26, Category.ACTIVITY, "26기 워크샵 활동", Track.ALL, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.ACTIVITY, "MT 후기", Track.ALL, LocalDate.of(2026, 1, 2))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.ACTIVITY, null, null, "워크샵", PageRequest.of(0, 10));
+
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getContent().get(0).getTitle()).isEqualTo("26기 워크샵 활동");
+            }
+
+            @Test
+            @DisplayName("TC-I-002 keyword 대소문자 무시 → 영문 대소문자 관계 없이 히트")
+            void case_insensitive() {
+                saveAll(
+                        buildArchive(26, Category.ACTIVITY, "BOAZ MT 2025", Track.ALL, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.ACTIVITY, "워크샵", Track.ALL, LocalDate.of(2026, 1, 2))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.ACTIVITY, null, null, "boaz", PageRequest.of(0, 10));
+
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getContent().get(0).getTitle()).isEqualTo("BOAZ MT 2025");
+            }
+
+            @Test
+            @DisplayName("TC-I-003 keyword 공백 무시 → 검색어의 공백 제거 후 매칭")
+            void space_insensitive() {
+                saveAll(
+                        buildArchive(26, Category.ACTIVITY, "종강파티활동", Track.ALL, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.ACTIVITY, "MT후기", Track.ALL, LocalDate.of(2026, 1, 2))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.ACTIVITY, null, null, "종강 파티", PageRequest.of(0, 10));
+
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getContent().get(0).getTitle()).isEqualTo("종강파티활동");
+            }
+
+            @Test
+            @DisplayName("TC-I-004 keyword=\"\" → LIKE '%%' → 전체 반환")
+            void empty_string_returns_all() {
+                saveAll(
+                        buildArchive(26, Category.ACTIVITY, "활동A", Track.ALL, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.ACTIVITY, "활동B", Track.ALL, LocalDate.of(2026, 1, 2)),
+                        buildArchive(26, Category.ACTIVITY, "활동C", Track.ALL, LocalDate.of(2026, 1, 3))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.ACTIVITY, null, null, "", PageRequest.of(0, 10));
+
+                assertThat(result.getContent()).hasSize(3);
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 B] 정렬")
+        class Sorting {
+
+            @Test
+            @DisplayName("TC-I-005 contentDate=null → 맨 뒤 정렬")
+            void null_date_last() {
+                Archive a1 = buildArchive(26, Category.ACTIVITY, "A", Track.ALL, LocalDate.of(2026, 1, 1));
+                Archive a2 = buildArchive(26, Category.ACTIVITY, "B", Track.ALL, null);
+                Archive a3 = buildArchive(26, Category.ACTIVITY, "C", Track.ALL, LocalDate.of(2026, 3, 1));
+                em.persist(a1); em.persist(a2); em.persist(a3);
+                em.flush(); em.clear();
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.ACTIVITY, null, null, null, PageRequest.of(0, 10));
+
+                List<String> titles = result.getContent().stream().map(Archive::getTitle).toList();
+                assertThat(titles).containsExactly("C", "A", "B");
+            }
+
+            @Test
+            @DisplayName("TC-I-006 contentDate DESC 정렬 → 최신순")
+            void date_desc() {
+                Archive a1 = buildArchive(26, Category.ACTIVITY, "A", Track.ALL, LocalDate.of(2025, 5, 1));
+                Archive a2 = buildArchive(26, Category.ACTIVITY, "B", Track.ALL, LocalDate.of(2026, 3, 1));
+                Archive a3 = buildArchive(26, Category.ACTIVITY, "C", Track.ALL, LocalDate.of(2024, 1, 1));
+                em.persist(a1); em.persist(a2); em.persist(a3);
+                em.flush(); em.clear();
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.ACTIVITY, null, null, null, PageRequest.of(0, 10));
+
+                List<String> titles = result.getContent().stream().map(Archive::getTitle).toList();
+                assertThat(titles).containsExactly("B", "A", "C");
+            }
+
+            @Test
+            @DisplayName("TC-I-007 contentDate 동일 → title ASC tie-break")
+            void same_date_title_asc() {
+                LocalDate sameDate = LocalDate.of(2026, 1, 1);
+                Archive a1 = buildArchive(26, Category.ACTIVITY, "나다라", Track.ALL, sameDate);
+                Archive a2 = buildArchive(26, Category.ACTIVITY, "가나다", Track.ALL, sameDate);
+                Archive a3 = buildArchive(26, Category.ACTIVITY, "다라마", Track.ALL, sameDate);
+                em.persist(a1); em.persist(a2); em.persist(a3);
+                em.flush(); em.clear();
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.ACTIVITY, null, null, null, PageRequest.of(0, 10));
+
+                List<String> titles = result.getContent().stream().map(Archive::getTitle).toList();
+                assertThat(titles).containsExactly("가나다", "나다라", "다라마");
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 C] 필터 후 totalSize")
+        class FilterTotalSize {
+
+            @Test
+            @DisplayName("TC-I-008 term 필터 적용 시 totalSize = 필터된 개수")
+            void term_filter_total_size() {
+                saveAll(
+                        buildArchive(25, Category.ACTIVITY, "A", Track.ALL, LocalDate.of(2025, 1, 1)),
+                        buildArchive(25, Category.ACTIVITY, "B", Track.ALL, LocalDate.of(2025, 1, 2)),
+                        buildArchive(26, Category.ACTIVITY, "C", Track.ALL, LocalDate.of(2026, 1, 1))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.ACTIVITY, null, 25, null, PageRequest.of(0, 10));
+
+                assertThat(result.getTotalElements()).isEqualTo(2);
+                assertThat(result.getContent()).hasSize(2);
+            }
+
+            @Test
+            @DisplayName("TC-I-009 keyword 필터 적용 시 totalSize = 매칭된 개수")
+            void keyword_filter_total_size() {
+                saveAll(
+                        buildArchive(26, Category.ACTIVITY, "워크샵 후기", Track.ALL, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.ACTIVITY, "MT 일정", Track.ALL, LocalDate.of(2026, 1, 2)),
+                        buildArchive(26, Category.ACTIVITY, "종강 파티 워크샵", Track.ALL, LocalDate.of(2026, 1, 3))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.ACTIVITY, null, null, "워크샵", PageRequest.of(0, 10));
+
+                assertThat(result.getTotalElements()).isEqualTo(2);
+                assertThat(result.getContent()).hasSize(2);
+            }
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ARC-003 searchArchives - BLOG 통합 테스트
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("ARC-003 searchArchives(BLOG) 통합 테스트")
+    class BlogSearchIntegration {
+
+        @Nested
+        @DisplayName("[그룹 A] keyword 검색 동작")
+        class KeywordSearch {
+
+            @Test
+            @DisplayName("TC-I-001 keyword 부분 일치 → 제목 중간에 검색어 포함 시 히트")
+            void partial_match() {
+                saveAll(
+                        buildArchive(26, Category.BLOG, "Transformer 모델 구현기", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.BLOG, "데이터 전처리 가이드", Track.ANALYSIS, LocalDate.of(2026, 1, 2))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.BLOG, null, null, "구현기", PageRequest.of(0, 10));
+
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getContent().get(0).getTitle()).isEqualTo("Transformer 모델 구현기");
+            }
+
+            @Test
+            @DisplayName("TC-I-002 keyword 대소문자 무시 → 영문 대소문자 관계 없이 히트")
+            void case_insensitive() {
+                saveAll(
+                        buildArchive(26, Category.BLOG, "Transformer 분석", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.BLOG, "데이터 전처리", Track.ANALYSIS, LocalDate.of(2026, 1, 2))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.BLOG, null, null, "transformer", PageRequest.of(0, 10));
+
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getContent().get(0).getTitle()).isEqualTo("Transformer 분석");
+            }
+
+            @Test
+            @DisplayName("TC-I-003 keyword 공백 무시 → 검색어의 공백 제거 후 매칭")
+            void space_insensitive() {
+                saveAll(
+                        buildArchive(26, Category.BLOG, "딥러닝모델최적화", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.BLOG, "데이터전처리", Track.ANALYSIS, LocalDate.of(2026, 1, 2))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.BLOG, null, null, "딥 러 닝", PageRequest.of(0, 10));
+
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getContent().get(0).getTitle()).isEqualTo("딥러닝모델최적화");
+            }
+
+            @Test
+            @DisplayName("TC-I-004 keyword=\"\" → LIKE '%%' → 전체 반환")
+            void empty_string_returns_all() {
+                saveAll(
+                        buildArchive(26, Category.BLOG, "블로그A", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.BLOG, "블로그B", Track.ANALYSIS, LocalDate.of(2026, 1, 2)),
+                        buildArchive(26, Category.BLOG, "블로그C", Track.VISUALIZATION, LocalDate.of(2026, 1, 3))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.BLOG, null, null, "", PageRequest.of(0, 10));
+
+                assertThat(result.getContent()).hasSize(3);
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 B] 정렬")
+        class Sorting {
+
+            @Test
+            @DisplayName("TC-I-005 contentDate=null → 맨 뒤 정렬")
+            void null_date_last() {
+                Archive a1 = buildArchive(26, Category.BLOG, "A", Track.ENGINEERING, LocalDate.of(2026, 1, 1));
+                Archive a2 = buildArchive(26, Category.BLOG, "B", Track.ENGINEERING, null);
+                Archive a3 = buildArchive(26, Category.BLOG, "C", Track.ENGINEERING, LocalDate.of(2026, 3, 1));
+                em.persist(a1); em.persist(a2); em.persist(a3);
+                em.flush(); em.clear();
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.BLOG, null, null, null, PageRequest.of(0, 10));
+
+                List<String> titles = result.getContent().stream().map(Archive::getTitle).toList();
+                assertThat(titles).containsExactly("C", "A", "B");
+            }
+
+            @Test
+            @DisplayName("TC-I-006 contentDate DESC 정렬 → 최신순")
+            void date_desc() {
+                Archive a1 = buildArchive(26, Category.BLOG, "A", Track.ENGINEERING, LocalDate.of(2025, 5, 1));
+                Archive a2 = buildArchive(26, Category.BLOG, "B", Track.ENGINEERING, LocalDate.of(2026, 3, 1));
+                Archive a3 = buildArchive(26, Category.BLOG, "C", Track.ENGINEERING, LocalDate.of(2024, 1, 1));
+                em.persist(a1); em.persist(a2); em.persist(a3);
+                em.flush(); em.clear();
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.BLOG, null, null, null, PageRequest.of(0, 10));
+
+                List<String> titles = result.getContent().stream().map(Archive::getTitle).toList();
+                assertThat(titles).containsExactly("B", "A", "C");
+            }
+
+            @Test
+            @DisplayName("TC-I-007 contentDate 동일 → title ASC tie-break")
+            void same_date_title_asc() {
+                LocalDate sameDate = LocalDate.of(2026, 1, 1);
+                Archive a1 = buildArchive(26, Category.BLOG, "나다라", Track.ENGINEERING, sameDate);
+                Archive a2 = buildArchive(26, Category.BLOG, "가나다", Track.ENGINEERING, sameDate);
+                Archive a3 = buildArchive(26, Category.BLOG, "다라마", Track.ENGINEERING, sameDate);
+                em.persist(a1); em.persist(a2); em.persist(a3);
+                em.flush(); em.clear();
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.BLOG, null, null, null, PageRequest.of(0, 10));
+
+                List<String> titles = result.getContent().stream().map(Archive::getTitle).toList();
+                assertThat(titles).containsExactly("가나다", "나다라", "다라마");
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 C] 필터 후 totalSize")
+        class FilterTotalSize {
+
+            @Test
+            @DisplayName("TC-I-008 track 필터 적용 시 totalSize = 필터된 개수")
+            void track_filter_total_size() {
+                saveAll(
+                        buildArchive(26, Category.BLOG, "A", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.BLOG, "B", Track.ENGINEERING, LocalDate.of(2026, 1, 2)),
+                        buildArchive(26, Category.BLOG, "C", Track.VISUALIZATION, LocalDate.of(2026, 1, 3))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.BLOG, Track.ENGINEERING, null, null, PageRequest.of(0, 10));
+
+                assertThat(result.getTotalElements()).isEqualTo(2);
+                assertThat(result.getContent()).hasSize(2);
+            }
+
+            @Test
+            @DisplayName("TC-I-009 keyword 필터 적용 시 totalSize = 매칭된 개수")
+            void keyword_filter_total_size() {
+                saveAll(
+                        buildArchive(26, Category.BLOG, "Transformer 구현기", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.BLOG, "데이터 전처리", Track.ANALYSIS, LocalDate.of(2026, 1, 2)),
+                        buildArchive(26, Category.BLOG, "Transformer 최적화", Track.ENGINEERING, LocalDate.of(2026, 1, 3))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.BLOG, null, null, "Transformer", PageRequest.of(0, 10));
+
+                assertThat(result.getTotalElements()).isEqualTo(2);
+                assertThat(result.getContent()).hasSize(2);
+            }
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ARC-004 findDistinctTermsOrdered 통합 테스트
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("ARC-004 findDistinctTermsOrdered 통합 테스트")
+    class FindDistinctTermsOrdered {
+
+        @Nested
+        @DisplayName("[그룹 A] DISTINCT")
+        class Distinct {
+
+            @Test
+            @DisplayName("TC-I-001 같은 term인 데이터가 여러 개인 경우, 한 번만 반환")
+            void dedup_same_term() {
+                saveAll(
+                        buildArchive(26, Category.BLOG, "A", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.BLOG, "B", Track.ENGINEERING, LocalDate.of(2026, 1, 2)),
+                        buildArchive(25, Category.BLOG, "C", Track.ENGINEERING, LocalDate.of(2025, 1, 1))
+                );
+
+                List<Integer> result = archiveRepository.findDistinctTermsOrdered();
+
+                assertThat(result).hasSize(2);
+                assertThat(result).containsExactly(26, 25);
+            }
+
+            @Test
+            @DisplayName("TC-I-002 여러 category에 같은 term이 있는 경우, 한 번만 반환")
+            void dedup_across_categories() {
+                saveAll(
+                        buildArchive(26, Category.PROJECT, "A", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.ACTIVITY, "B", Track.ALL, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.BLOG, "C", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(25, Category.PROJECT, "D", Track.ENGINEERING, LocalDate.of(2025, 1, 1))
+                );
+
+                List<Integer> result = archiveRepository.findDistinctTermsOrdered();
+
+                assertThat(result).hasSize(2);
+                assertThat(result).containsExactly(26, 25);
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 B] 정렬")
+        class Sorting {
+
+            @Test
+            @DisplayName("TC-I-003 term DESC 정렬 → 최신 기수 먼저")
+            void term_desc() {
+                saveAll(
+                        buildArchive(24, Category.BLOG, "A", Track.ENGINEERING, LocalDate.of(2024, 1, 1)),
+                        buildArchive(26, Category.BLOG, "B", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(25, Category.BLOG, "C", Track.ENGINEERING, LocalDate.of(2025, 1, 1))
+                );
+
+                List<Integer> result = archiveRepository.findDistinctTermsOrdered();
+
+                assertThat(result).containsExactly(26, 25, 24);
+            }
+
+            @Test
+            @DisplayName("TC-I-004 term=0 인 경우, 맨 뒤 정렬")
+            void term_zero_last() {
+                saveAll(
+                        buildArchive(26, Category.BLOG, "A", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(0, Category.BLOG, "B", Track.ENGINEERING, null),
+                        buildArchive(25, Category.BLOG, "C", Track.ENGINEERING, LocalDate.of(2025, 1, 1))
+                );
+
+                List<Integer> result = archiveRepository.findDistinctTermsOrdered();
+
+                assertThat(result).containsExactly(26, 25, 0);
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 C] 빈 결과")
+        class EmptyResult {
+
+            @Test
+            @DisplayName("TC-I-005 DB가 비어있는 경우, 빈 목록 반환")
+            void empty_db() {
+                List<Integer> result = archiveRepository.findDistinctTermsOrdered();
+
+                assertThat(result).isEmpty();
+            }
+        }
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/archive/service/ArchiveServiceTest.java
+++ b/src/test/java/com/boaz/backend/domain/archive/service/ArchiveServiceTest.java
@@ -1,0 +1,533 @@
+package com.boaz.backend.domain.archive.service;
+
+import com.boaz.backend.domain.archive.dto.response.ArchivePageResponse;
+import com.boaz.backend.domain.archive.dto.response.ArchiveTermsResponse;
+import com.boaz.backend.domain.archive.entity.Archive;
+import com.boaz.backend.domain.archive.entity.Archive.Category;
+import com.boaz.backend.domain.archive.repository.ArchiveRepository;
+import com.boaz.backend.global.common.enums.Track;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ArchiveServiceTest {
+
+    @InjectMocks ArchiveService archiveService;
+    @Mock ArchiveRepository archiveRepository;
+
+    private Archive buildArchive(int term, Category category, String title, Track track, LocalDate contentDate) {
+        return Archive.builder()
+                .term(term).category(category).title(title)
+                .track(track).imageUrl("http://img.example.com/test.jpg")
+                .links("{}").contentDate(contentDate)
+                .build();
+    }
+
+    private Page<Archive> emptyPage() {
+        return new PageImpl<>(List.of(), PageRequest.of(0, 6), 0L);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ARC-001 프로젝트 아카이빙 조회
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("ARC-001 프로젝트 아카이빙 조회")
+    class ProjectSearch {
+
+        @Nested
+        @DisplayName("[그룹 A] normalizeKeyword")
+        class NormalizeKeyword {
+
+            @Test
+            @DisplayName("TC-001 keyword=null → Repository에 null 전달")
+            void keyword_null() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.PROJECT, Track.ALL, null, null, 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.PROJECT), isNull(), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+
+            @Test
+            @DisplayName("TC-002 keyword=\"\" → null 정규화 후 Repository에 null 전달")
+            void keyword_empty() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.PROJECT, Track.ALL, null, "", 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.PROJECT), isNull(), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+
+            @Test
+            @DisplayName("TC-003 keyword 공백만 → null 정규화 후 Repository에 null 전달")
+            void keyword_blank() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.PROJECT, Track.ALL, null, "   ", 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.PROJECT), isNull(), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+
+            @Test
+            @DisplayName("TC-004 keyword 앞뒤 공백 → trim 후 Repository에 전달")
+            void keyword_trim() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.PROJECT, Track.ALL, null, "  딥러닝  ", 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.PROJECT), isNull(), isNull(), eq("딥러닝"), eq(PageRequest.of(0, 6)));
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 B] track 변환")
+        class TrackConversion {
+
+            @Test
+            @DisplayName("TC-005 track=ALL → null 변환 후 Repository에 전달")
+            void track_all_to_null() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.PROJECT, Track.ALL, null, null, 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.PROJECT), isNull(), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+
+            @Test
+            @DisplayName("TC-006 track=ENGINEERING → null 변환 없이 그대로 전달")
+            void track_specific() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.PROJECT, Track.ENGINEERING, null, null, 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.PROJECT), eq(Track.ENGINEERING), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 C] 페이지네이션 변환 + 응답 DTO 변환")
+        class PaginationConversion {
+
+            @Test
+            @DisplayName("TC-007 page=2, size=3 → 0기반 변환 + currentPage/totalSize 검증")
+            void pagination_conversion() {
+                Archive archive = buildArchive(26, Category.PROJECT, "실시간 추천 시스템", Track.ENGINEERING, LocalDate.of(2026, 1, 1));
+                Page<Archive> mockPage = new PageImpl<>(List.of(archive), PageRequest.of(1, 3), 7L);
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(mockPage);
+
+                ArchivePageResponse response = archiveService.searchArchives(Category.PROJECT, Track.ALL, null, null, 2, 3);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.PROJECT), isNull(), isNull(), isNull(), eq(PageRequest.of(1, 3)));
+                assertThat(response.getCurrentPage()).isEqualTo(2);
+                assertThat(response.getTotalSize()).isEqualTo(7L);
+                assertThat(response.isHasPrevious()).isTrue();
+                assertThat(response.isHasNext()).isTrue();
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 D] 예외")
+        class ValidationExceptions {
+
+            @Test
+            @DisplayName("TC-008 page=0 → INVALID_PAGINATION")
+            void page_zero() {
+                assertThatThrownBy(() -> archiveService.searchArchives(Category.PROJECT, Track.ALL, null, null, 0, 6))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode").isEqualTo(ErrorCode.INVALID_PAGINATION);
+            }
+
+            @Test
+            @DisplayName("TC-009 size=0 → INVALID_PAGINATION")
+            void size_zero() {
+                assertThatThrownBy(() -> archiveService.searchArchives(Category.PROJECT, Track.ALL, null, null, 1, 0))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode").isEqualTo(ErrorCode.INVALID_PAGINATION);
+            }
+
+            @Test
+            @DisplayName("TC-010 size=101 → INVALID_PAGINATION")
+            void size_over_max() {
+                assertThatThrownBy(() -> archiveService.searchArchives(Category.PROJECT, Track.ALL, null, null, 1, 101))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode").isEqualTo(ErrorCode.INVALID_PAGINATION);
+            }
+
+            @Test
+            @DisplayName("TC-011 term=-1 → INVALID_PARAMETER_TYPE")
+            void term_negative() {
+                assertThatThrownBy(() -> archiveService.searchArchives(Category.PROJECT, Track.ALL, -1, null, 1, 6))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode").isEqualTo(ErrorCode.INVALID_PARAMETER_TYPE);
+            }
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ARC-002 활동사진 아카이빙 조회
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("ARC-002 활동사진 아카이빙 조회")
+    class ActivitySearch {
+
+        @Nested
+        @DisplayName("[그룹 A] normalizeKeyword")
+        class NormalizeKeyword {
+
+            @Test
+            @DisplayName("TC-001 keyword=null → Repository에 null 전달")
+            void keyword_null() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.ACTIVITY, null, null, null, 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.ACTIVITY), isNull(), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+
+            @Test
+            @DisplayName("TC-002 keyword=\"\" → null 정규화 후 Repository에 null 전달")
+            void keyword_empty() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.ACTIVITY, null, null, "", 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.ACTIVITY), isNull(), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+
+            @Test
+            @DisplayName("TC-003 keyword 공백만 → null 정규화 후 Repository에 null 전달")
+            void keyword_blank() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.ACTIVITY, null, null, "   ", 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.ACTIVITY), isNull(), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+
+            @Test
+            @DisplayName("TC-004 keyword 앞뒤 공백 → trim 후 Repository에 전달")
+            void keyword_trim() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.ACTIVITY, null, null, "  활동사진  ", 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.ACTIVITY), isNull(), isNull(), eq("활동사진"), eq(PageRequest.of(0, 6)));
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 B] track 고정 null 확인")
+        class TrackFixedNull {
+
+            @Test
+            @DisplayName("TC-005 컨트롤러가 null 하드코딩 → null 그대로 Repository에 전달")
+            void track_fixed_null() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.ACTIVITY, null, null, null, 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.ACTIVITY), isNull(), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 C] 페이지네이션 변환 + 응답 DTO 변환")
+        class PaginationConversion {
+
+            @Test
+            @DisplayName("TC-006 page=2, size=3 → 0기반 변환 + currentPage/totalSize 검증")
+            void pagination_conversion() {
+                Archive archive = buildArchive(26, Category.ACTIVITY, "26기 워크샵 활동", Track.ALL, LocalDate.of(2026, 1, 1));
+                Page<Archive> mockPage = new PageImpl<>(List.of(archive), PageRequest.of(1, 3), 7L);
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(mockPage);
+
+                ArchivePageResponse response = archiveService.searchArchives(Category.ACTIVITY, null, null, null, 2, 3);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.ACTIVITY), isNull(), isNull(), isNull(), eq(PageRequest.of(1, 3)));
+                assertThat(response.getCurrentPage()).isEqualTo(2);
+                assertThat(response.getTotalSize()).isEqualTo(7L);
+                assertThat(response.isHasPrevious()).isTrue();
+                assertThat(response.isHasNext()).isTrue();
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 D] 예외")
+        class ValidationExceptions {
+
+            @Test
+            @DisplayName("TC-007 page=0 → INVALID_PAGINATION")
+            void page_zero() {
+                assertThatThrownBy(() -> archiveService.searchArchives(Category.ACTIVITY, null, null, null, 0, 6))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode").isEqualTo(ErrorCode.INVALID_PAGINATION);
+            }
+
+            @Test
+            @DisplayName("TC-008 size=0 → INVALID_PAGINATION")
+            void size_zero() {
+                assertThatThrownBy(() -> archiveService.searchArchives(Category.ACTIVITY, null, null, null, 1, 0))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode").isEqualTo(ErrorCode.INVALID_PAGINATION);
+            }
+
+            @Test
+            @DisplayName("TC-009 size=101 → INVALID_PAGINATION")
+            void size_over_max() {
+                assertThatThrownBy(() -> archiveService.searchArchives(Category.ACTIVITY, null, null, null, 1, 101))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode").isEqualTo(ErrorCode.INVALID_PAGINATION);
+            }
+
+            @Test
+            @DisplayName("TC-010 term=-1 → INVALID_PARAMETER_TYPE")
+            void term_negative() {
+                assertThatThrownBy(() -> archiveService.searchArchives(Category.ACTIVITY, null, -1, null, 1, 6))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode").isEqualTo(ErrorCode.INVALID_PARAMETER_TYPE);
+            }
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ARC-003 기술블로그 아카이빙 조회
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("ARC-003 기술블로그 아카이빙 조회")
+    class BlogSearch {
+
+        @Nested
+        @DisplayName("[그룹 A] normalizeKeyword")
+        class NormalizeKeyword {
+
+            @Test
+            @DisplayName("TC-001 keyword=null → Repository에 null 전달")
+            void keyword_null() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.BLOG, Track.ALL, null, null, 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.BLOG), isNull(), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+
+            @Test
+            @DisplayName("TC-002 keyword=\"\" → null 정규화 후 Repository에 null 전달")
+            void keyword_empty() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.BLOG, Track.ALL, null, "", 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.BLOG), isNull(), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+
+            @Test
+            @DisplayName("TC-003 keyword 공백만 → null 정규화 후 Repository에 null 전달")
+            void keyword_blank() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.BLOG, Track.ALL, null, "   ", 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.BLOG), isNull(), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+
+            @Test
+            @DisplayName("TC-004 keyword 앞뒤 공백 → trim 후 Repository에 전달")
+            void keyword_trim() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.BLOG, Track.ALL, null, "   딥러닝  ", 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.BLOG), isNull(), isNull(), eq("딥러닝"), eq(PageRequest.of(0, 6)));
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 B] track 변환")
+        class TrackConversion {
+
+            @Test
+            @DisplayName("TC-005 track=ALL → null 변환 후 Repository에 전달")
+            void track_all_to_null() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.BLOG, Track.ALL, null, null, 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.BLOG), isNull(), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+
+            @Test
+            @DisplayName("TC-006 track=ENGINEERING → null 변환 없이 그대로 전달")
+            void track_specific() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.BLOG, Track.ENGINEERING, null, null, 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.BLOG), eq(Track.ENGINEERING), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 C] term null 고정 확인")
+        class TermFixedNull {
+
+            @Test
+            @DisplayName("TC-007 컨트롤러가 null 하드코딩 → null 그대로 Repository에 전달")
+            void term_fixed_null() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.BLOG, Track.ALL, null, null, 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.BLOG), isNull(), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 D] 페이지네이션 변환 + 응답 DTO 변환")
+        class PaginationConversion {
+
+            @Test
+            @DisplayName("TC-008 page=2, size=3 → 0기반 변환 + currentPage/totalSize 검증")
+            void pagination_conversion() {
+                Archive archive = buildArchive(26, Category.BLOG, "Transformer 모델 구현기", Track.ENGINEERING, LocalDate.of(2026, 1, 1));
+                Page<Archive> mockPage = new PageImpl<>(List.of(archive), PageRequest.of(1, 3), 7L);
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(mockPage);
+
+                ArchivePageResponse response = archiveService.searchArchives(Category.BLOG, Track.ALL, null, null, 2, 3);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.BLOG), isNull(), isNull(), isNull(), eq(PageRequest.of(1, 3)));
+                assertThat(response.getCurrentPage()).isEqualTo(2);
+                assertThat(response.getTotalSize()).isEqualTo(7L);
+                assertThat(response.isHasPrevious()).isTrue();
+                assertThat(response.isHasNext()).isTrue();
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 E] 예외")
+        class ValidationExceptions {
+
+            @Test
+            @DisplayName("TC-009 page=0 → INVALID_PAGINATION")
+            void page_zero() {
+                assertThatThrownBy(() -> archiveService.searchArchives(Category.BLOG, Track.ALL, null, null, 0, 6))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode").isEqualTo(ErrorCode.INVALID_PAGINATION);
+            }
+
+            @Test
+            @DisplayName("TC-010 size=0 → INVALID_PAGINATION")
+            void size_zero() {
+                assertThatThrownBy(() -> archiveService.searchArchives(Category.BLOG, Track.ALL, null, null, 1, 0))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode").isEqualTo(ErrorCode.INVALID_PAGINATION);
+            }
+
+            @Test
+            @DisplayName("TC-011 size=101 → INVALID_PAGINATION")
+            void size_over_max() {
+                assertThatThrownBy(() -> archiveService.searchArchives(Category.BLOG, Track.ALL, null, null, 1, 101))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode").isEqualTo(ErrorCode.INVALID_PAGINATION);
+            }
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ARC-004 기수 목록 조회
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("ARC-004 기수 목록 조회")
+    class GetTermsTest {
+
+        @Nested
+        @DisplayName("[그룹 A] DTO 변환 + Repository 위임")
+        class TermLabelConversion {
+
+            @Test
+            @DisplayName("TC-001 term 목록 조회 시 value/label 변환 (N기)")
+            void term_label_general() {
+                when(archiveRepository.findDistinctTermsOrdered()).thenReturn(List.of(26, 25, 24));
+
+                ArchiveTermsResponse response = archiveService.getTerms();
+
+                verify(archiveRepository).findDistinctTermsOrdered();
+                assertThat(response.terms()).hasSize(3);
+                assertThat(response.terms().get(0).value()).isEqualTo(26);
+                assertThat(response.terms().get(0).label()).isEqualTo("26기");
+                assertThat(response.terms().get(1).value()).isEqualTo(25);
+                assertThat(response.terms().get(2).value()).isEqualTo(24);
+            }
+
+            @Test
+            @DisplayName("TC-002 term=0 → label \"7기 이전\" 변환")
+            void term_zero_label() {
+                when(archiveRepository.findDistinctTermsOrdered()).thenReturn(List.of(26, 25, 0));
+
+                ArchiveTermsResponse response = archiveService.getTerms();
+
+                assertThat(response.terms().get(2).value()).isEqualTo(0);
+                assertThat(response.terms().get(2).label()).isEqualTo("7기 이전");
+            }
+
+            @Test
+            @DisplayName("TC-003 term 일반값 → label \"N기\" 변환")
+            void term_general_label() {
+                when(archiveRepository.findDistinctTermsOrdered()).thenReturn(List.of(26));
+
+                ArchiveTermsResponse response = archiveService.getTerms();
+
+                assertThat(response.terms().get(0).value()).isEqualTo(26);
+                assertThat(response.terms().get(0).label()).isEqualTo("26기");
+            }
+
+            @Test
+            @DisplayName("TC-004 DB에 데이터 없음 → 빈 terms 반환")
+            void empty_terms() {
+                when(archiveRepository.findDistinctTermsOrdered()).thenReturn(List.of());
+
+                ArchiveTermsResponse response = archiveService.getTerms();
+
+                assertThat(response.terms()).isEmpty();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 💡 개요

* Issue Number: #150 

## 🪐 주요 변경 사항
- 아카이빙 도메인 테스트 코드 작성 (Unit / Integration)

## ✅ 상세 내용
- `ArchiveServiceTest`: keyword 정규화, track 변환, pagination 변환, 예외 처리 (36개)
- `ArchiveControllerTest`: 공개 엔드포인트 200 OK 검증 (4개)
- `ArchiveRepositoryTest`: keyword 검색, 정렬, 필터 totalSize, DISTINCT (29개, Testcontainers)

## 🔔 참고 사항
- 전체 69개 테스트 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **변경 목적**: 아카이빙 도메인의 검색·조회 로직과 기수(term) 처리에 대한 단위 및 통합 테스트를 추가하여 기능 정확성과 회귀 방지 수준을 높입니다.

- **주요 변경 내용**:
  - Service 계층 (`src/test/.../archive/service/ArchiveServiceTest.java`): 키워드 정규화(공백/대소문자/빈값 처리), 트랙 변환(ALL→null 등), 페이지 매핑(0-based 변환, currentPage/totalSize/prev/next 검증), 잘못된 파라미터에 대한 예외 처리 검증 등 36개 테스트 추가.
  - Controller 계층 (`src/test/.../archive/controller/ArchiveControllerTest.java`): `/api/v1/archiving/projects`, `/activities`, `/blogs`, `/terms` 엔드포인트의 기본 호출 응답(200 OK) 및 응답 필드(status, data.current_page, data.total_size, terms value/label) 검증 4개 테스트 추가.
  - Repository/통합 테스트 (`src/test/.../archive/repository/ArchiveRepositoryTest.java`, `src/test/.../archive/integration/ArchiveIntegrationTest.java`): 부분일치 키워드 검색, contentDate null 처리 및 정렬(최신순, 동일일자 타이브레이커 title ASC), 트랙/키워드/term 필터에 따른 totalSize 일치, DISTINCT term 반환과 정렬/term=0 후순위 동작 검증 등 Testcontainers 기반 통합·저장소 테스트 포함(총 약 29개+통합 테스트 추가).
  - 전체 테스트 실행: 69개 테스트가 추가되어 모두 통과 보고.

- **영향 범위**: API 변경 없음 / DB 스키마 변경 없음 / 설정 변경 없음 — 테스트 코드 추가만 이루어짐.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->