### PR TITLE
[Fix] 모집 마감 경계 처리 - 마지막 1초 지원서 튕김 수정

### DIFF
--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/response/RecruitmentResponse.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/response/RecruitmentResponse.java
@@ -56,13 +56,13 @@ public class RecruitmentResponse {
         }
     }
 
-    private RecruitmentResponse(Recruitment recruitment) {
+    private RecruitmentResponse(Recruitment recruitment, LocalDateTime now) {
         this.recruitmentId = recruitment.getId();
         this.term = recruitment.getTerm();
         this.startDate = recruitment.getStartDate();
         this.endDate = recruitment.getEndDate();
         this.brochureUrl = recruitment.getBrochureUrl();
-        this.isActive = recruitment.isActive();
+        this.isActive = recruitment.isActive(now);
         try {
             this.schedule = objectMapper.readTree(recruitment.getSchedule());
         } catch (Exception e) {
@@ -74,7 +74,7 @@ public class RecruitmentResponse {
         return new RecruitmentResponse(recruitment, isActive);
     }
 
-    public static RecruitmentResponse from(Recruitment recruitment) {
-        return new RecruitmentResponse(recruitment);
+    public static RecruitmentResponse from(Recruitment recruitment, LocalDateTime now) {
+        return new RecruitmentResponse(recruitment, now);
     }
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/entity/Recruitment.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/entity/Recruitment.java
@@ -31,8 +31,6 @@ public class Recruitment extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String brochureUrl;
 
-    // 주어진 시각이 모집 기간(start_date ~ end_date, 양끝 포함) 안인지 판정한다.
-    // 호출부에서 초 단위로 버린 현재 시각을 넘겨야 마지막 초까지 정확히 포함된다.
     public boolean isActive(LocalDateTime now) {
         return !now.isBefore(startDate) && !now.isAfter(endDate);
     }

--- a/src/main/java/com/boaz/backend/domain/recruitment/entity/Recruitment.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/entity/Recruitment.java
@@ -31,8 +31,9 @@ public class Recruitment extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String brochureUrl;
 
-    public boolean isActive() {
-        LocalDateTime now = LocalDateTime.now();
+    // 주어진 시각이 모집 기간(start_date ~ end_date, 양끝 포함) 안인지 판정한다.
+    // 호출부에서 초 단위로 버린 현재 시각을 넘겨야 마지막 초까지 정확히 포함된다.
+    public boolean isActive(LocalDateTime now) {
         return !now.isBefore(startDate) && !now.isAfter(endDate);
     }
 

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -85,9 +85,7 @@ public class RecruitmentService {
 
     private final S3Service s3Service;
 
-    // 모집 기간 판정용 현재 시각 (초 단위 버림).
-    // end_date가 초 단위(예: 23:59:59)로 저장되는데 now()는 밀리초/나노초까지 가져,
-    // 버리지 않으면 마지막 초(23:59:59.xxx) 제출이 마감으로 처리되어 튕긴다.
+    // 모집 기간 판정용 현재 시각 (초 단위 버림)
     private LocalDateTime now() {
         return LocalDateTime.now(clock).truncatedTo(ChronoUnit.SECONDS);
     }

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -51,10 +51,12 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.beans.factory.annotation.Value;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -76,16 +78,24 @@ public class RecruitmentService {
     private final ObjectMapper objectMapper;
     private final SubscriptionRepository subscriptionRepository;
     private final CsvService csvService;
+    private final Clock clock;
 
     @Value("${spring.cloud.aws.s3.recruitment-bucket}")
     private String recruitmentBucket;
 
     private final S3Service s3Service;
 
+    // 모집 기간 판정용 현재 시각 (초 단위 버림).
+    // end_date가 초 단위(예: 23:59:59)로 저장되는데 now()는 밀리초/나노초까지 가져,
+    // 버리지 않으면 마지막 초(23:59:59.xxx) 제출이 마감으로 처리되어 튕긴다.
+    private LocalDateTime now() {
+        return LocalDateTime.now(clock).truncatedTo(ChronoUnit.SECONDS);
+    }
+
     // 모집 중 여부 조회
     public RecruitmentStatusResponse getRecruitmentStatus() {
         Optional<Recruitment> activeRecruitment = recruitmentRepository
-                .findActiveRecruitment(LocalDateTime.now());
+                .findActiveRecruitment(now());
 
         return activeRecruitment
                 .map(r -> RecruitmentStatusResponse.of(true, r.getTerm()))
@@ -94,7 +104,7 @@ public class RecruitmentService {
 
     // 모집 공고 마감 일시 조회
     public DeadlineResponse getDeadline() {
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = now();
         Recruitment recruitment = recruitmentRepository.findActiveRecruitment(now)
                 .orElseThrow(() -> new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
         return DeadlineResponse.from(recruitment);
@@ -105,7 +115,7 @@ public class RecruitmentService {
         Recruitment recruitment = recruitmentRepository.findByTerm(term)
                 .orElseThrow(() -> new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
 
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = now();
         boolean isActive = !now.isBefore(recruitment.getStartDate())
                         && !now.isAfter(recruitment.getEndDate());
 
@@ -120,7 +130,7 @@ public class RecruitmentService {
                 .orElseThrow(() -> new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
 
         // 모집 중 여부 확인
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = now();
         boolean isActive = !now.isBefore(recruitment.getStartDate())
                         && !now.isAfter(recruitment.getEndDate());
         if (!isActive) {
@@ -164,7 +174,7 @@ public class RecruitmentService {
                 .orElseThrow(() -> new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
 
         // 모집 기간 확인
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = now();
         boolean isActive = !now.isBefore(recruitment.getStartDate())
                         && !now.isAfter(recruitment.getEndDate());
         if (!isActive) {
@@ -370,7 +380,7 @@ public class RecruitmentService {
                 .orElseThrow(() -> new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
 
         // 모집 기간 확인
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = now();
         boolean isActive = !now.isBefore(recruitment.getStartDate())
                         && !now.isAfter(recruitment.getEndDate());
         if (!isActive) {

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -115,9 +115,7 @@ public class RecruitmentService {
         Recruitment recruitment = recruitmentRepository.findByTerm(term)
                 .orElseThrow(() -> new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
 
-        LocalDateTime now = now();
-        boolean isActive = !now.isBefore(recruitment.getStartDate())
-                        && !now.isAfter(recruitment.getEndDate());
+        boolean isActive = recruitment.isActive(now());
 
         return RecruitmentResponse.from(recruitment, isActive);
     }
@@ -130,10 +128,7 @@ public class RecruitmentService {
                 .orElseThrow(() -> new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
 
         // 모집 중 여부 확인
-        LocalDateTime now = now();
-        boolean isActive = !now.isBefore(recruitment.getStartDate())
-                        && !now.isAfter(recruitment.getEndDate());
-        if (!isActive) {
+        if (!recruitment.isActive(now())) {
             throw new CustomException(ErrorCode.RECRUITMENT_NOT_AVAILABLE);
         }
 
@@ -174,10 +169,7 @@ public class RecruitmentService {
                 .orElseThrow(() -> new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
 
         // 모집 기간 확인
-        LocalDateTime now = now();
-        boolean isActive = !now.isBefore(recruitment.getStartDate())
-                        && !now.isAfter(recruitment.getEndDate());
-        if (!isActive) {
+        if (!recruitment.isActive(now())) {
             throw new CustomException(ErrorCode.RECRUITMENT_CLOSED);
         }
 
@@ -380,10 +372,7 @@ public class RecruitmentService {
                 .orElseThrow(() -> new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
 
         // 모집 기간 확인
-        LocalDateTime now = now();
-        boolean isActive = !now.isBefore(recruitment.getStartDate())
-                        && !now.isAfter(recruitment.getEndDate());
-        if (!isActive) {
+        if (!recruitment.isActive(now())) {
             throw new CustomException(ErrorCode.RECRUITMENT_CLOSED);
         }
 
@@ -656,8 +645,9 @@ public class RecruitmentService {
 
     // 모든 모집 공고 조회 (term 내림차순)
     public List<RecruitmentResponse> getAllRecruitments() {
+        LocalDateTime now = now();
         return recruitmentRepository.findAllByOrderByTermDesc().stream()
-                .map(RecruitmentResponse::from)
+                .map(r -> RecruitmentResponse.from(r, now))
                 .toList();
     }
 
@@ -749,7 +739,7 @@ public class RecruitmentService {
         Recruitment recruitment = recruitmentRepository.findById(recruitmentId)
                 .orElseThrow(() -> new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
 
-        if (recruitment.isActive()) {
+        if (recruitment.isActive(now())) {
             throw new CustomException(ErrorCode.RECRUITMENT_NOT_CLOSED);
         }
 

--- a/src/main/java/com/boaz/backend/global/config/ClockConfig.java
+++ b/src/main/java/com/boaz/backend/global/config/ClockConfig.java
@@ -4,14 +4,16 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.time.Clock;
+import java.time.ZoneId;
 
 @Configuration
 public class ClockConfig {
 
-    // JVM 기본 타임존(Asia/Seoul)을 따르는 시스템 클럭.
-    // 모집 기간 판정 시각을 한 곳에서 주입받아 테스트에서 고정 가능하도록 빈으로 제공한다.
+    // Asia/Seoul 타임존을 명시적으로 고정한 시스템 클럭.
+    // JVM 기본 타임존(전역 TimeZone.setDefault)에 의존하지 않고 모집 기간 판정 시각을
+    // 한 곳에서 주입받아, 테스트에서 고정 가능하도록 빈으로 제공한다.
     @Bean
     public Clock clock() {
-        return Clock.systemDefaultZone();
+        return Clock.system(ZoneId.of("Asia/Seoul"));
     }
 }

--- a/src/main/java/com/boaz/backend/global/config/ClockConfig.java
+++ b/src/main/java/com/boaz/backend/global/config/ClockConfig.java
@@ -1,0 +1,17 @@
+package com.boaz.backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class ClockConfig {
+
+    // JVM 기본 타임존(Asia/Seoul)을 따르는 시스템 클럭.
+    // 모집 기간 판정 시각을 한 곳에서 주입받아 테스트에서 고정 가능하도록 빈으로 제공한다.
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/service/RecruitmentServiceTest.java
@@ -31,6 +31,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -1448,6 +1449,86 @@ class RecruitmentServiceTest {
             doNothing().when(subscriptionRepository).deleteAll();
             recruitmentService.deleteAllSubscriptions();
             verify(subscriptionRepository).deleteAll();
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // REC-008: 모집 마감 경계 (#163 마지막 초 처리)
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("REC-008 모집 마감 경계 (마지막 초 처리)")
+    class DeadlineBoundary {
+
+        private static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
+        private final LocalDateTime endDate = LocalDateTime.of(2026, 6, 24, 23, 59, 59);
+
+        // 모집 기간 판정에 쓰이는 현재 시각을 고정한다.
+        private void fixClockAt(LocalDateTime at) {
+            Clock fixed = Clock.fixed(at.atZone(ZONE).toInstant(), ZONE);
+            ReflectionTestUtils.setField(recruitmentService, "clock", fixed);
+        }
+
+        private Recruitment recruitmentEndingAt(LocalDateTime end) {
+            Recruitment r = Recruitment.create(27,
+                    end.minusDays(16), end, "[]", "https://example.com/brochure.pdf");
+            ReflectionTestUtils.setField(r, "id", 1L);
+            return r;
+        }
+
+        private void stubHappyPathSubmit(Recruitment r) {
+            User user = createUser(1L);
+            ApplicationQuestion q1 = createTextQuestion(1L, r, ApplicationQuestion.Category.COMMON, 1, true);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(r));
+            when(applicantRepository.findByRecruitmentIdAndUserId(1L, 1L)).thenReturn(Optional.empty());
+            when(applicationQuestionRepository.findByRecruitmentIdAndCategories(any(), any(), any()))
+                    .thenReturn(List.of(q1));
+            when(applicantRepository.save(any())).thenAnswer(inv -> {
+                Applicant a = inv.getArgument(0);
+                ReflectionTestUtils.setField(a, "id", 42L);
+                return a;
+            });
+        }
+
+        @Test
+        @DisplayName("TC-001 마감 초의 끝자락(23:59:59.999) 제출 → 접수 (튕기지 않음)")
+        void submitAtLastSecondMillis() {
+            fixClockAt(endDate.plusNanos(999_000_000)); // 2026-06-24 23:59:59.999
+            stubHappyPathSubmit(recruitmentEndingAt(endDate));
+
+            ApplicationRequest req = buildApplicationRequest(List.of(buildTextAnswer(1L, "답변내용")));
+            ApplicationResponse res = recruitmentService.submitApplication(1L, 1L, req);
+
+            assertThat(res.getApplicantId()).isEqualTo(42L);
+        }
+
+        @Test
+        @DisplayName("TC-002 마감 정각(23:59:59.000) 제출 → 접수")
+        void submitExactlyAtEnd() {
+            fixClockAt(endDate); // 2026-06-24 23:59:59.000
+            stubHappyPathSubmit(recruitmentEndingAt(endDate));
+
+            ApplicationRequest req = buildApplicationRequest(List.of(buildTextAnswer(1L, "답변내용")));
+            ApplicationResponse res = recruitmentService.submitApplication(1L, 1L, req);
+
+            assertThat(res.getApplicantId()).isEqualTo(42L);
+        }
+
+        @Test
+        @DisplayName("TC-003 다음날 자정(06-25 00:00:00) 제출 → RECRUITMENT_CLOSED")
+        void submitAtNextMidnight() {
+            fixClockAt(endDate.toLocalDate().plusDays(1).atStartOfDay()); // 2026-06-25 00:00:00
+            User user = createUser(1L);
+            Recruitment r = recruitmentEndingAt(endDate);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(r));
+
+            ApplicationRequest req = buildApplicationRequest(List.of(buildTextAnswer(1L, "답변내용")));
+
+            assertThatThrownBy(() -> recruitmentService.submitApplication(1L, 1L, req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.RECRUITMENT_CLOSED);
         }
     }
 }

--- a/src/test/java/com/boaz/backend/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/service/RecruitmentServiceTest.java
@@ -29,6 +29,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -59,6 +60,7 @@ class RecruitmentServiceTest {
     @BeforeEach
     void setUp() {
         ReflectionTestUtils.setField(recruitmentService, "recruitmentBucket", "test-bucket");
+        ReflectionTestUtils.setField(recruitmentService, "clock", Clock.systemDefaultZone());
     }
 
     // ──────────────────────────────────────────────


### PR DESCRIPTION
## 💡 개요

* Issue Number: #163

모집 마감 판정이 초 단위로 저장된 `end_date`(예: `2026-06-24 23:59:59`)를 밀리초/나노초 정밀도의 `LocalDateTime.now()`와 비교해, 마지막 초(`23:59:59.001~.999`) 제출이 `RECRUITMENT_CLOSED`로 튕기던 문제를 수정합니다.

## 🪐 주요 변경 사항
- 기간 판정용 현재 시각을 **주입된 `Clock` 기반 + 초 단위 버림(`truncatedTo(SECONDS)`)** 으로 처리하는 `RecruitmentService.now()` 헬퍼 도입
- `Recruitment.isActive(LocalDateTime now)` 순수 메서드화 → 서비스 곳곳의 중복 판정 로직 통합
- `ClockConfig`로 `Clock` 빈 등록 (JVM tz `Asia/Seoul` 기준)
- 마감 경계 테스트 추가

## ✅ 상세 내용
- **튕김 원인**: 저장값은 초 단위인데 `now()`는 sub-second까지 가져, `now.isAfter(endDate)`가 `23:59:59.000` 직후부터 참이 되어 마지막 초가 통째로 마감 처리됨
- **수정**: `now()`를 초 단위로 버려 `23:59:59.xxx` 전 구간 접수, `06-25 00:00:00`부터 마감
- `end_date` 데이터(`23:59:59`)와 화면 표시(`~ 6월 24일`)는 **변경 없음** (코드만 수정)
- 적용 범위: 제출 / 임시저장 / 모집중 여부 / 마감 일시 / 공고·질문 조회 / 지원서 삭제 가드 / 관리자 공고 목록 — 모두 동일한 주입 Clock 기준으로 일관
- 타임존은 기존과 동일하게 `Asia/Seoul`로 일관 (불일치 아님)
- 테스트: 고정 `Clock`으로 `23:59:59.999`·마감 정각 제출 → 접수, 익일 자정 제출 → `RECRUITMENT_CLOSED` 검증

## 🔔 참고 사항
- 리포지토리 쿼리(`endDate >= :now`)도 호출부에서 truncate된 `now`를 받아 자동으로 일관됩니다.
- `downloadApplications`의 `LocalDateTime.now()`는 CSV 파일명 타임스탬프용이라 기간 판정과 무관 → 변경하지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**변경 목적**
모집 마감 경계 처리 문제를 해결합니다. 기존에 end_date는 초 단위로 저장되지만 LocalDateTime.now()는 서브초 정밀도로 비교되어, 마감 시각 최종 초(예: 23:59:59.001~.999) 동안의 지원이 거절되는 버그를 수정합니다.

**주요 변경 내용**
- **설정 레이어**: ClockConfig 신규 추가 - Clock bean을 Asia/Seoul 타임존으로 등록
- **도메인 레이어**: Recruitment.isActive() 메서드를 인자 없는 형태에서 LocalDateTime now를 받는 순수 메서드로 변경
- **서비스 레이어**: 
  - RecruitmentService에 Clock 주입 및 now() 헬퍼 메서드 추가 (현재 시각을 초 단위로 truncate)
  - getAllRecruitments(), isRecruitmentActive(), deleteApplicants() 등 모든 현재 시간 체크에서 truncated clock 기반 now() 사용으로 통일
- **DTO 레이어**: RecruitmentResponse.from() 메서드 시그니처를 boolean isActive 파라미터에서 LocalDateTime now 파라미터로 변경
- **테스트 레이어**: RecruitmentServiceTest에 마감 경계 케이스 테스트 추가 (23:59:59.999 지원 수락, 00:00:00 지원 거절 검증)

**영향 범위**
- API 변경: RecruitmentResponse 생성 로직 변경으로 내부 호출부 수정 필요
- 설정 변경: Clock bean 신규 등록
- DB 스키마 변경: 없음 (저장된 end_date 형식 유지)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->