### PR TITLE
[Fix] 모집 예정 공고 조회 시 일정 데이터 미반환 문제 수정

### DIFF
--- a/src/main/java/com/boaz/backend/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/repository/RecruitmentRepository.java
@@ -14,6 +14,10 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> 
     @Query("SELECT r FROM Recruitment r WHERE r.startDate <= :now AND r.endDate >= :now")
     Optional<Recruitment> findActiveRecruitment(LocalDateTime now);
 
+    // 진행 중이거나 아직 마감되지 않은 공고 중 가장 임박한 것 (예정 포함)
+    @Query("SELECT r FROM Recruitment r WHERE r.endDate >= :now ORDER BY r.startDate ASC LIMIT 1")
+    Optional<Recruitment> findCurrentOrUpcoming(LocalDateTime now);
+
     // 기수로 공고 조회
     Optional<Recruitment> findByTerm(Integer term);
 

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -92,11 +92,9 @@ public class RecruitmentService {
 
     // 모집 중 여부 조회
     public RecruitmentStatusResponse getRecruitmentStatus() {
-        Optional<Recruitment> activeRecruitment = recruitmentRepository
-                .findActiveRecruitment(now());
-
-        return activeRecruitment
-                .map(r -> RecruitmentStatusResponse.of(true, r.getTerm()))
+        LocalDateTime now = now();
+        return recruitmentRepository.findCurrentOrUpcoming(now)
+                .map(r -> RecruitmentStatusResponse.of(r.isActive(now), r.getTerm()))
                 .orElse(RecruitmentStatusResponse.of(false, null));
     }
 
@@ -113,9 +111,7 @@ public class RecruitmentService {
         Recruitment recruitment = recruitmentRepository.findByTerm(term)
                 .orElseThrow(() -> new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
 
-        boolean isActive = recruitment.isActive(now());
-
-        return RecruitmentResponse.from(recruitment, isActive);
+        return RecruitmentResponse.from(recruitment, now());
     }
 
     // 지원서 질문 조회하기

--- a/src/test/java/com/boaz/backend/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/service/RecruitmentServiceTest.java
@@ -84,6 +84,14 @@ class RecruitmentServiceTest {
         return r;
     }
 
+    private Recruitment createUpcomingRecruitment() {
+        Recruitment r = Recruitment.create(28,
+                LocalDateTime.now().plusDays(14), LocalDateTime.now().plusDays(30),
+                "[]", null);
+        ReflectionTestUtils.setField(r, "id", 3L);
+        return r;
+    }
+
     private User createUser(Long id) {
         User u = User.builder()
                 .provider("kakao").providerId("test-" + id)
@@ -197,7 +205,7 @@ class RecruitmentServiceTest {
         @DisplayName("TC-001 모집 기간 중 → isActive:true, term 반환")
         void active() {
             Recruitment r = createActiveRecruitment();
-            when(recruitmentRepository.findActiveRecruitment(any())).thenReturn(Optional.of(r));
+            when(recruitmentRepository.findCurrentOrUpcoming(any())).thenReturn(Optional.of(r));
 
             RecruitmentStatusResponse res = recruitmentService.getRecruitmentStatus();
 
@@ -206,9 +214,9 @@ class RecruitmentServiceTest {
         }
 
         @Test
-        @DisplayName("TC-002 모집 기간 외 공고만 있을 때 → isActive:false")
+        @DisplayName("TC-002 마감된 공고만 존재 (endDate 경과) → isActive:false, term:null")
         void expiredRecruitment() {
-            when(recruitmentRepository.findActiveRecruitment(any())).thenReturn(Optional.empty());
+            when(recruitmentRepository.findCurrentOrUpcoming(any())).thenReturn(Optional.empty());
 
             RecruitmentStatusResponse res = recruitmentService.getRecruitmentStatus();
 
@@ -219,7 +227,7 @@ class RecruitmentServiceTest {
         @Test
         @DisplayName("TC-003 공고 데이터 없음 → isActive:false (예외 없음)")
         void noData() {
-            when(recruitmentRepository.findActiveRecruitment(any())).thenReturn(Optional.empty());
+            when(recruitmentRepository.findCurrentOrUpcoming(any())).thenReturn(Optional.empty());
 
             RecruitmentStatusResponse res = recruitmentService.getRecruitmentStatus();
 
@@ -229,10 +237,13 @@ class RecruitmentServiceTest {
         @Test
         @DisplayName("TC-004 start_date 정각 → isActive:true")
         void startDateBoundary() {
-            LocalDateTime now = LocalDateTime.now();
-            Recruitment r = Recruitment.create(27, now, now.plusDays(7), "[]", null);
+            LocalDateTime fixedNow = LocalDateTime.of(2026, 7, 1, 10, 0, 0);
+            Clock fixed = Clock.fixed(fixedNow.atZone(ZoneId.of("Asia/Seoul")).toInstant(), ZoneId.of("Asia/Seoul"));
+            ReflectionTestUtils.setField(recruitmentService, "clock", fixed);
+
+            Recruitment r = Recruitment.create(27, fixedNow, fixedNow.plusDays(7), "[]", null);
             ReflectionTestUtils.setField(r, "id", 1L);
-            when(recruitmentRepository.findActiveRecruitment(any())).thenReturn(Optional.of(r));
+            when(recruitmentRepository.findCurrentOrUpcoming(any())).thenReturn(Optional.of(r));
 
             assertThat(recruitmentService.getRecruitmentStatus().getIsActive()).isTrue();
         }
@@ -240,9 +251,21 @@ class RecruitmentServiceTest {
         @Test
         @DisplayName("TC-005 end_date 1초 초과 → isActive:false")
         void endDatePast() {
-            when(recruitmentRepository.findActiveRecruitment(any())).thenReturn(Optional.empty());
+            when(recruitmentRepository.findCurrentOrUpcoming(any())).thenReturn(Optional.empty());
 
             assertThat(recruitmentService.getRecruitmentStatus().getIsActive()).isFalse();
+        }
+
+        @Test
+        @DisplayName("TC-006 예정 공고 존재 (start_date 미래) → isActive:false, term 반환")
+        void upcomingRecruitment() {
+            Recruitment r = createUpcomingRecruitment();
+            when(recruitmentRepository.findCurrentOrUpcoming(any())).thenReturn(Optional.of(r));
+
+            RecruitmentStatusResponse res = recruitmentService.getRecruitmentStatus();
+
+            assertThat(res.getIsActive()).isFalse();
+            assertThat(res.getTerm()).isEqualTo(28);
         }
     }
 
@@ -285,6 +308,21 @@ class RecruitmentServiceTest {
                     .isInstanceOf(CustomException.class)
                     .extracting(e -> ((CustomException) e).getErrorCode())
                     .isEqualTo(ErrorCode.RECRUITMENT_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("TC-004 예정 공고 조회 → isActive:false + 날짜/일정 필드 반환 (null 아님)")
+        void upcomingRecruitment() {
+            Recruitment r = createUpcomingRecruitment();
+            when(recruitmentRepository.findByTerm(28)).thenReturn(Optional.of(r));
+
+            RecruitmentResponse res = recruitmentService.getRecruitment(28);
+
+            assertThat(res.getIsActive()).isFalse();
+            assertThat(res.getTerm()).isEqualTo(28);
+            assertThat(res.getStartDate()).isNotNull();
+            assertThat(res.getEndDate()).isNotNull();
+            assertThat(res.getSchedule()).isNotNull();
         }
     }
 


### PR DESCRIPTION
## 💡 개요

* Issue Number: #166

## 🪐 주요 변경 사항
- `findCurrentOrUpcoming` 쿼리 추가 — endDate 미경과 공고 중 startDate 가장 임박한 것 반환 (모집 중 + 예정 공고 모두 포함)
- `getRecruitmentStatus`: 예정 공고 존재 시 `is_active: false`여도 `term` 반환
- `getRecruitment`: `is_active` 여부와 무관하게 `start_date`, `end_date`, `schedule`, `brochure_url` 등 모든 필드 반환 (`brochure_url`은 미등록 시 null)

## ✅ 상세 내용
- 기존 `findActiveRecruitment`는 모집 중인 공고만 잡아 예정 공고의 term을 `/status`에서 내려줄 수 없었음
- `findCurrentOrUpcoming`은 `endDate >= now` 조건으로 모집 중 + 예정을 함께 조회하고, `r.isActive(now)`로 `is_active` 값을 정확히 계산
- 기존 `RecruitmentResponse.from(recruitment, isActive)` 생성자는 `is_active: false`일 때 날짜/일정 필드를 null로 덮어쓰는 문제가 있어, `from(recruitment, now())` 생성자로 교체

## 🔔 참고 사항
- 프론트 분기 기준: `term` 없음 → 섹션 미렌더 / `term` 있고 `is_active: false` → 시작일까지 D-day + 사전알림 / `term` 있고 `is_active: true` → 마감일까지 카운트다운
- 다음 모집 공고는 일정 확정 시(모집 시작 2~3주 전) 운영팀이 DB에 미리 등록 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 변경 목적
모집 예정 공고 조회 시 일정 데이터가 반환되지 않는 문제를 해결하기 위해, 리포지토리 쿼리를 추가하고 서비스 로직을 개선하여 활성 공고뿐만 아니라 예정 공고도 함께 조회하고 일정 정보를 정상 반환하도록 수정했습니다.

## 주요 변경 내용

**Repository 레이어**
- `findCurrentOrUpcoming(LocalDateTime now)` 메서드 추가: endDate가 현재 이후인 공고 중 startDate가 가장 임박한 공고 1건 조회 (활성 + 예정 공고 포함)

**Service 레이어**
- `getRecruitmentStatus()`: 기존 활성 모집만 조회하던 방식에서 현재/예정 공고 조회로 변경; 예정 공고 존재 시에도 일정(term) 정보 반환
- `getRecruitment()`: `is_active` 값과 무관하게 `start_date`, `end_date`, `schedule`, `brochure_url` 등 모든 날짜/일정 필드 반환

**Test 레이어**
- 예정 공고 생성 헬퍼 메서드 추가
- 리포지토리 스태빙을 `findActiveRecruitment()`에서 `findCurrentOrUpcoming()`으로 변경
- 예정 공고(`is_active:false`) 케이스에 대한 테스트 커버리지 확충

## 영향 범위
- **API 변경**: `/status` 엔드포인트가 예정 공고의 일정(term) 정보를 추가로 반환
- **DB 스키마 변경**: 없음
- **설정 변경**: 없음

<!-- end of auto-generated comment: release notes by coderabbit.ai -->