### PR TITLE
[Fix] #168 질문 조회 API 부문명 치환 오류 수정

### DIFF
--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -143,7 +143,7 @@ public class RecruitmentService {
         return questions.stream()
             .map(question -> {
                 String content = question.getContent() != null
-                        ? question.getContent().replace("{Track}", track.name())
+                        ? question.getContent().replace("{부문}", track.getDisplayName())
                         : null;
                 return QuestionResponse.from(question, content);
             })

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -143,7 +143,7 @@ public class RecruitmentService {
         return questions.stream()
             .map(question -> {
                 String content = question.getContent() != null
-                        ? question.getContent().replace("{부문}", track.getDisplayName())
+                        ? question.getContent().replace("{Track}", track.getDisplayName())
                         : null;
                 return QuestionResponse.from(question, content);
             })

--- a/src/main/java/com/boaz/backend/global/common/enums/Track.java
+++ b/src/main/java/com/boaz/backend/global/common/enums/Track.java
@@ -4,8 +4,17 @@ import com.boaz.backend.global.exception.CustomException;
 import com.boaz.backend.global.exception.ErrorCode;
 
 public enum Track {
-    // 전부문, 분석, 시각화, 엔지니어링
-    ALL, ANALYSIS, VISUALIZATION, ENGINEERING;
+    ALL("전부문"), ANALYSIS("분석"), VISUALIZATION("시각화"), ENGINEERING("엔지니어링");
+
+    private final String displayName;
+
+    Track(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
 
     public void validateNotAll() {
         if (this == ALL) {

--- a/src/test/java/com/boaz/backend/domain/recruitment/integration/RecruitmentIntegrationTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/integration/RecruitmentIntegrationTest.java
@@ -429,7 +429,7 @@ class RecruitmentIntegrationTest extends TestcontainersBase {
             assertThat(result).hasSize(2);
             assertThat(result).extracting(QuestionResponse::getOrderNum).containsExactly(1, 2);
             assertThat(result).noneMatch(q -> q.getCategory().equals("VISUALIZATION"));
-            assertThat(result.get(1).getContent()).contains("ENGINEERING");
+            assertThat(result.get(1).getContent()).contains("엔지니어링");
         }
 
         @Test


### PR DESCRIPTION
@coderabbitai ignore

## 💡 개요

* Issue Number: #168

## 🪐 주요 변경 사항
- `Track` enum에 한글 displayName 필드 추가
- `getQuestions()`에서 `{Track}` 플레이스홀더를 `track.getDisplayName()`으로 치환하도록 수정

## ✅ 상세 내용
- `Track.ANALYSIS` → `분석`, `Track.VISUALIZATION` → `시각화`, `Track.ENGINEERING` → `엔지니어링`
- 기존 `track.name()`은 enum 이름(영문)을 반환해 한글 부문명이 아닌 `ANALYSIS` 등이 노출되던 문제 수정
- 관련 통합 테스트 검증값 수정 (`ENGINEERING` → `엔지니어링`)

## 🔔 참고 사항
- DB 데이터의 `{Track}` 플레이스홀더 통일 작업은 별도 진행