### PR TITLE
[Chore] 시즌 전환 시 EC2-B CodeDeploy 대상 태그 탈부착

### DIFF
--- a/infra/scripts/season-down.sh
+++ b/infra/scripts/season-down.sh
@@ -107,14 +107,22 @@ else
 fi
 
 # --------------------------------------------------
-# 4. EC2-B를 Target Group에서 deregister + stop
+# 4. EC2-B를 Target Group에서 deregister + 태그 제거 + stop
+#    중지 전에 CodeDeploy 대상 태그(app=boaz-api)를 제거해야
+#    평시(EC2-A 단독) CodeDeploy 배포가 중지된 EC2-B를 대상으로 잡아
+#    실패하는 것을 막는다.
 # --------------------------------------------------
 echo ""
-echo "[4/5] EC2-B Target Group에서 제거 + 중지 중..."
+echo "[4/5] EC2-B Target Group 제거 + 태그 제거 + 중지 중..."
 
 aws elbv2 deregister-targets --target-group-arn "$TARGET_GROUP_ARN" \
   --targets "Id=$EC2_B_ID" \
   --region "$AWS_REGION" --profile "$AWS_PROFILE" 2>/dev/null || true
+
+echo "  → CodeDeploy 대상 태그 제거 (app=boaz-api)..."
+aws ec2 delete-tags --resources "$EC2_B_ID" \
+  --tags "Key=app,Value=boaz-api" \
+  --region "$AWS_REGION" --profile "$AWS_PROFILE"
 
 aws ec2 stop-instances --instance-ids "$EC2_B_ID" \
   --region "$AWS_REGION" --profile "$AWS_PROFILE" > /dev/null

--- a/infra/scripts/season-up.sh
+++ b/infra/scripts/season-up.sh
@@ -57,10 +57,18 @@ ALB_PORT=$(ssm_get "ALB_PORT")
 echo "  ✅ 설정 로드 완료"
 
 # --------------------------------------------------
-# 1. EC2-B 시작
+# 1. EC2-B 태그 부착 + 시작
+#    부팅 전에 CodeDeploy 대상 태그(app=boaz-api)를 먼저 부착해야
+#    이후 CodeDeploy 재배포(2단계)가 EC2-B까지 대상에 포함한다.
+#    (태그는 중지 상태 인스턴스에도 부착 가능)
 # --------------------------------------------------
 echo ""
-echo "[1/7] EC2-B 시작 중... ($EC2_B_ID)"
+echo "[1/7] EC2-B 태그 부착 + 시작 중... ($EC2_B_ID)"
+echo "  → CodeDeploy 대상 태그 부착 (app=boaz-api)..."
+aws ec2 create-tags --resources "$EC2_B_ID" \
+  --tags "Key=app,Value=boaz-api" \
+  --region "$AWS_REGION" --profile "$AWS_PROFILE"
+
 aws ec2 start-instances --instance-ids "$EC2_B_ID" \
   --region "$AWS_REGION" --profile "$AWS_PROFILE" > /dev/null
 aws ec2 wait instance-running --instance-ids "$EC2_B_ID" \


### PR DESCRIPTION
## 💡 개요

* Issue Number: #105

평시(EC2-A 단독) 운영 시, CodeDeploy 배포가 중지된 EC2-B를 대상으로 잡아 실패하는 문제를 방지하기 위해 시즌 전환 스크립트에서 EC2-B의 CodeDeploy 대상 태그(`app=boaz-api`)를 탈부착한다.

## 🪐 주요 변경 사항
- `season-up.sh`: EC2-B **부팅 전** 태그 `app=boaz-api` 부착
- `season-down.sh`: EC2-B **중지 전** 태그 제거

## ✅ 상세 내용
- season-up은 부팅 전에 태그를 먼저 붙여야 이후 CodeDeploy 재배포 단계가 EC2-B까지 대상에 포함한다. (태그는 중지 상태 인스턴스에도 부착 가능)
- season-down은 deregister 직후·stop 직전에 태그를 제거해, 평시 CodeDeploy 배포가 중지된 EC2-B를 대상으로 잡지 않도록 한다.
- 두 동작 모두 실제 시즌 up/down 스크립트 실행으로 검증 완료.

## 🔔 참고 사항
- CodeDeploy 배포 그룹의 태그 필터가 `app=boaz-api`이고 EC2-A에 해당 태그가 영구 부착돼 있는 전제.
- `create-tags`/`delete-tags`는 멱등이라 스크립트 재실행에 안전.

@coderabbitai ignore