### PR TITLE
[Test] JWT, OAuth 관련 테스트 코드 작성 

### DIFF
--- a/src/test/java/com/boaz/backend/domain/archive/controller/ArchiveControllerTest.java
+++ b/src/test/java/com/boaz/backend/domain/archive/controller/ArchiveControllerTest.java
@@ -1,0 +1,130 @@
+package com.boaz.backend.domain.archive.controller;
+
+import com.boaz.backend.domain.archive.dto.response.ArchivePageResponse;
+import com.boaz.backend.domain.archive.dto.response.ArchiveTermsResponse;
+import com.boaz.backend.domain.archive.service.ArchiveService;
+import com.boaz.backend.support.TestSecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ActiveProfiles("test")
+@WebMvcTest(
+        value = ArchiveController.class,
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class}
+)
+@Import(TestSecurityConfig.class)
+class ArchiveControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @MockitoBean ArchiveService archiveService;
+
+    private ArchivePageResponse mockPageResponse(int currentPage, long totalSize) {
+        return ArchivePageResponse.builder()
+                .currentPage(currentPage).totalPages(1).size(6)
+                .currentSize((int) totalSize).totalSize(totalSize)
+                .hasPrevious(false).hasNext(false).posts(List.of())
+                .build();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ARC-001 GET /api/v1/archiving/projects
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("ARC-001 GET /api/v1/archiving/projects")
+    class GetProjects {
+
+        @Test
+        @DisplayName("TC-012 인증 없이 기본 파라미터 → 200 OK")
+        void getProjects_200() throws Exception {
+            when(archiveService.searchArchives(any(), any(), any(), any(), anyInt(), anyInt()))
+                    .thenReturn(mockPageResponse(1, 3));
+
+            mockMvc.perform(get("/api/v1/archiving/projects"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.current_page").value(1))
+                    .andExpect(jsonPath("$.data.total_size").value(3));
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ARC-002 GET /api/v1/archiving/activities
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("ARC-002 GET /api/v1/archiving/activities")
+    class GetActivities {
+
+        @Test
+        @DisplayName("TC-011 인증 없이 기본 파라미터 → 200 OK")
+        void getActivities_200() throws Exception {
+            when(archiveService.searchArchives(any(), any(), any(), any(), anyInt(), anyInt()))
+                    .thenReturn(mockPageResponse(1, 3));
+
+            mockMvc.perform(get("/api/v1/archiving/activities"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.current_page").value(1))
+                    .andExpect(jsonPath("$.data.total_size").value(3));
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ARC-003 GET /api/v1/archiving/blogs
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("ARC-003 GET /api/v1/archiving/blogs")
+    class GetBlogs {
+
+        @Test
+        @DisplayName("TC-012 인증 없이 기본 파라미터 → 200 OK")
+        void getBlogs_200() throws Exception {
+            when(archiveService.searchArchives(any(), any(), any(), any(), anyInt(), anyInt()))
+                    .thenReturn(mockPageResponse(1, 3));
+
+            mockMvc.perform(get("/api/v1/archiving/blogs"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.current_page").value(1))
+                    .andExpect(jsonPath("$.data.total_size").value(3));
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ARC-004 GET /api/v1/archiving/terms
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("ARC-004 GET /api/v1/archiving/terms")
+    class GetTerms {
+
+        @Test
+        @DisplayName("TC-005 인증 없이 조회 → 200 OK + value/label 검증")
+        void getTerms_200() throws Exception {
+            when(archiveService.getTerms())
+                    .thenReturn(ArchiveTermsResponse.from(List.of(26, 0)));
+
+            mockMvc.perform(get("/api/v1/archiving/terms"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.terms[0].value").value(26))
+                    .andExpect(jsonPath("$.data.terms[0].label").value("26기"))
+                    .andExpect(jsonPath("$.data.terms[1].value").value(0))
+                    .andExpect(jsonPath("$.data.terms[1].label").value("7기 이전"));
+        }
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/archive/repository/ArchiveRepositoryTest.java
+++ b/src/test/java/com/boaz/backend/domain/archive/repository/ArchiveRepositoryTest.java
@@ -1,0 +1,631 @@
+package com.boaz.backend.domain.archive.repository;
+
+import com.boaz.backend.domain.archive.entity.Archive;
+import com.boaz.backend.domain.archive.entity.Archive.Category;
+import com.boaz.backend.global.common.enums.Track;
+import com.boaz.backend.global.config.JpaConfig;
+import com.boaz.backend.support.TestcontainersBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(JpaConfig.class)
+@ActiveProfiles("test")
+class ArchiveRepositoryTest extends TestcontainersBase {
+
+    @Autowired ArchiveRepository archiveRepository;
+    @Autowired TestEntityManager em;
+
+    private Archive buildArchive(int term, Category category, String title, Track track, LocalDate contentDate) {
+        return Archive.builder()
+                .term(term).category(category).title(title)
+                .track(track).imageUrl("http://img.example.com/test.jpg")
+                .links("{}").contentDate(contentDate)
+                .build();
+    }
+
+    private void saveAll(Archive... archives) {
+        for (Archive a : archives) {
+            em.persist(a);
+        }
+        em.flush();
+        em.clear();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ARC-001 searchArchives - PROJECT 통합 테스트
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("ARC-001 searchArchives(PROJECT) 통합 테스트")
+    class ProjectSearchIntegration {
+
+        @Nested
+        @DisplayName("[그룹 A] keyword 검색 동작")
+        class KeywordSearch {
+
+            @Test
+            @DisplayName("TC-I-001 keyword 부분 일치 → 제목 중간에 검색어 포함 시 히트")
+            void partial_match() {
+                saveAll(
+                        buildArchive(26, Category.PROJECT, "실시간 추천 시스템 구축", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.PROJECT, "이상 탐지 모델 개발", Track.ANALYSIS, LocalDate.of(2026, 1, 2))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.PROJECT, null, null, "추천", PageRequest.of(0, 10));
+
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getContent().get(0).getTitle()).isEqualTo("실시간 추천 시스템 구축");
+            }
+
+            @Test
+            @DisplayName("TC-I-002 keyword 대소문자 무시 → 영문 대소문자 관계 없이 히트")
+            void case_insensitive() {
+                saveAll(
+                        buildArchive(26, Category.PROJECT, "BOAZ Project", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.PROJECT, "이상 탐지", Track.ANALYSIS, LocalDate.of(2026, 1, 2))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.PROJECT, null, null, "boaz", PageRequest.of(0, 10));
+
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getContent().get(0).getTitle()).isEqualTo("BOAZ Project");
+            }
+
+            @Test
+            @DisplayName("TC-I-003 keyword 공백 무시 → 검색어의 공백 제거 후 매칭")
+            void space_insensitive() {
+                saveAll(
+                        buildArchive(26, Category.PROJECT, "딥러닝프로젝트", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.PROJECT, "이상탐지", Track.ANALYSIS, LocalDate.of(2026, 1, 2))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.PROJECT, null, null, "딥 러 닝", PageRequest.of(0, 10));
+
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getContent().get(0).getTitle()).isEqualTo("딥러닝프로젝트");
+            }
+
+            @Test
+            @DisplayName("TC-I-004 keyword=\"\" → LIKE '%%' → 전체 반환")
+            void empty_string_returns_all() {
+                saveAll(
+                        buildArchive(26, Category.PROJECT, "프로젝트A", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.PROJECT, "프로젝트B", Track.ANALYSIS, LocalDate.of(2026, 1, 2)),
+                        buildArchive(26, Category.PROJECT, "프로젝트C", Track.VISUALIZATION, LocalDate.of(2026, 1, 3))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.PROJECT, null, null, "", PageRequest.of(0, 10));
+
+                assertThat(result.getContent()).hasSize(3);
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 B] 정렬")
+        class Sorting {
+
+            @Test
+            @DisplayName("TC-I-005 contentDate=null → 맨 뒤 정렬")
+            void null_date_last() {
+                Archive a1 = buildArchive(26, Category.PROJECT, "A", Track.ENGINEERING, LocalDate.of(2026, 1, 1));
+                Archive a2 = buildArchive(26, Category.PROJECT, "B", Track.ENGINEERING, null);
+                Archive a3 = buildArchive(26, Category.PROJECT, "C", Track.ENGINEERING, LocalDate.of(2026, 3, 1));
+                em.persist(a1); em.persist(a2); em.persist(a3);
+                em.flush(); em.clear();
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.PROJECT, null, null, null, PageRequest.of(0, 10));
+
+                List<String> titles = result.getContent().stream().map(Archive::getTitle).toList();
+                assertThat(titles).containsExactly("C", "A", "B");
+            }
+
+            @Test
+            @DisplayName("TC-I-006 contentDate DESC 정렬 → 최신순")
+            void date_desc() {
+                Archive a1 = buildArchive(26, Category.PROJECT, "A", Track.ENGINEERING, LocalDate.of(2025, 5, 1));
+                Archive a2 = buildArchive(26, Category.PROJECT, "B", Track.ENGINEERING, LocalDate.of(2026, 3, 1));
+                Archive a3 = buildArchive(26, Category.PROJECT, "C", Track.ENGINEERING, LocalDate.of(2024, 1, 1));
+                em.persist(a1); em.persist(a2); em.persist(a3);
+                em.flush(); em.clear();
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.PROJECT, null, null, null, PageRequest.of(0, 10));
+
+                List<String> titles = result.getContent().stream().map(Archive::getTitle).toList();
+                assertThat(titles).containsExactly("B", "A", "C");
+            }
+
+            @Test
+            @DisplayName("TC-I-007 contentDate 동일 → title ASC tie-break")
+            void same_date_title_asc() {
+                LocalDate sameDate = LocalDate.of(2026, 1, 1);
+                Archive a1 = buildArchive(26, Category.PROJECT, "나다라", Track.ENGINEERING, sameDate);
+                Archive a2 = buildArchive(26, Category.PROJECT, "가나다", Track.ENGINEERING, sameDate);
+                Archive a3 = buildArchive(26, Category.PROJECT, "다라마", Track.ENGINEERING, sameDate);
+                em.persist(a1); em.persist(a2); em.persist(a3);
+                em.flush(); em.clear();
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.PROJECT, null, null, null, PageRequest.of(0, 10));
+
+                List<String> titles = result.getContent().stream().map(Archive::getTitle).toList();
+                assertThat(titles).containsExactly("가나다", "나다라", "다라마");
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 C] 필터 후 totalSize")
+        class FilterTotalSize {
+
+            @Test
+            @DisplayName("TC-I-008 track 필터 적용 시 totalSize = 필터된 개수")
+            void track_filter_total_size() {
+                saveAll(
+                        buildArchive(26, Category.PROJECT, "A", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.PROJECT, "B", Track.ENGINEERING, LocalDate.of(2026, 1, 2)),
+                        buildArchive(26, Category.PROJECT, "C", Track.VISUALIZATION, LocalDate.of(2026, 1, 3))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.PROJECT, Track.ENGINEERING, null, null, PageRequest.of(0, 10));
+
+                assertThat(result.getTotalElements()).isEqualTo(2);
+                assertThat(result.getContent()).hasSize(2);
+            }
+
+            @Test
+            @DisplayName("TC-I-009 keyword 필터 적용 시 totalSize = 매칭된 개수")
+            void keyword_filter_total_size() {
+                saveAll(
+                        buildArchive(26, Category.PROJECT, "추천 시스템", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.PROJECT, "이상 탐지", Track.ANALYSIS, LocalDate.of(2026, 1, 2)),
+                        buildArchive(26, Category.PROJECT, "추천 알고리즘", Track.ENGINEERING, LocalDate.of(2026, 1, 3))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.PROJECT, null, null, "추천", PageRequest.of(0, 10));
+
+                assertThat(result.getTotalElements()).isEqualTo(2);
+                assertThat(result.getContent()).hasSize(2);
+            }
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ARC-002 searchArchives - ACTIVITY 통합 테스트
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("ARC-002 searchArchives(ACTIVITY) 통합 테스트")
+    class ActivitySearchIntegration {
+
+        @Nested
+        @DisplayName("[그룹 A] keyword 검색 동작")
+        class KeywordSearch {
+
+            @Test
+            @DisplayName("TC-I-001 keyword 부분 일치 → 제목 중간에 검색어 포함 시 히트")
+            void partial_match() {
+                saveAll(
+                        buildArchive(26, Category.ACTIVITY, "26기 워크샵 활동", Track.ALL, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.ACTIVITY, "MT 후기", Track.ALL, LocalDate.of(2026, 1, 2))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.ACTIVITY, null, null, "워크샵", PageRequest.of(0, 10));
+
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getContent().get(0).getTitle()).isEqualTo("26기 워크샵 활동");
+            }
+
+            @Test
+            @DisplayName("TC-I-002 keyword 대소문자 무시 → 영문 대소문자 관계 없이 히트")
+            void case_insensitive() {
+                saveAll(
+                        buildArchive(26, Category.ACTIVITY, "BOAZ MT 2025", Track.ALL, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.ACTIVITY, "워크샵", Track.ALL, LocalDate.of(2026, 1, 2))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.ACTIVITY, null, null, "boaz", PageRequest.of(0, 10));
+
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getContent().get(0).getTitle()).isEqualTo("BOAZ MT 2025");
+            }
+
+            @Test
+            @DisplayName("TC-I-003 keyword 공백 무시 → 검색어의 공백 제거 후 매칭")
+            void space_insensitive() {
+                saveAll(
+                        buildArchive(26, Category.ACTIVITY, "종강파티활동", Track.ALL, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.ACTIVITY, "MT후기", Track.ALL, LocalDate.of(2026, 1, 2))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.ACTIVITY, null, null, "종강 파티", PageRequest.of(0, 10));
+
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getContent().get(0).getTitle()).isEqualTo("종강파티활동");
+            }
+
+            @Test
+            @DisplayName("TC-I-004 keyword=\"\" → LIKE '%%' → 전체 반환")
+            void empty_string_returns_all() {
+                saveAll(
+                        buildArchive(26, Category.ACTIVITY, "활동A", Track.ALL, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.ACTIVITY, "활동B", Track.ALL, LocalDate.of(2026, 1, 2)),
+                        buildArchive(26, Category.ACTIVITY, "활동C", Track.ALL, LocalDate.of(2026, 1, 3))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.ACTIVITY, null, null, "", PageRequest.of(0, 10));
+
+                assertThat(result.getContent()).hasSize(3);
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 B] 정렬")
+        class Sorting {
+
+            @Test
+            @DisplayName("TC-I-005 contentDate=null → 맨 뒤 정렬")
+            void null_date_last() {
+                Archive a1 = buildArchive(26, Category.ACTIVITY, "A", Track.ALL, LocalDate.of(2026, 1, 1));
+                Archive a2 = buildArchive(26, Category.ACTIVITY, "B", Track.ALL, null);
+                Archive a3 = buildArchive(26, Category.ACTIVITY, "C", Track.ALL, LocalDate.of(2026, 3, 1));
+                em.persist(a1); em.persist(a2); em.persist(a3);
+                em.flush(); em.clear();
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.ACTIVITY, null, null, null, PageRequest.of(0, 10));
+
+                List<String> titles = result.getContent().stream().map(Archive::getTitle).toList();
+                assertThat(titles).containsExactly("C", "A", "B");
+            }
+
+            @Test
+            @DisplayName("TC-I-006 contentDate DESC 정렬 → 최신순")
+            void date_desc() {
+                Archive a1 = buildArchive(26, Category.ACTIVITY, "A", Track.ALL, LocalDate.of(2025, 5, 1));
+                Archive a2 = buildArchive(26, Category.ACTIVITY, "B", Track.ALL, LocalDate.of(2026, 3, 1));
+                Archive a3 = buildArchive(26, Category.ACTIVITY, "C", Track.ALL, LocalDate.of(2024, 1, 1));
+                em.persist(a1); em.persist(a2); em.persist(a3);
+                em.flush(); em.clear();
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.ACTIVITY, null, null, null, PageRequest.of(0, 10));
+
+                List<String> titles = result.getContent().stream().map(Archive::getTitle).toList();
+                assertThat(titles).containsExactly("B", "A", "C");
+            }
+
+            @Test
+            @DisplayName("TC-I-007 contentDate 동일 → title ASC tie-break")
+            void same_date_title_asc() {
+                LocalDate sameDate = LocalDate.of(2026, 1, 1);
+                Archive a1 = buildArchive(26, Category.ACTIVITY, "나다라", Track.ALL, sameDate);
+                Archive a2 = buildArchive(26, Category.ACTIVITY, "가나다", Track.ALL, sameDate);
+                Archive a3 = buildArchive(26, Category.ACTIVITY, "다라마", Track.ALL, sameDate);
+                em.persist(a1); em.persist(a2); em.persist(a3);
+                em.flush(); em.clear();
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.ACTIVITY, null, null, null, PageRequest.of(0, 10));
+
+                List<String> titles = result.getContent().stream().map(Archive::getTitle).toList();
+                assertThat(titles).containsExactly("가나다", "나다라", "다라마");
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 C] 필터 후 totalSize")
+        class FilterTotalSize {
+
+            @Test
+            @DisplayName("TC-I-008 term 필터 적용 시 totalSize = 필터된 개수")
+            void term_filter_total_size() {
+                saveAll(
+                        buildArchive(25, Category.ACTIVITY, "A", Track.ALL, LocalDate.of(2025, 1, 1)),
+                        buildArchive(25, Category.ACTIVITY, "B", Track.ALL, LocalDate.of(2025, 1, 2)),
+                        buildArchive(26, Category.ACTIVITY, "C", Track.ALL, LocalDate.of(2026, 1, 1))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.ACTIVITY, null, 25, null, PageRequest.of(0, 10));
+
+                assertThat(result.getTotalElements()).isEqualTo(2);
+                assertThat(result.getContent()).hasSize(2);
+            }
+
+            @Test
+            @DisplayName("TC-I-009 keyword 필터 적용 시 totalSize = 매칭된 개수")
+            void keyword_filter_total_size() {
+                saveAll(
+                        buildArchive(26, Category.ACTIVITY, "워크샵 후기", Track.ALL, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.ACTIVITY, "MT 일정", Track.ALL, LocalDate.of(2026, 1, 2)),
+                        buildArchive(26, Category.ACTIVITY, "종강 파티 워크샵", Track.ALL, LocalDate.of(2026, 1, 3))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.ACTIVITY, null, null, "워크샵", PageRequest.of(0, 10));
+
+                assertThat(result.getTotalElements()).isEqualTo(2);
+                assertThat(result.getContent()).hasSize(2);
+            }
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ARC-003 searchArchives - BLOG 통합 테스트
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("ARC-003 searchArchives(BLOG) 통합 테스트")
+    class BlogSearchIntegration {
+
+        @Nested
+        @DisplayName("[그룹 A] keyword 검색 동작")
+        class KeywordSearch {
+
+            @Test
+            @DisplayName("TC-I-001 keyword 부분 일치 → 제목 중간에 검색어 포함 시 히트")
+            void partial_match() {
+                saveAll(
+                        buildArchive(26, Category.BLOG, "Transformer 모델 구현기", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.BLOG, "데이터 전처리 가이드", Track.ANALYSIS, LocalDate.of(2026, 1, 2))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.BLOG, null, null, "구현기", PageRequest.of(0, 10));
+
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getContent().get(0).getTitle()).isEqualTo("Transformer 모델 구현기");
+            }
+
+            @Test
+            @DisplayName("TC-I-002 keyword 대소문자 무시 → 영문 대소문자 관계 없이 히트")
+            void case_insensitive() {
+                saveAll(
+                        buildArchive(26, Category.BLOG, "Transformer 분석", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.BLOG, "데이터 전처리", Track.ANALYSIS, LocalDate.of(2026, 1, 2))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.BLOG, null, null, "transformer", PageRequest.of(0, 10));
+
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getContent().get(0).getTitle()).isEqualTo("Transformer 분석");
+            }
+
+            @Test
+            @DisplayName("TC-I-003 keyword 공백 무시 → 검색어의 공백 제거 후 매칭")
+            void space_insensitive() {
+                saveAll(
+                        buildArchive(26, Category.BLOG, "딥러닝모델최적화", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.BLOG, "데이터전처리", Track.ANALYSIS, LocalDate.of(2026, 1, 2))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.BLOG, null, null, "딥 러 닝", PageRequest.of(0, 10));
+
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getContent().get(0).getTitle()).isEqualTo("딥러닝모델최적화");
+            }
+
+            @Test
+            @DisplayName("TC-I-004 keyword=\"\" → LIKE '%%' → 전체 반환")
+            void empty_string_returns_all() {
+                saveAll(
+                        buildArchive(26, Category.BLOG, "블로그A", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.BLOG, "블로그B", Track.ANALYSIS, LocalDate.of(2026, 1, 2)),
+                        buildArchive(26, Category.BLOG, "블로그C", Track.VISUALIZATION, LocalDate.of(2026, 1, 3))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.BLOG, null, null, "", PageRequest.of(0, 10));
+
+                assertThat(result.getContent()).hasSize(3);
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 B] 정렬")
+        class Sorting {
+
+            @Test
+            @DisplayName("TC-I-005 contentDate=null → 맨 뒤 정렬")
+            void null_date_last() {
+                Archive a1 = buildArchive(26, Category.BLOG, "A", Track.ENGINEERING, LocalDate.of(2026, 1, 1));
+                Archive a2 = buildArchive(26, Category.BLOG, "B", Track.ENGINEERING, null);
+                Archive a3 = buildArchive(26, Category.BLOG, "C", Track.ENGINEERING, LocalDate.of(2026, 3, 1));
+                em.persist(a1); em.persist(a2); em.persist(a3);
+                em.flush(); em.clear();
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.BLOG, null, null, null, PageRequest.of(0, 10));
+
+                List<String> titles = result.getContent().stream().map(Archive::getTitle).toList();
+                assertThat(titles).containsExactly("C", "A", "B");
+            }
+
+            @Test
+            @DisplayName("TC-I-006 contentDate DESC 정렬 → 최신순")
+            void date_desc() {
+                Archive a1 = buildArchive(26, Category.BLOG, "A", Track.ENGINEERING, LocalDate.of(2025, 5, 1));
+                Archive a2 = buildArchive(26, Category.BLOG, "B", Track.ENGINEERING, LocalDate.of(2026, 3, 1));
+                Archive a3 = buildArchive(26, Category.BLOG, "C", Track.ENGINEERING, LocalDate.of(2024, 1, 1));
+                em.persist(a1); em.persist(a2); em.persist(a3);
+                em.flush(); em.clear();
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.BLOG, null, null, null, PageRequest.of(0, 10));
+
+                List<String> titles = result.getContent().stream().map(Archive::getTitle).toList();
+                assertThat(titles).containsExactly("B", "A", "C");
+            }
+
+            @Test
+            @DisplayName("TC-I-007 contentDate 동일 → title ASC tie-break")
+            void same_date_title_asc() {
+                LocalDate sameDate = LocalDate.of(2026, 1, 1);
+                Archive a1 = buildArchive(26, Category.BLOG, "나다라", Track.ENGINEERING, sameDate);
+                Archive a2 = buildArchive(26, Category.BLOG, "가나다", Track.ENGINEERING, sameDate);
+                Archive a3 = buildArchive(26, Category.BLOG, "다라마", Track.ENGINEERING, sameDate);
+                em.persist(a1); em.persist(a2); em.persist(a3);
+                em.flush(); em.clear();
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.BLOG, null, null, null, PageRequest.of(0, 10));
+
+                List<String> titles = result.getContent().stream().map(Archive::getTitle).toList();
+                assertThat(titles).containsExactly("가나다", "나다라", "다라마");
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 C] 필터 후 totalSize")
+        class FilterTotalSize {
+
+            @Test
+            @DisplayName("TC-I-008 track 필터 적용 시 totalSize = 필터된 개수")
+            void track_filter_total_size() {
+                saveAll(
+                        buildArchive(26, Category.BLOG, "A", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.BLOG, "B", Track.ENGINEERING, LocalDate.of(2026, 1, 2)),
+                        buildArchive(26, Category.BLOG, "C", Track.VISUALIZATION, LocalDate.of(2026, 1, 3))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.BLOG, Track.ENGINEERING, null, null, PageRequest.of(0, 10));
+
+                assertThat(result.getTotalElements()).isEqualTo(2);
+                assertThat(result.getContent()).hasSize(2);
+            }
+
+            @Test
+            @DisplayName("TC-I-009 keyword 필터 적용 시 totalSize = 매칭된 개수")
+            void keyword_filter_total_size() {
+                saveAll(
+                        buildArchive(26, Category.BLOG, "Transformer 구현기", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.BLOG, "데이터 전처리", Track.ANALYSIS, LocalDate.of(2026, 1, 2)),
+                        buildArchive(26, Category.BLOG, "Transformer 최적화", Track.ENGINEERING, LocalDate.of(2026, 1, 3))
+                );
+
+                Page<Archive> result = archiveRepository.searchArchives(
+                        Category.BLOG, null, null, "Transformer", PageRequest.of(0, 10));
+
+                assertThat(result.getTotalElements()).isEqualTo(2);
+                assertThat(result.getContent()).hasSize(2);
+            }
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ARC-004 findDistinctTermsOrdered 통합 테스트
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("ARC-004 findDistinctTermsOrdered 통합 테스트")
+    class FindDistinctTermsOrdered {
+
+        @Nested
+        @DisplayName("[그룹 A] DISTINCT")
+        class Distinct {
+
+            @Test
+            @DisplayName("TC-I-001 같은 term인 데이터가 여러 개인 경우, 한 번만 반환")
+            void dedup_same_term() {
+                saveAll(
+                        buildArchive(26, Category.BLOG, "A", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.BLOG, "B", Track.ENGINEERING, LocalDate.of(2026, 1, 2)),
+                        buildArchive(25, Category.BLOG, "C", Track.ENGINEERING, LocalDate.of(2025, 1, 1))
+                );
+
+                List<Integer> result = archiveRepository.findDistinctTermsOrdered();
+
+                assertThat(result).hasSize(2);
+                assertThat(result).containsExactly(26, 25);
+            }
+
+            @Test
+            @DisplayName("TC-I-002 여러 category에 같은 term이 있는 경우, 한 번만 반환")
+            void dedup_across_categories() {
+                saveAll(
+                        buildArchive(26, Category.PROJECT, "A", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.ACTIVITY, "B", Track.ALL, LocalDate.of(2026, 1, 1)),
+                        buildArchive(26, Category.BLOG, "C", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(25, Category.PROJECT, "D", Track.ENGINEERING, LocalDate.of(2025, 1, 1))
+                );
+
+                List<Integer> result = archiveRepository.findDistinctTermsOrdered();
+
+                assertThat(result).hasSize(2);
+                assertThat(result).containsExactly(26, 25);
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 B] 정렬")
+        class Sorting {
+
+            @Test
+            @DisplayName("TC-I-003 term DESC 정렬 → 최신 기수 먼저")
+            void term_desc() {
+                saveAll(
+                        buildArchive(24, Category.BLOG, "A", Track.ENGINEERING, LocalDate.of(2024, 1, 1)),
+                        buildArchive(26, Category.BLOG, "B", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(25, Category.BLOG, "C", Track.ENGINEERING, LocalDate.of(2025, 1, 1))
+                );
+
+                List<Integer> result = archiveRepository.findDistinctTermsOrdered();
+
+                assertThat(result).containsExactly(26, 25, 24);
+            }
+
+            @Test
+            @DisplayName("TC-I-004 term=0 인 경우, 맨 뒤 정렬")
+            void term_zero_last() {
+                saveAll(
+                        buildArchive(26, Category.BLOG, "A", Track.ENGINEERING, LocalDate.of(2026, 1, 1)),
+                        buildArchive(0, Category.BLOG, "B", Track.ENGINEERING, null),
+                        buildArchive(25, Category.BLOG, "C", Track.ENGINEERING, LocalDate.of(2025, 1, 1))
+                );
+
+                List<Integer> result = archiveRepository.findDistinctTermsOrdered();
+
+                assertThat(result).containsExactly(26, 25, 0);
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 C] 빈 결과")
+        class EmptyResult {
+
+            @Test
+            @DisplayName("TC-I-005 DB가 비어있는 경우, 빈 목록 반환")
+            void empty_db() {
+                List<Integer> result = archiveRepository.findDistinctTermsOrdered();
+
+                assertThat(result).isEmpty();
+            }
+        }
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/archive/service/ArchiveServiceTest.java
+++ b/src/test/java/com/boaz/backend/domain/archive/service/ArchiveServiceTest.java
@@ -1,0 +1,533 @@
+package com.boaz.backend.domain.archive.service;
+
+import com.boaz.backend.domain.archive.dto.response.ArchivePageResponse;
+import com.boaz.backend.domain.archive.dto.response.ArchiveTermsResponse;
+import com.boaz.backend.domain.archive.entity.Archive;
+import com.boaz.backend.domain.archive.entity.Archive.Category;
+import com.boaz.backend.domain.archive.repository.ArchiveRepository;
+import com.boaz.backend.global.common.enums.Track;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ArchiveServiceTest {
+
+    @InjectMocks ArchiveService archiveService;
+    @Mock ArchiveRepository archiveRepository;
+
+    private Archive buildArchive(int term, Category category, String title, Track track, LocalDate contentDate) {
+        return Archive.builder()
+                .term(term).category(category).title(title)
+                .track(track).imageUrl("http://img.example.com/test.jpg")
+                .links("{}").contentDate(contentDate)
+                .build();
+    }
+
+    private Page<Archive> emptyPage() {
+        return new PageImpl<>(List.of(), PageRequest.of(0, 6), 0L);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ARC-001 프로젝트 아카이빙 조회
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("ARC-001 프로젝트 아카이빙 조회")
+    class ProjectSearch {
+
+        @Nested
+        @DisplayName("[그룹 A] normalizeKeyword")
+        class NormalizeKeyword {
+
+            @Test
+            @DisplayName("TC-001 keyword=null → Repository에 null 전달")
+            void keyword_null() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.PROJECT, Track.ALL, null, null, 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.PROJECT), isNull(), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+
+            @Test
+            @DisplayName("TC-002 keyword=\"\" → null 정규화 후 Repository에 null 전달")
+            void keyword_empty() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.PROJECT, Track.ALL, null, "", 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.PROJECT), isNull(), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+
+            @Test
+            @DisplayName("TC-003 keyword 공백만 → null 정규화 후 Repository에 null 전달")
+            void keyword_blank() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.PROJECT, Track.ALL, null, "   ", 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.PROJECT), isNull(), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+
+            @Test
+            @DisplayName("TC-004 keyword 앞뒤 공백 → trim 후 Repository에 전달")
+            void keyword_trim() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.PROJECT, Track.ALL, null, "  딥러닝  ", 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.PROJECT), isNull(), isNull(), eq("딥러닝"), eq(PageRequest.of(0, 6)));
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 B] track 변환")
+        class TrackConversion {
+
+            @Test
+            @DisplayName("TC-005 track=ALL → null 변환 후 Repository에 전달")
+            void track_all_to_null() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.PROJECT, Track.ALL, null, null, 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.PROJECT), isNull(), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+
+            @Test
+            @DisplayName("TC-006 track=ENGINEERING → null 변환 없이 그대로 전달")
+            void track_specific() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.PROJECT, Track.ENGINEERING, null, null, 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.PROJECT), eq(Track.ENGINEERING), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 C] 페이지네이션 변환 + 응답 DTO 변환")
+        class PaginationConversion {
+
+            @Test
+            @DisplayName("TC-007 page=2, size=3 → 0기반 변환 + currentPage/totalSize 검증")
+            void pagination_conversion() {
+                Archive archive = buildArchive(26, Category.PROJECT, "실시간 추천 시스템", Track.ENGINEERING, LocalDate.of(2026, 1, 1));
+                Page<Archive> mockPage = new PageImpl<>(List.of(archive), PageRequest.of(1, 3), 7L);
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(mockPage);
+
+                ArchivePageResponse response = archiveService.searchArchives(Category.PROJECT, Track.ALL, null, null, 2, 3);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.PROJECT), isNull(), isNull(), isNull(), eq(PageRequest.of(1, 3)));
+                assertThat(response.getCurrentPage()).isEqualTo(2);
+                assertThat(response.getTotalSize()).isEqualTo(7L);
+                assertThat(response.isHasPrevious()).isTrue();
+                assertThat(response.isHasNext()).isTrue();
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 D] 예외")
+        class ValidationExceptions {
+
+            @Test
+            @DisplayName("TC-008 page=0 → INVALID_PAGINATION")
+            void page_zero() {
+                assertThatThrownBy(() -> archiveService.searchArchives(Category.PROJECT, Track.ALL, null, null, 0, 6))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode").isEqualTo(ErrorCode.INVALID_PAGINATION);
+            }
+
+            @Test
+            @DisplayName("TC-009 size=0 → INVALID_PAGINATION")
+            void size_zero() {
+                assertThatThrownBy(() -> archiveService.searchArchives(Category.PROJECT, Track.ALL, null, null, 1, 0))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode").isEqualTo(ErrorCode.INVALID_PAGINATION);
+            }
+
+            @Test
+            @DisplayName("TC-010 size=101 → INVALID_PAGINATION")
+            void size_over_max() {
+                assertThatThrownBy(() -> archiveService.searchArchives(Category.PROJECT, Track.ALL, null, null, 1, 101))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode").isEqualTo(ErrorCode.INVALID_PAGINATION);
+            }
+
+            @Test
+            @DisplayName("TC-011 term=-1 → INVALID_PARAMETER_TYPE")
+            void term_negative() {
+                assertThatThrownBy(() -> archiveService.searchArchives(Category.PROJECT, Track.ALL, -1, null, 1, 6))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode").isEqualTo(ErrorCode.INVALID_PARAMETER_TYPE);
+            }
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ARC-002 활동사진 아카이빙 조회
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("ARC-002 활동사진 아카이빙 조회")
+    class ActivitySearch {
+
+        @Nested
+        @DisplayName("[그룹 A] normalizeKeyword")
+        class NormalizeKeyword {
+
+            @Test
+            @DisplayName("TC-001 keyword=null → Repository에 null 전달")
+            void keyword_null() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.ACTIVITY, null, null, null, 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.ACTIVITY), isNull(), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+
+            @Test
+            @DisplayName("TC-002 keyword=\"\" → null 정규화 후 Repository에 null 전달")
+            void keyword_empty() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.ACTIVITY, null, null, "", 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.ACTIVITY), isNull(), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+
+            @Test
+            @DisplayName("TC-003 keyword 공백만 → null 정규화 후 Repository에 null 전달")
+            void keyword_blank() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.ACTIVITY, null, null, "   ", 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.ACTIVITY), isNull(), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+
+            @Test
+            @DisplayName("TC-004 keyword 앞뒤 공백 → trim 후 Repository에 전달")
+            void keyword_trim() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.ACTIVITY, null, null, "  활동사진  ", 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.ACTIVITY), isNull(), isNull(), eq("활동사진"), eq(PageRequest.of(0, 6)));
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 B] track 고정 null 확인")
+        class TrackFixedNull {
+
+            @Test
+            @DisplayName("TC-005 컨트롤러가 null 하드코딩 → null 그대로 Repository에 전달")
+            void track_fixed_null() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.ACTIVITY, null, null, null, 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.ACTIVITY), isNull(), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 C] 페이지네이션 변환 + 응답 DTO 변환")
+        class PaginationConversion {
+
+            @Test
+            @DisplayName("TC-006 page=2, size=3 → 0기반 변환 + currentPage/totalSize 검증")
+            void pagination_conversion() {
+                Archive archive = buildArchive(26, Category.ACTIVITY, "26기 워크샵 활동", Track.ALL, LocalDate.of(2026, 1, 1));
+                Page<Archive> mockPage = new PageImpl<>(List.of(archive), PageRequest.of(1, 3), 7L);
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(mockPage);
+
+                ArchivePageResponse response = archiveService.searchArchives(Category.ACTIVITY, null, null, null, 2, 3);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.ACTIVITY), isNull(), isNull(), isNull(), eq(PageRequest.of(1, 3)));
+                assertThat(response.getCurrentPage()).isEqualTo(2);
+                assertThat(response.getTotalSize()).isEqualTo(7L);
+                assertThat(response.isHasPrevious()).isTrue();
+                assertThat(response.isHasNext()).isTrue();
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 D] 예외")
+        class ValidationExceptions {
+
+            @Test
+            @DisplayName("TC-007 page=0 → INVALID_PAGINATION")
+            void page_zero() {
+                assertThatThrownBy(() -> archiveService.searchArchives(Category.ACTIVITY, null, null, null, 0, 6))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode").isEqualTo(ErrorCode.INVALID_PAGINATION);
+            }
+
+            @Test
+            @DisplayName("TC-008 size=0 → INVALID_PAGINATION")
+            void size_zero() {
+                assertThatThrownBy(() -> archiveService.searchArchives(Category.ACTIVITY, null, null, null, 1, 0))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode").isEqualTo(ErrorCode.INVALID_PAGINATION);
+            }
+
+            @Test
+            @DisplayName("TC-009 size=101 → INVALID_PAGINATION")
+            void size_over_max() {
+                assertThatThrownBy(() -> archiveService.searchArchives(Category.ACTIVITY, null, null, null, 1, 101))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode").isEqualTo(ErrorCode.INVALID_PAGINATION);
+            }
+
+            @Test
+            @DisplayName("TC-010 term=-1 → INVALID_PARAMETER_TYPE")
+            void term_negative() {
+                assertThatThrownBy(() -> archiveService.searchArchives(Category.ACTIVITY, null, -1, null, 1, 6))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode").isEqualTo(ErrorCode.INVALID_PARAMETER_TYPE);
+            }
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ARC-003 기술블로그 아카이빙 조회
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("ARC-003 기술블로그 아카이빙 조회")
+    class BlogSearch {
+
+        @Nested
+        @DisplayName("[그룹 A] normalizeKeyword")
+        class NormalizeKeyword {
+
+            @Test
+            @DisplayName("TC-001 keyword=null → Repository에 null 전달")
+            void keyword_null() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.BLOG, Track.ALL, null, null, 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.BLOG), isNull(), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+
+            @Test
+            @DisplayName("TC-002 keyword=\"\" → null 정규화 후 Repository에 null 전달")
+            void keyword_empty() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.BLOG, Track.ALL, null, "", 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.BLOG), isNull(), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+
+            @Test
+            @DisplayName("TC-003 keyword 공백만 → null 정규화 후 Repository에 null 전달")
+            void keyword_blank() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.BLOG, Track.ALL, null, "   ", 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.BLOG), isNull(), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+
+            @Test
+            @DisplayName("TC-004 keyword 앞뒤 공백 → trim 후 Repository에 전달")
+            void keyword_trim() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.BLOG, Track.ALL, null, "   딥러닝  ", 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.BLOG), isNull(), isNull(), eq("딥러닝"), eq(PageRequest.of(0, 6)));
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 B] track 변환")
+        class TrackConversion {
+
+            @Test
+            @DisplayName("TC-005 track=ALL → null 변환 후 Repository에 전달")
+            void track_all_to_null() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.BLOG, Track.ALL, null, null, 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.BLOG), isNull(), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+
+            @Test
+            @DisplayName("TC-006 track=ENGINEERING → null 변환 없이 그대로 전달")
+            void track_specific() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.BLOG, Track.ENGINEERING, null, null, 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.BLOG), eq(Track.ENGINEERING), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 C] term null 고정 확인")
+        class TermFixedNull {
+
+            @Test
+            @DisplayName("TC-007 컨트롤러가 null 하드코딩 → null 그대로 Repository에 전달")
+            void term_fixed_null() {
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(emptyPage());
+
+                archiveService.searchArchives(Category.BLOG, Track.ALL, null, null, 1, 6);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.BLOG), isNull(), isNull(), isNull(), eq(PageRequest.of(0, 6)));
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 D] 페이지네이션 변환 + 응답 DTO 변환")
+        class PaginationConversion {
+
+            @Test
+            @DisplayName("TC-008 page=2, size=3 → 0기반 변환 + currentPage/totalSize 검증")
+            void pagination_conversion() {
+                Archive archive = buildArchive(26, Category.BLOG, "Transformer 모델 구현기", Track.ENGINEERING, LocalDate.of(2026, 1, 1));
+                Page<Archive> mockPage = new PageImpl<>(List.of(archive), PageRequest.of(1, 3), 7L);
+                when(archiveRepository.searchArchives(any(), any(), any(), any(), any())).thenReturn(mockPage);
+
+                ArchivePageResponse response = archiveService.searchArchives(Category.BLOG, Track.ALL, null, null, 2, 3);
+
+                verify(archiveRepository).searchArchives(
+                        eq(Category.BLOG), isNull(), isNull(), isNull(), eq(PageRequest.of(1, 3)));
+                assertThat(response.getCurrentPage()).isEqualTo(2);
+                assertThat(response.getTotalSize()).isEqualTo(7L);
+                assertThat(response.isHasPrevious()).isTrue();
+                assertThat(response.isHasNext()).isTrue();
+            }
+        }
+
+        @Nested
+        @DisplayName("[그룹 E] 예외")
+        class ValidationExceptions {
+
+            @Test
+            @DisplayName("TC-009 page=0 → INVALID_PAGINATION")
+            void page_zero() {
+                assertThatThrownBy(() -> archiveService.searchArchives(Category.BLOG, Track.ALL, null, null, 0, 6))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode").isEqualTo(ErrorCode.INVALID_PAGINATION);
+            }
+
+            @Test
+            @DisplayName("TC-010 size=0 → INVALID_PAGINATION")
+            void size_zero() {
+                assertThatThrownBy(() -> archiveService.searchArchives(Category.BLOG, Track.ALL, null, null, 1, 0))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode").isEqualTo(ErrorCode.INVALID_PAGINATION);
+            }
+
+            @Test
+            @DisplayName("TC-011 size=101 → INVALID_PAGINATION")
+            void size_over_max() {
+                assertThatThrownBy(() -> archiveService.searchArchives(Category.BLOG, Track.ALL, null, null, 1, 101))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode").isEqualTo(ErrorCode.INVALID_PAGINATION);
+            }
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ARC-004 기수 목록 조회
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("ARC-004 기수 목록 조회")
+    class GetTermsTest {
+
+        @Nested
+        @DisplayName("[그룹 A] DTO 변환 + Repository 위임")
+        class TermLabelConversion {
+
+            @Test
+            @DisplayName("TC-001 term 목록 조회 시 value/label 변환 (N기)")
+            void term_label_general() {
+                when(archiveRepository.findDistinctTermsOrdered()).thenReturn(List.of(26, 25, 24));
+
+                ArchiveTermsResponse response = archiveService.getTerms();
+
+                verify(archiveRepository).findDistinctTermsOrdered();
+                assertThat(response.terms()).hasSize(3);
+                assertThat(response.terms().get(0).value()).isEqualTo(26);
+                assertThat(response.terms().get(0).label()).isEqualTo("26기");
+                assertThat(response.terms().get(1).value()).isEqualTo(25);
+                assertThat(response.terms().get(2).value()).isEqualTo(24);
+            }
+
+            @Test
+            @DisplayName("TC-002 term=0 → label \"7기 이전\" 변환")
+            void term_zero_label() {
+                when(archiveRepository.findDistinctTermsOrdered()).thenReturn(List.of(26, 25, 0));
+
+                ArchiveTermsResponse response = archiveService.getTerms();
+
+                assertThat(response.terms().get(2).value()).isEqualTo(0);
+                assertThat(response.terms().get(2).label()).isEqualTo("7기 이전");
+            }
+
+            @Test
+            @DisplayName("TC-003 term 일반값 → label \"N기\" 변환")
+            void term_general_label() {
+                when(archiveRepository.findDistinctTermsOrdered()).thenReturn(List.of(26));
+
+                ArchiveTermsResponse response = archiveService.getTerms();
+
+                assertThat(response.terms().get(0).value()).isEqualTo(26);
+                assertThat(response.terms().get(0).label()).isEqualTo("26기");
+            }
+
+            @Test
+            @DisplayName("TC-004 DB에 데이터 없음 → 빈 terms 반환")
+            void empty_terms() {
+                when(archiveRepository.findDistinctTermsOrdered()).thenReturn(List.of());
+
+                ArchiveTermsResponse response = archiveService.getTerms();
+
+                assertThat(response.terms()).isEmpty();
+            }
+        }
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/auth/controller/UserAuthControllerTest.java
+++ b/src/test/java/com/boaz/backend/domain/auth/controller/UserAuthControllerTest.java
@@ -1,0 +1,103 @@
+package com.boaz.backend.domain.auth.controller;
+
+import com.boaz.backend.domain.auth.dto.response.TokenRefreshResponse;
+import com.boaz.backend.domain.auth.service.AuthService;
+import com.boaz.backend.global.security.UserPrincipal;
+import com.boaz.backend.global.util.CookieProvider;
+import com.boaz.backend.support.TestSecurityConfig;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ActiveProfiles("test")
+@WebMvcTest(
+        value = UserAuthController.class,
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class}
+)
+@Import(TestSecurityConfig.class)
+class UserAuthControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @MockitoBean AuthService authService;
+    @MockitoBean CookieProvider cookieProvider;
+
+    private UsernamePasswordAuthenticationToken userAuth() {
+        return new UsernamePasswordAuthenticationToken(
+                new UserPrincipal(1L), null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // AUTH-006 POST /api/v1/auth/user/logout
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("AUTH-006 POST /api/v1/auth/user/logout")
+    class Logout {
+
+        @Test
+        @DisplayName("TC-003 유효한 Access Token → 200 OK + 쿠키 만료 처리")
+        void logout_success() throws Exception {
+            doNothing().when(authService).userLogout(1L);
+            doNothing().when(cookieProvider).expireUserRefreshTokenCookie(any());
+
+            mockMvc.perform(post("/api/v1/auth/user/logout")
+                            .with(authentication(userAuth())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data").doesNotExist());
+
+            verify(authService).userLogout(1L);
+            verify(cookieProvider).expireUserRefreshTokenCookie(any());
+        }
+
+        @Test
+        @DisplayName("TC-004 인증 없이 접근 → 401")
+        void logout_unauthorized() throws Exception {
+            mockMvc.perform(post("/api/v1/auth/user/logout"))
+                    .andExpect(status().isUnauthorized());
+
+            verify(authService, never()).userLogout(anyLong());
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // AUTH-005 POST /api/v1/auth/user/refresh
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("AUTH-005 POST /api/v1/auth/user/refresh")
+    class Refresh {
+
+        @Test
+        @DisplayName("유효한 쿠키 → 200 OK + 새 Access Token 반환")
+        void refresh_success() throws Exception {
+            when(authService.userRefresh("valid-refresh-token"))
+                    .thenReturn(new TokenRefreshResponse("new-access-token"));
+
+            mockMvc.perform(post("/api/v1/auth/user/refresh")
+                            .cookie(new Cookie("user_refresh_token", "valid-refresh-token")))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.access_token").value("new-access-token"));
+        }
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/boaz/backend/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,188 @@
+package com.boaz.backend.domain.auth.service;
+
+import com.boaz.backend.domain.auth.dto.response.TokenRefreshResponse;
+import com.boaz.backend.domain.auth.entity.RefreshToken;
+import com.boaz.backend.domain.auth.repository.RefreshTokenRepository;
+import com.boaz.backend.domain.admin.repository.AdminRepository;
+import com.boaz.backend.global.common.enums.AccountType;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import com.boaz.backend.global.security.JwtProvider;
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @InjectMocks AuthService authService;
+
+    @Mock AdminRepository adminRepository;
+    @Mock RefreshTokenRepository refreshTokenRepository;
+    @Mock JwtProvider jwtProvider;
+    @Mock PasswordEncoder passwordEncoder;
+
+    private RefreshToken buildRefreshToken(String token) {
+        return RefreshToken.builder()
+                .accountType(AccountType.USER)
+                .accountId(1L)
+                .token(token)
+                .expiresAt(LocalDateTime.now().plusDays(7))
+                .build();
+    }
+
+    private Claims stubClaims(String subject) {
+        Claims claims = mock(Claims.class);
+        lenient().when(claims.getSubject()).thenReturn(subject);
+        return claims;
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // AUTH-005 사용자 토큰 갱신 - userRefresh
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("AUTH-005 userRefresh")
+    class UserRefresh {
+
+        @Test
+        @DisplayName("TC-001 유효한 Refresh Token 쿠키 → 새 Access Token 반환")
+        void valid_refresh_token() {
+            RefreshToken saved = buildRefreshToken("valid-refresh-token");
+            Claims claims = stubClaims("1");
+            doNothing().when(jwtProvider).validateToken("valid-refresh-token");
+            when(jwtProvider.parseClaims("valid-refresh-token")).thenReturn(claims);
+            when(refreshTokenRepository.findByAccountTypeAndAccountId(AccountType.USER, 1L))
+                    .thenReturn(Optional.of(saved));
+            when(jwtProvider.generateUserAccessToken(1L)).thenReturn("new-access-token");
+
+            TokenRefreshResponse response = authService.userRefresh("valid-refresh-token");
+
+            verify(jwtProvider).validateToken("valid-refresh-token");
+            verify(jwtProvider).parseClaims("valid-refresh-token");
+            verify(refreshTokenRepository).findByAccountTypeAndAccountId(AccountType.USER, 1L);
+            verify(jwtProvider).generateUserAccessToken(1L);
+            assertThat(response.getAccessToken()).isEqualTo("new-access-token");
+        }
+
+        @Test
+        @DisplayName("TC-002 쿠키가 null → TOKEN_NOT_FOUND")
+        void cookie_null() {
+            assertThatThrownBy(() -> authService.userRefresh(null))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.TOKEN_NOT_FOUND);
+
+            verify(jwtProvider, never()).validateToken(any());
+        }
+
+        @Test
+        @DisplayName("TC-003 쿠키가 공백 → TOKEN_NOT_FOUND")
+        void cookie_blank() {
+            assertThatThrownBy(() -> authService.userRefresh("   "))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.TOKEN_NOT_FOUND);
+
+            verify(jwtProvider, never()).validateToken(any());
+        }
+
+        @Test
+        @DisplayName("TC-004 만료된 Refresh Token → EXPIRED_TOKEN")
+        void expired_token() {
+            doThrow(new CustomException(ErrorCode.EXPIRED_TOKEN))
+                    .when(jwtProvider).validateToken("expired-refresh-token");
+
+            assertThatThrownBy(() -> authService.userRefresh("expired-refresh-token"))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.EXPIRED_TOKEN);
+
+            verify(jwtProvider).validateToken("expired-refresh-token");
+            verify(refreshTokenRepository, never()).findByAccountTypeAndAccountId(any(), any());
+        }
+
+        @Test
+        @DisplayName("TC-005 위조된 Refresh Token → INVALID_TOKEN")
+        void forged_token() {
+            doThrow(new CustomException(ErrorCode.INVALID_TOKEN))
+                    .when(jwtProvider).validateToken("forged-refresh-token");
+
+            assertThatThrownBy(() -> authService.userRefresh("forged-refresh-token"))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.INVALID_TOKEN);
+
+            verify(refreshTokenRepository, never()).findByAccountTypeAndAccountId(any(), any());
+        }
+
+        @Test
+        @DisplayName("TC-006 DB에 Refresh Token 없음 → INVALID_TOKEN")
+        void no_db_token() {
+            Claims claims = stubClaims("1");
+            doNothing().when(jwtProvider).validateToken("valid-refresh-token");
+            when(jwtProvider.parseClaims("valid-refresh-token")).thenReturn(claims);
+            when(refreshTokenRepository.findByAccountTypeAndAccountId(AccountType.USER, 1L))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> authService.userRefresh("valid-refresh-token"))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.INVALID_TOKEN);
+
+            verify(jwtProvider, never()).generateUserAccessToken(any());
+        }
+
+        @Test
+        @DisplayName("TC-007 DB 토큰과 쿠키 토큰 불일치 → INVALID_TOKEN")
+        void token_mismatch() {
+            RefreshToken saved = buildRefreshToken("new-refresh-token");
+            Claims claims = stubClaims("1");
+            doNothing().when(jwtProvider).validateToken("old-refresh-token");
+            when(jwtProvider.parseClaims("old-refresh-token")).thenReturn(claims);
+            when(refreshTokenRepository.findByAccountTypeAndAccountId(AccountType.USER, 1L))
+                    .thenReturn(Optional.of(saved));
+
+            assertThatThrownBy(() -> authService.userRefresh("old-refresh-token"))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.INVALID_TOKEN);
+
+            verify(jwtProvider, never()).generateUserAccessToken(any());
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // AUTH-006 사용자 로그아웃 - userLogout
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("AUTH-006 userLogout")
+    class UserLogout {
+
+        @Test
+        @DisplayName("TC-001 로그아웃 → DB Refresh Token 삭제")
+        void logout_deletes_refresh_token() {
+            authService.userLogout(1L);
+
+            verify(refreshTokenRepository).deleteByAccountTypeAndAccountId(AccountType.USER, 1L);
+        }
+
+        @Test
+        @DisplayName("TC-002 이미 로그아웃 상태 (DB에 토큰 없음) → 예외 없이 정상 처리")
+        void logout_already_logged_out() {
+            doNothing().when(refreshTokenRepository)
+                    .deleteByAccountTypeAndAccountId(AccountType.USER, 1L);
+
+            authService.userLogout(1L);
+
+            verify(refreshTokenRepository).deleteByAccountTypeAndAccountId(AccountType.USER, 1L);
+        }
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/boaz/backend/domain/user/service/UserServiceTest.java
@@ -6,7 +6,9 @@ import com.boaz.backend.domain.user.repository.UserRepository;
 import com.boaz.backend.global.common.enums.MemberType;
 import com.boaz.backend.global.exception.CustomException;
 import com.boaz.backend.global.exception.ErrorCode;
+import com.boaz.backend.global.oauth.OAuth2UserInfo;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -18,7 +20,9 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -56,5 +60,72 @@ class UserServiceTest {
                 .isInstanceOf(CustomException.class)
                 .extracting(e -> ((CustomException) e).getErrorCode())
                 .isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // AUTH-004 findOrCreate
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("AUTH-004 findOrCreate")
+    class FindOrCreate {
+
+        private OAuth2UserInfo mockUserInfo(String provider, String providerId, String nickname) {
+            OAuth2UserInfo info = mock(OAuth2UserInfo.class);
+            when(info.getProvider()).thenReturn(provider);
+            when(info.getProviderId()).thenReturn(providerId);
+            lenient().when(info.getNickname()).thenReturn(nickname);
+            return info;
+        }
+
+        @Test
+        @DisplayName("TC-001 최초 로그인 → User OUTSIDER로 신규 저장 후 반환")
+        void first_login_creates_user() {
+            OAuth2UserInfo userInfo = mockUserInfo("kakao", "12345", "보아즈");
+            when(userRepository.findByProviderAndProviderId("kakao", "12345"))
+                    .thenReturn(Optional.empty());
+            User saved = User.builder().provider("kakao").providerId("12345")
+                    .nickname("보아즈").memberType(MemberType.OUTSIDER).build();
+            when(userRepository.save(any())).thenReturn(saved);
+
+            User result = userService.findOrCreate(userInfo);
+
+            verify(userRepository).findByProviderAndProviderId("kakao", "12345");
+            verify(userRepository).save(argThat(u ->
+                    u.getProvider().equals("kakao") &&
+                    u.getProviderId().equals("12345") &&
+                    u.getMemberType() == MemberType.OUTSIDER));
+            assertThat(result.getMemberType()).isEqualTo(MemberType.OUTSIDER);
+        }
+
+        @Test
+        @DisplayName("TC-002 재로그인 → 기존 User 반환, save 미호출")
+        void re_login_returns_existing_user() {
+            User existingUser = createUser(1L, "보아즈");
+            OAuth2UserInfo userInfo = mockUserInfo("kakao", "12345", null);
+            when(userRepository.findByProviderAndProviderId("kakao", "12345"))
+                    .thenReturn(Optional.of(existingUser));
+
+            User result = userService.findOrCreate(userInfo);
+
+            verify(userRepository).findByProviderAndProviderId("kakao", "12345");
+            verify(userRepository, never()).save(any());
+            assertThat(result).isEqualTo(existingUser);
+        }
+
+        @Test
+        @DisplayName("TC-003 같은 providerId라도 provider가 다르면 별도 User 생성")
+        void different_provider_creates_new_user() {
+            OAuth2UserInfo userInfo = mockUserInfo("google", "12345", "보아즈");
+            when(userRepository.findByProviderAndProviderId("google", "12345"))
+                    .thenReturn(Optional.empty());
+            User saved = User.builder().provider("google").providerId("12345")
+                    .nickname("보아즈").memberType(MemberType.OUTSIDER).build();
+            when(userRepository.save(any())).thenReturn(saved);
+
+            userService.findOrCreate(userInfo);
+
+            verify(userRepository).findByProviderAndProviderId("google", "12345");
+            verify(userRepository).save(argThat(u -> u.getProvider().equals("google")));
+        }
     }
 }

--- a/src/test/java/com/boaz/backend/global/oauth/CustomOAuth2UserServiceTest.java
+++ b/src/test/java/com/boaz/backend/global/oauth/CustomOAuth2UserServiceTest.java
@@ -1,0 +1,118 @@
+package com.boaz.backend.global.oauth;
+
+import com.boaz.backend.domain.user.entity.User;
+import com.boaz.backend.domain.user.service.UserService;
+import com.boaz.backend.global.common.enums.MemberType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CustomOAuth2UserServiceTest {
+
+    @Mock UserService userService;
+
+    CustomOAuth2UserService customOAuth2UserService;
+
+    @BeforeEach
+    void setUp() {
+        customOAuth2UserService = spy(new CustomOAuth2UserService(userService));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // TC-004 provider=kakao
+    // ──────────────────────────────────────────────────────────────────────────
+    @Test
+    @DisplayName("TC-004 provider=kakao → KakaoOAuth2UserInfo 생성 후 findOrCreate() 호출")
+    void kakao_provider_calls_find_or_create() {
+        Map<String, Object> attributes = Map.of("id", 12345L,
+                "kakao_account", Map.of("profile", Map.of("nickname", "보아즈")));
+
+        OAuth2UserInfo info = (OAuth2UserInfo) ReflectionTestUtils.invokeMethod(
+                customOAuth2UserService, "createUserInfo", "kakao", attributes);
+
+        assertThat(info).isInstanceOf(KakaoOAuth2UserInfo.class);
+        assertThat(info.getProvider()).isEqualTo("kakao");
+        assertThat(info.getProviderId()).isEqualTo("12345");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // TC-005 provider=google
+    // ──────────────────────────────────────────────────────────────────────────
+    @Test
+    @DisplayName("TC-005 provider=google → GoogleOAuth2UserInfo 생성 후 findOrCreate() 호출")
+    void google_provider_creates_google_user_info() {
+        Map<String, Object> attributes = Map.of("sub", "google-uid-001", "name", "김보아즈");
+
+        OAuth2UserInfo info = (OAuth2UserInfo) ReflectionTestUtils.invokeMethod(
+                customOAuth2UserService, "createUserInfo", "google", attributes);
+
+        assertThat(info).isInstanceOf(GoogleOAuth2UserInfo.class);
+        assertThat(info.getProvider()).isEqualTo("google");
+        assertThat(info.getProviderId()).isEqualTo("google-uid-001");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // TC-006 provider=naver
+    // ──────────────────────────────────────────────────────────────────────────
+    @Test
+    @DisplayName("TC-006 provider=naver → NaverOAuth2UserInfo 생성 후 findOrCreate() 호출")
+    void naver_provider_creates_naver_user_info() {
+        Map<String, Object> attributes = Map.of("response",
+                Map.of("id", "naver-uid-001", "name", "이보아즈"));
+
+        OAuth2UserInfo info = (OAuth2UserInfo) ReflectionTestUtils.invokeMethod(
+                customOAuth2UserService, "createUserInfo", "naver", attributes);
+
+        assertThat(info).isInstanceOf(NaverOAuth2UserInfo.class);
+        assertThat(info.getProvider()).isEqualTo("naver");
+        assertThat(info.getProviderId()).isEqualTo("naver-uid-001");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // TC-007 지원하지 않는 provider
+    // ──────────────────────────────────────────────────────────────────────────
+    @Test
+    @DisplayName("TC-007 지원하지 않는 provider → OAuth2AuthenticationException")
+    void unsupported_provider_throws() {
+        assertThatThrownBy(() ->
+                ReflectionTestUtils.invokeMethod(
+                        customOAuth2UserService, "createUserInfo", "facebook", Map.of()))
+                .isInstanceOf(OAuth2AuthenticationException.class)
+                .satisfies(e -> assertThat(
+                        ((OAuth2AuthenticationException) e).getError().getErrorCode())
+                        .contains("Unsupported provider"));
+
+        verify(userService, never()).findOrCreate(any());
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // TC-008 providerId=null
+    // ──────────────────────────────────────────────────────────────────────────
+    @Test
+    @DisplayName("TC-008 providerId=null → getProviderId() null 반환 확인")
+    void null_provider_id_from_kakao() {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("id", null);
+
+        OAuth2UserInfo info = (OAuth2UserInfo) ReflectionTestUtils.invokeMethod(
+                customOAuth2UserService, "createUserInfo", "kakao", attributes);
+
+        assertThat(info.getProviderId()).isNull();
+    }
+}

--- a/src/test/java/com/boaz/backend/global/oauth/OAuth2AuthenticationFailureHandlerTest.java
+++ b/src/test/java/com/boaz/backend/global/oauth/OAuth2AuthenticationFailureHandlerTest.java
@@ -1,0 +1,88 @@
+package com.boaz.backend.global.oauth;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import jakarta.servlet.http.Cookie;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class OAuth2AuthenticationFailureHandlerTest {
+
+    OAuth2AuthenticationFailureHandler handler;
+
+    private static final String DEFAULT_FAILURE_URI = "http://localhost:3000/login?error=true";
+    private static final String ALLOWED_REDIRECT = "http://localhost:3000/auth/callback";
+
+    @BeforeEach
+    void setUp() {
+        handler = new OAuth2AuthenticationFailureHandler();
+        ReflectionTestUtils.setField(handler, "defaultFailureRedirectUri", DEFAULT_FAILURE_URI);
+        ReflectionTestUtils.setField(handler, "allowedRedirectUris", List.of(ALLOWED_REDIRECT));
+    }
+
+    private String encodeRedirectUri(String uri) {
+        return Base64.getUrlEncoder().encodeToString(uri.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private MockHttpServletRequest requestWithRedirectCookie(String uri) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("oauth2_redirect_uri", encodeRedirectUri(uri)));
+        return request;
+    }
+
+    private AuthenticationException authException() {
+        return mock(AuthenticationException.class);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // TC-024 허용된 redirect URI 쿠키 있는 경우
+    // ──────────────────────────────────────────────────────────────────────────
+    @Test
+    @DisplayName("TC-024 허용된 redirect URI 쿠키 → {scheme}://{authority}/login?error=true 리다이렉트")
+    void allowed_redirect_uri_redirects_to_login_error() throws Exception {
+        MockHttpServletRequest request = requestWithRedirectCookie(ALLOWED_REDIRECT);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        handler.onAuthenticationFailure(request, response, authException());
+
+        assertThat(response.getRedirectedUrl())
+                .isEqualTo("http://localhost:3000/login?error=true");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // TC-025 redirect URI 쿠키 없는 경우
+    // ──────────────────────────────────────────────────────────────────────────
+    @Test
+    @DisplayName("TC-025 redirect URI 쿠키 없음 → defaultFailureRedirectUri로 리다이렉트")
+    void no_cookie_uses_default_failure_redirect() throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        handler.onAuthenticationFailure(new MockHttpServletRequest(), response, authException());
+
+        assertThat(response.getRedirectedUrl()).isEqualTo(DEFAULT_FAILURE_URI);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // TC-026 비허용 redirect URI
+    // ──────────────────────────────────────────────────────────────────────────
+    @Test
+    @DisplayName("TC-026 허용되지 않은 redirect URI → defaultFailureRedirectUri로 리다이렉트")
+    void disallowed_redirect_uri_uses_default_failure() throws Exception {
+        MockHttpServletRequest request = requestWithRedirectCookie("http://evil.com/callback");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        handler.onAuthenticationFailure(request, response, authException());
+
+        assertThat(response.getRedirectedUrl()).isEqualTo(DEFAULT_FAILURE_URI);
+    }
+}

--- a/src/test/java/com/boaz/backend/global/oauth/OAuth2AuthenticationSuccessHandlerTest.java
+++ b/src/test/java/com/boaz/backend/global/oauth/OAuth2AuthenticationSuccessHandlerTest.java
@@ -1,0 +1,192 @@
+package com.boaz.backend.global.oauth;
+
+import com.boaz.backend.domain.auth.entity.RefreshToken;
+import com.boaz.backend.domain.auth.repository.RefreshTokenRepository;
+import com.boaz.backend.domain.user.entity.User;
+import com.boaz.backend.global.common.enums.AccountType;
+import com.boaz.backend.global.common.enums.MemberType;
+import com.boaz.backend.global.security.JwtProvider;
+import com.boaz.backend.global.util.CookieProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import jakarta.servlet.http.Cookie;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OAuth2AuthenticationSuccessHandlerTest {
+
+    @Mock JwtProvider jwtProvider;
+    @Mock RefreshTokenRepository refreshTokenRepository;
+    @Mock CookieProvider cookieProvider;
+    @Mock Authentication authentication;
+
+    OAuth2AuthenticationSuccessHandler handler;
+
+    private static final String DEFAULT_REDIRECT = "http://localhost:3000/auth/callback";
+    private static final String ALLOWED_REDIRECT = "http://localhost:3000/auth/callback";
+
+    @BeforeEach
+    void setUp() {
+        handler = new OAuth2AuthenticationSuccessHandler(jwtProvider, refreshTokenRepository, cookieProvider);
+        ReflectionTestUtils.setField(handler, "defaultRedirectUri", DEFAULT_REDIRECT);
+        ReflectionTestUtils.setField(handler, "allowedRedirectUris", List.of(ALLOWED_REDIRECT));
+    }
+
+    private User buildUser(Long id) {
+        User user = User.builder()
+                .provider("kakao").providerId("12345").nickname("보아즈")
+                .memberType(MemberType.OUTSIDER).build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private OAuth2UserAdapter buildAdapter(User user) {
+        org.springframework.security.oauth2.core.user.OAuth2User delegate =
+                mock(org.springframework.security.oauth2.core.user.OAuth2User.class);
+        return new OAuth2UserAdapter(delegate, user);
+    }
+
+    private String encodeRedirectUri(String uri) {
+        return Base64.getUrlEncoder().encodeToString(uri.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private MockHttpServletRequest requestWithRedirectCookie(String uri) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("oauth2_redirect_uri", encodeRedirectUri(uri)));
+        return request;
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // TC-019 최초 로그인 - RefreshToken 신규 저장
+    // ──────────────────────────────────────────────────────────────────────────
+    @Test
+    @DisplayName("TC-019 최초 로그인 → RefreshToken 신규 저장 + AccessToken 발급 + 쿠키 세팅")
+    void first_login_saves_refresh_token() throws Exception {
+        User user = buildUser(1L);
+        when(authentication.getPrincipal()).thenReturn(buildAdapter(user));
+        when(jwtProvider.generateUserAccessToken(1L)).thenReturn("access-token");
+        when(jwtProvider.generateUserRefreshToken(1L)).thenReturn("refresh-token");
+        when(jwtProvider.getRefreshTokenExpiry()).thenReturn(LocalDateTime.now().plusDays(7));
+        when(refreshTokenRepository.findByAccountTypeAndAccountId(AccountType.USER, 1L))
+                .thenReturn(Optional.empty());
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        handler.onAuthenticationSuccess(new MockHttpServletRequest(), response, authentication);
+
+        verify(refreshTokenRepository).save(argThat(rt ->
+                rt.getAccountType() == AccountType.USER &&
+                rt.getAccountId().equals(1L) &&
+                rt.getToken().equals("refresh-token")));
+        verify(cookieProvider).addUserRefreshTokenCookie(any(), eq("refresh-token"));
+        assertThat(response.getRedirectedUrl()).contains("#token=access-token");
+        assertThat(response.getRedirectedUrl()).startsWith(DEFAULT_REDIRECT);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // TC-020 재로그인 - RefreshToken 업데이트
+    // ──────────────────────────────────────────────────────────────────────────
+    @Test
+    @DisplayName("TC-020 재로그인 → 기존 RefreshToken 업데이트 (save 없이 더티체킹)")
+    void re_login_updates_refresh_token() throws Exception {
+        User user = buildUser(1L);
+        when(authentication.getPrincipal()).thenReturn(buildAdapter(user));
+        when(jwtProvider.generateUserAccessToken(1L)).thenReturn("access-token");
+        when(jwtProvider.generateUserRefreshToken(1L)).thenReturn("new-refresh-token");
+        when(jwtProvider.getRefreshTokenExpiry()).thenReturn(LocalDateTime.now().plusDays(7));
+
+        RefreshToken existingToken = spy(RefreshToken.builder()
+                .accountType(AccountType.USER).accountId(1L)
+                .token("old-refresh-token")
+                .expiresAt(LocalDateTime.now().plusDays(7)).build());
+        when(refreshTokenRepository.findByAccountTypeAndAccountId(AccountType.USER, 1L))
+                .thenReturn(Optional.of(existingToken));
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        handler.onAuthenticationSuccess(new MockHttpServletRequest(), response, authentication);
+
+        verify(refreshTokenRepository, never()).save(any());
+        verify(existingToken).update(eq("new-refresh-token"), any());
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // TC-021 허용된 redirect URI 쿠키 있는 경우
+    // ──────────────────────────────────────────────────────────────────────────
+    @Test
+    @DisplayName("TC-021 허용된 redirect URI 쿠키 → 해당 URI로 리다이렉트")
+    void allowed_redirect_uri_is_used() throws Exception {
+        User user = buildUser(1L);
+        when(authentication.getPrincipal()).thenReturn(buildAdapter(user));
+        when(jwtProvider.generateUserAccessToken(1L)).thenReturn("access-token");
+        when(jwtProvider.generateUserRefreshToken(1L)).thenReturn("refresh-token");
+        when(jwtProvider.getRefreshTokenExpiry()).thenReturn(LocalDateTime.now().plusDays(7));
+        when(refreshTokenRepository.findByAccountTypeAndAccountId(AccountType.USER, 1L))
+                .thenReturn(Optional.empty());
+
+        MockHttpServletRequest request = requestWithRedirectCookie(ALLOWED_REDIRECT);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        handler.onAuthenticationSuccess(request, response, authentication);
+
+        assertThat(response.getRedirectedUrl())
+                .isEqualTo(ALLOWED_REDIRECT + "#token=access-token");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // TC-022 redirect URI 쿠키 없는 경우
+    // ──────────────────────────────────────────────────────────────────────────
+    @Test
+    @DisplayName("TC-022 redirect URI 쿠키 없음 → defaultRedirectUri로 리다이렉트")
+    void no_cookie_uses_default_redirect() throws Exception {
+        User user = buildUser(1L);
+        when(authentication.getPrincipal()).thenReturn(buildAdapter(user));
+        when(jwtProvider.generateUserAccessToken(1L)).thenReturn("access-token");
+        when(jwtProvider.generateUserRefreshToken(1L)).thenReturn("refresh-token");
+        when(jwtProvider.getRefreshTokenExpiry()).thenReturn(LocalDateTime.now().plusDays(7));
+        when(refreshTokenRepository.findByAccountTypeAndAccountId(AccountType.USER, 1L))
+                .thenReturn(Optional.empty());
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        handler.onAuthenticationSuccess(new MockHttpServletRequest(), response, authentication);
+
+        assertThat(response.getRedirectedUrl())
+                .isEqualTo(DEFAULT_REDIRECT + "#token=access-token");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // TC-023 비허용 redirect URI
+    // ──────────────────────────────────────────────────────────────────────────
+    @Test
+    @DisplayName("TC-023 허용되지 않은 redirect URI → defaultRedirectUri로 리다이렉트")
+    void disallowed_redirect_uri_uses_default() throws Exception {
+        User user = buildUser(1L);
+        when(authentication.getPrincipal()).thenReturn(buildAdapter(user));
+        when(jwtProvider.generateUserAccessToken(1L)).thenReturn("access-token");
+        when(jwtProvider.generateUserRefreshToken(1L)).thenReturn("refresh-token");
+        when(jwtProvider.getRefreshTokenExpiry()).thenReturn(LocalDateTime.now().plusDays(7));
+        when(refreshTokenRepository.findByAccountTypeAndAccountId(AccountType.USER, 1L))
+                .thenReturn(Optional.empty());
+
+        MockHttpServletRequest request = requestWithRedirectCookie("http://evil.com/callback");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        handler.onAuthenticationSuccess(request, response, authentication);
+
+        assertThat(response.getRedirectedUrl())
+                .isEqualTo(DEFAULT_REDIRECT + "#token=access-token");
+    }
+}

--- a/src/test/java/com/boaz/backend/global/oauth/OAuth2UserInfoTest.java
+++ b/src/test/java/com/boaz/backend/global/oauth/OAuth2UserInfoTest.java
@@ -1,0 +1,143 @@
+package com.boaz.backend.global.oauth;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OAuth2UserInfoTest {
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // KakaoOAuth2UserInfo
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("KakaoOAuth2UserInfo")
+    class KakaoTests {
+
+        @Test
+        @DisplayName("TC-009 id가 있는 경우 → getProviderId() Long→String 변환")
+        void providerId_long_to_string() {
+            KakaoOAuth2UserInfo info = new KakaoOAuth2UserInfo(Map.of("id", 12345L));
+            assertThat(info.getProviderId()).isEqualTo("12345");
+        }
+
+        @Test
+        @DisplayName("TC-010 kakao_account.profile.nickname 있는 경우 → getNickname() 반환")
+        void nickname_from_nested_profile() {
+            Map<String, Object> profile = Map.of("nickname", "보아즈");
+            Map<String, Object> kakaoAccount = Map.of("profile", profile);
+            KakaoOAuth2UserInfo info = new KakaoOAuth2UserInfo(
+                    Map.of("id", 12345L, "kakao_account", kakaoAccount));
+
+            assertThat(info.getNickname()).isEqualTo("보아즈");
+        }
+
+        @Test
+        @DisplayName("TC-011 kakao_account 없는 경우 → getNickname() null (NPE 없음)")
+        void nickname_null_when_no_kakao_account() {
+            KakaoOAuth2UserInfo info = new KakaoOAuth2UserInfo(Map.of("id", 12345L));
+            assertThat(info.getNickname()).isNull();
+        }
+
+        @Test
+        @DisplayName("TC-012 profile 없는 경우 → getNickname() null (NPE 없음)")
+        void nickname_null_when_no_profile() {
+            Map<String, Object> kakaoAccount = new HashMap<>();
+            KakaoOAuth2UserInfo info = new KakaoOAuth2UserInfo(
+                    Map.of("id", 12345L, "kakao_account", kakaoAccount));
+
+            assertThat(info.getNickname()).isNull();
+        }
+
+        @Test
+        @DisplayName("id가 null인 경우 → getProviderId() null")
+        void providerId_null_when_id_null() {
+            Map<String, Object> attrs = new HashMap<>();
+            attrs.put("id", null);
+            KakaoOAuth2UserInfo info = new KakaoOAuth2UserInfo(attrs);
+
+            assertThat(info.getProviderId()).isNull();
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // GoogleOAuth2UserInfo
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("GoogleOAuth2UserInfo")
+    class GoogleTests {
+
+        @Test
+        @DisplayName("TC-013 sub 있는 경우 → getProviderId() 반환")
+        void providerId_from_sub() {
+            GoogleOAuth2UserInfo info = new GoogleOAuth2UserInfo(
+                    Map.of("sub", "google-uid-001", "name", "김보아즈"));
+
+            assertThat(info.getProviderId()).isEqualTo("google-uid-001");
+        }
+
+        @Test
+        @DisplayName("TC-014 name 있는 경우 → getNickname() 반환")
+        void nickname_from_name() {
+            GoogleOAuth2UserInfo info = new GoogleOAuth2UserInfo(
+                    Map.of("sub", "google-uid-001", "name", "김보아즈"));
+
+            assertThat(info.getNickname()).isEqualTo("김보아즈");
+        }
+
+        @Test
+        @DisplayName("getProvider() → \"google\"")
+        void provider_is_google() {
+            GoogleOAuth2UserInfo info = new GoogleOAuth2UserInfo(Map.of("sub", "id"));
+            assertThat(info.getProvider()).isEqualTo("google");
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // NaverOAuth2UserInfo
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("NaverOAuth2UserInfo")
+    class NaverTests {
+
+        @Test
+        @DisplayName("TC-015 response.id 있는 경우 → getProviderId() 반환")
+        void providerId_from_response_id() {
+            NaverOAuth2UserInfo info = new NaverOAuth2UserInfo(
+                    Map.of("response", Map.of("id", "naver-uid-001", "name", "이보아즈")));
+
+            assertThat(info.getProviderId()).isEqualTo("naver-uid-001");
+        }
+
+        @Test
+        @DisplayName("TC-016 name이 있는 경우 → getNickname() = name (nickname 무시)")
+        void nickname_prefers_name() {
+            NaverOAuth2UserInfo info = new NaverOAuth2UserInfo(Map.of("response", Map.of(
+                    "id", "naver-uid-001", "name", "이보아즈", "nickname", "보아즈닉")));
+
+            assertThat(info.getNickname()).isEqualTo("이보아즈");
+        }
+
+        @Test
+        @DisplayName("TC-017 name 비어있고 nickname 있는 경우 → getNickname() = nickname 폴백")
+        void nickname_fallback_when_name_blank() {
+            NaverOAuth2UserInfo info = new NaverOAuth2UserInfo(Map.of("response", Map.of(
+                    "id", "naver-uid-001", "name", "", "nickname", "보아즈닉")));
+
+            assertThat(info.getNickname()).isEqualTo("보아즈닉");
+        }
+
+        @Test
+        @DisplayName("TC-018 response 없는 경우 → getProviderId()/getNickname() null (NPE 없음)")
+        void null_when_no_response() {
+            NaverOAuth2UserInfo info = new NaverOAuth2UserInfo(Map.of());
+
+            assertThat(info.getProviderId()).isNull();
+            assertThat(info.getNickname()).isNull();
+        }
+    }
+}

--- a/src/test/java/com/boaz/backend/global/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/boaz/backend/global/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,234 @@
+package com.boaz.backend.global.security;
+
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+
+    @Mock JwtProvider jwtProvider;
+    @Mock AdminUserDetailsService adminUserDetailsService;
+
+    JwtAuthenticationFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        filter = new JwtAuthenticationFilter(jwtProvider, adminUserDetailsService);
+        SecurityContextHolder.clearContext();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private MockHttpServletRequest requestWithBearer(String token) {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.addHeader("Authorization", "Bearer " + token);
+        return req;
+    }
+
+    private Claims mockClaims(String subject, String type, String tokenType) {
+        Claims claims = mock(Claims.class);
+        lenient().when(claims.getSubject()).thenReturn(subject);
+        lenient().when(claims.get("type", String.class)).thenReturn(type);
+        lenient().when(claims.get("tokenType", String.class)).thenReturn(tokenType);
+        lenient().when(claims.get("username", String.class)).thenReturn(null);
+        return claims;
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // TC-001 Authorization 헤더 없는 경우
+    // ──────────────────────────────────────────────────────────────────────────
+    @Test
+    @DisplayName("TC-001 Authorization 헤더 없음 → 필터 통과, SecurityContext 비어있음")
+    void no_auth_header_passes_filter() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(chain.getRequest()).isNotNull();
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // TC-002 Bearer 형식이 아닌 경우
+    // ──────────────────────────────────────────────────────────────────────────
+    @Test
+    @DisplayName("TC-002 Bearer 형식 아닌 Authorization 헤더 → 필터 통과, SecurityContext 비어있음")
+    void non_bearer_passes_filter() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Basic dXNlcjpwYXNz");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(chain.getRequest()).isNotNull();
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // TC-003 유효한 USER Access Token
+    // ──────────────────────────────────────────────────────────────────────────
+    @Test
+    @DisplayName("TC-003 유효한 USER Access Token → UserPrincipal + ROLE_USER 세팅 후 통과")
+    void valid_user_access_token() throws Exception {
+        Claims claims = mockClaims("1", "USER", "ACCESS");
+        doNothing().when(jwtProvider).validateToken("valid-user-token");
+        when(jwtProvider.parseClaims("valid-user-token")).thenReturn(claims);
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(requestWithBearer("valid-user-token"), response, chain);
+
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(auth).isNotNull();
+        assertThat(auth.getPrincipal()).isInstanceOf(UserPrincipal.class);
+        assertThat(((UserPrincipal) auth.getPrincipal()).userId()).isEqualTo(1L);
+        assertThat(auth.getAuthorities()).extracting(Object::toString).contains("ROLE_USER");
+        assertThat(chain.getRequest()).isNotNull();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // TC-004 유효한 ADMIN Access Token
+    // ──────────────────────────────────────────────────────────────────────────
+    @Test
+    @DisplayName("TC-004 유효한 ADMIN Access Token → AdminUserDetails 세팅 후 통과")
+    void valid_admin_access_token() throws Exception {
+        Claims claims = mockClaims("10", "ADMIN", "ACCESS");
+        when(claims.get("username", String.class)).thenReturn("admin01");
+
+        doNothing().when(jwtProvider).validateToken("valid-admin-token");
+        when(jwtProvider.parseClaims("valid-admin-token")).thenReturn(claims);
+
+        UserDetails adminDetails = mock(UserDetails.class);
+        doReturn(List.of(new SimpleGrantedAuthority("ROLE_SUPER"))).when(adminDetails).getAuthorities();
+        when(adminUserDetailsService.loadUserByUsername("admin01")).thenReturn(adminDetails);
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(requestWithBearer("valid-admin-token"), response, chain);
+
+        verify(adminUserDetailsService).loadUserByUsername("admin01");
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(auth).isNotNull();
+        assertThat(auth.getPrincipal()).isInstanceOf(UserDetails.class);
+        assertThat(auth.getAuthorities()).extracting(Object::toString).contains("ROLE_SUPER");
+        assertThat(chain.getRequest()).isNotNull();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 예외 케이스 그룹
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("예외 케이스")
+    class ExceptionCases {
+
+        @Test
+        @DisplayName("TC-005 만료된 토큰 → 401 EXPIRED_TOKEN, chain 중단")
+        void expired_token() throws Exception {
+            doThrow(new CustomException(ErrorCode.EXPIRED_TOKEN))
+                    .when(jwtProvider).validateToken("expired-token");
+
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain chain = new MockFilterChain();
+            filter.doFilter(requestWithBearer("expired-token"), response, chain);
+
+            assertThat(response.getStatus()).isEqualTo(401);
+            assertThat(response.getContentAsString()).contains("EXPIRED_TOKEN");
+            assertThat(chain.getRequest()).isNull();
+            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        }
+
+        @Test
+        @DisplayName("TC-006 위조된 토큰 → 401 INVALID_TOKEN, chain 중단")
+        void forged_token() throws Exception {
+            doThrow(new CustomException(ErrorCode.INVALID_TOKEN))
+                    .when(jwtProvider).validateToken("forged-token");
+
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain chain = new MockFilterChain();
+            filter.doFilter(requestWithBearer("forged-token"), response, chain);
+
+            assertThat(response.getStatus()).isEqualTo(401);
+            assertThat(response.getContentAsString()).contains("INVALID_TOKEN");
+            assertThat(chain.getRequest()).isNull();
+            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        }
+
+        @Test
+        @DisplayName("TC-007 tokenType=REFRESH → 401 INVALID_TOKEN, chain 중단")
+        void refresh_token_used_as_access() throws Exception {
+            Claims claims = mockClaims("1", "USER", "REFRESH");
+            doNothing().when(jwtProvider).validateToken("refresh-token");
+            when(jwtProvider.parseClaims("refresh-token")).thenReturn(claims);
+
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain chain = new MockFilterChain();
+            filter.doFilter(requestWithBearer("refresh-token"), response, chain);
+
+            assertThat(response.getStatus()).isEqualTo(401);
+            assertThat(response.getContentAsString()).contains("INVALID_TOKEN");
+            assertThat(chain.getRequest()).isNull();
+        }
+
+        @Test
+        @DisplayName("TC-008 type=GUEST (알 수 없는 type) → 401 INVALID_TOKEN, chain 중단")
+        void unknown_type() throws Exception {
+            Claims claims = mockClaims("1", "GUEST", "ACCESS");
+            doNothing().when(jwtProvider).validateToken("unknown-type-token");
+            when(jwtProvider.parseClaims("unknown-type-token")).thenReturn(claims);
+
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain chain = new MockFilterChain();
+            filter.doFilter(requestWithBearer("unknown-type-token"), response, chain);
+
+            assertThat(response.getStatus()).isEqualTo(401);
+            assertThat(response.getContentAsString()).contains("INVALID_TOKEN");
+            assertThat(chain.getRequest()).isNull();
+        }
+
+        @Test
+        @DisplayName("TC-009 예기치 못한 예외 → 500 INTERNAL_SERVER_ERROR, chain 중단")
+        void unexpected_exception() throws Exception {
+            doNothing().when(jwtProvider).validateToken("some-token");
+            when(jwtProvider.parseClaims("some-token")).thenThrow(new RuntimeException("unexpected"));
+
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain chain = new MockFilterChain();
+            filter.doFilter(requestWithBearer("some-token"), response, chain);
+
+            assertThat(response.getStatus()).isEqualTo(500);
+            assertThat(response.getContentAsString()).contains("INTERNAL_SERVER_ERROR");
+            assertThat(chain.getRequest()).isNull();
+            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        }
+    }
+}

--- a/src/test/java/com/boaz/backend/global/security/JwtProviderTest.java
+++ b/src/test/java/com/boaz/backend/global/security/JwtProviderTest.java
@@ -1,0 +1,173 @@
+package com.boaz.backend.global.security;
+
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JwtProviderTest {
+
+    private static final String SECRET = "dGVzdC1zZWNyZXQta2V5LWZvci10ZXN0aW5nLW9ubHktbXVzdC1iZS1sb25nZW5vdWdo";
+    private static final String OTHER_SECRET = "b3RoZXItc2VjcmV0LWtleS1mb3ItdGVzdGluZy1vbmx5LW11c3QtYmUtbG9uZ2Vub3VnaA==";
+    private static final long ACCESS_EXP = 900000L;
+    private static final long REFRESH_EXP = 604800000L;
+
+    private final JwtProvider jwtProvider = new JwtProvider(SECRET, ACCESS_EXP, REFRESH_EXP);
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // [그룹 A] User 토큰 생성
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("[그룹 A] User 토큰 생성")
+    class UserTokenGeneration {
+
+        @Test
+        @DisplayName("TC-001 generateUserAccessToken → 클레임 검증")
+        void user_access_token_claims() {
+            String token = jwtProvider.generateUserAccessToken(1L);
+            Claims claims = jwtProvider.parseClaims(token);
+
+            assertThat(claims.getSubject()).isEqualTo("1");
+            assertThat(claims.get("type", String.class)).isEqualTo("USER");
+            assertThat(claims.get("tokenType", String.class)).isEqualTo("ACCESS");
+            assertThat(claims.getExpiration().after(new Date())).isTrue();
+        }
+
+        @Test
+        @DisplayName("TC-002 generateUserRefreshToken → 클레임 검증")
+        void user_refresh_token_claims() {
+            String token = jwtProvider.generateUserRefreshToken(1L);
+            Claims claims = jwtProvider.parseClaims(token);
+
+            assertThat(claims.getSubject()).isEqualTo("1");
+            assertThat(claims.get("type", String.class)).isEqualTo("USER");
+            assertThat(claims.get("tokenType", String.class)).isEqualTo("REFRESH");
+            assertThat(claims.getExpiration().after(new Date())).isTrue();
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // [그룹 B] Admin 토큰 생성
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("[그룹 B] Admin 토큰 생성")
+    class AdminTokenGeneration {
+
+        @Test
+        @DisplayName("TC-003 generateAdminAccessToken → username/role 클레임 포함")
+        void admin_access_token_claims() {
+            String token = jwtProvider.generateAdminAccessToken(10L, "admin01", "ROLE_SUPER");
+            Claims claims = jwtProvider.parseClaims(token);
+
+            assertThat(claims.getSubject()).isEqualTo("10");
+            assertThat(claims.get("type", String.class)).isEqualTo("ADMIN");
+            assertThat(claims.get("tokenType", String.class)).isEqualTo("ACCESS");
+            assertThat(claims.get("username", String.class)).isEqualTo("admin01");
+            assertThat(claims.get("role", String.class)).isEqualTo("ROLE_SUPER");
+            assertThat(claims.getExpiration().after(new Date())).isTrue();
+        }
+
+        @Test
+        @DisplayName("TC-004 generateAdminRefreshToken → username 클레임 없음")
+        void admin_refresh_token_no_username() {
+            String token = jwtProvider.generateAdminRefreshToken(10L);
+            Claims claims = jwtProvider.parseClaims(token);
+
+            assertThat(claims.getSubject()).isEqualTo("10");
+            assertThat(claims.get("type", String.class)).isEqualTo("ADMIN");
+            assertThat(claims.get("tokenType", String.class)).isEqualTo("REFRESH");
+            assertThat(claims.get("username", String.class)).isNull();
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // [그룹 C] validateToken
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("[그룹 C] validateToken")
+    class ValidateToken {
+
+        @Test
+        @DisplayName("TC-005 유효한 토큰 → 예외 없음")
+        void valid_token_no_exception() {
+            String token = jwtProvider.generateUserAccessToken(1L);
+            jwtProvider.validateToken(token); // should not throw
+        }
+
+        @Test
+        @DisplayName("TC-006 만료된 토큰 → EXPIRED_TOKEN")
+        void expired_token() throws InterruptedException {
+            JwtProvider shortExpiry = new JwtProvider(SECRET, 1L, REFRESH_EXP);
+            String token = shortExpiry.generateUserAccessToken(1L);
+            Thread.sleep(10);
+
+            assertThatThrownBy(() -> jwtProvider.validateToken(token))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.EXPIRED_TOKEN);
+        }
+
+        @Test
+        @DisplayName("TC-007 다른 키로 서명된 토큰 → INVALID_TOKEN")
+        void forged_token() {
+            JwtProvider otherProvider = new JwtProvider(OTHER_SECRET, ACCESS_EXP, REFRESH_EXP);
+            String forgedToken = otherProvider.generateUserAccessToken(1L);
+
+            assertThatThrownBy(() -> jwtProvider.validateToken(forgedToken))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.INVALID_TOKEN);
+        }
+
+        @Test
+        @DisplayName("TC-008 형식 오류 토큰 → INVALID_TOKEN")
+        void malformed_token() {
+            assertThatThrownBy(() -> jwtProvider.validateToken("this.is.not.a.jwt"))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.INVALID_TOKEN);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // [그룹 D] parseClaims
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("[그룹 D] parseClaims")
+    class ParseClaims {
+
+        @Test
+        @DisplayName("TC-009 유효한 USER Access Token → Claims 정상 반환")
+        void parse_user_access_token() {
+            String token = jwtProvider.generateUserAccessToken(1L);
+            Claims claims = jwtProvider.parseClaims(token);
+
+            assertThat(claims.getSubject()).isEqualTo("1");
+            assertThat(claims.get("type", String.class)).isEqualTo("USER");
+            assertThat(claims.get("tokenType", String.class)).isEqualTo("ACCESS");
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // [그룹 E] getRefreshTokenExpiry
+    // ──────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("[그룹 E] getRefreshTokenExpiry")
+    class RefreshTokenExpiry {
+
+        @Test
+        @DisplayName("TC-010 getRefreshTokenExpiry → 현재 시각 + refreshTokenExpiration 초")
+        void refresh_token_expiry() {
+            LocalDateTime before = LocalDateTime.now();
+            LocalDateTime expiry = jwtProvider.getRefreshTokenExpiry();
+
+            assertThat(expiry.isAfter(before.plusDays(6))).isTrue();
+            assertThat(expiry.isBefore(before.plusDays(8))).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
## 💡 개요

* Issue Number: #155 

## 🪐 주요 변경 사항
- JWT 토큰 생성/검증, 인증 필터 단위 테스트 작성 (SEC-001, SEC-002)
- 소셜 로그인, 토큰 갱신, 로그아웃 단위 테스트 작성 (AUTH-004, AUTH-005, AUTH-006)

## ✅ 상세 내용
- `JwtProviderTest`: 토큰 생성 클레임 검증, validateToken, parseClaims, getRefreshTokenExpiry
- `JwtAuthenticationFilterTest`: 헤더 없음/비Bearer 통과, USER/ADMIN 인증 등록, 예외 케이스 처리
- `OAuth2UserInfoTest`: Kakao/Google/Naver 응답 파싱 및 null 방어 처리
- `CustomOAuth2UserServiceTest`: provider별 파싱 위임, 예외 처리
- `OAuth2AuthenticationSuccessHandlerTest` / `FailureHandlerTest`: redirect URI 검증 및 토큰 발급
- `AuthServiceTest`: 토큰 갱신 7개 케이스, 로그아웃 2개 케이스
- `UserAuthControllerTest`: 로그아웃/토큰갱신 엔드포인트 검증

## 🔔 참고 사항