### PR TITLE
[Test] recruitment admin CRUD 테스트

### DIFF
--- a/src/test/java/com/boaz/backend/domain/recruitment/controller/RecruitmentAdminControllerTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/controller/RecruitmentAdminControllerTest.java
@@ -556,7 +556,7 @@ class RecruitmentAdminControllerTest {
         }
 
         @Test
-        @DisplayName("EX-002 item의 order_num 0 → 400 INVALID_INPUT_VALUE (@Valid cascade @Positive)")
+        @DisplayName("TC-009b item의 order_num 0 → 400 INVALID_INPUT_VALUE (@Valid cascade @Positive)")
         void itemOrderNumNotPositive() throws Exception {
             Map<String, Object> item = new HashMap<>();
             item.put("label", "공통1");

--- a/src/test/java/com/boaz/backend/domain/recruitment/controller/RecruitmentAdminControllerTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/controller/RecruitmentAdminControllerTest.java
@@ -556,6 +556,29 @@ class RecruitmentAdminControllerTest {
         }
 
         @Test
+        @DisplayName("EX-002 item의 order_num 0 → 400 INVALID_INPUT_VALUE (@Valid cascade @Positive)")
+        void itemOrderNumNotPositive() throws Exception {
+            Map<String, Object> item = new HashMap<>();
+            item.put("label", "공통1");
+            item.put("category", "COMMON");
+            item.put("type", "TEXT");
+            item.put("content", "질문");
+            item.put("limit_length", 500);
+            item.put("order_num", 0); // @Positive 위반
+            item.put("is_required", true);
+            Map<String, Object> body = new HashMap<>();
+            body.put("recruitment_id", 1);
+            body.put("questions", List.of(item));
+
+            mockMvc.perform(post("/api/v1/admin/recruitment/questions")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(body)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error_code").value("INVALID_INPUT_VALUE"));
+        }
+
+        @Test
         @DisplayName("EX-005 존재하지 않는 공고 → 404 RECRUITMENT_NOT_FOUND")
         void notFound() throws Exception {
             when(recruitmentService.createQuestions(any()))

--- a/src/test/java/com/boaz/backend/domain/recruitment/controller/RecruitmentAdminControllerTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/controller/RecruitmentAdminControllerTest.java
@@ -1,6 +1,15 @@
 package com.boaz.backend.domain.recruitment.controller;
 
+import com.boaz.backend.domain.recruitment.dto.response.QuestionIdResponse;
+import com.boaz.backend.domain.recruitment.dto.response.QuestionIdsResponse;
+import com.boaz.backend.domain.recruitment.dto.response.QuestionResponse;
+import com.boaz.backend.domain.recruitment.dto.response.RecruitmentIdResponse;
+import com.boaz.backend.domain.recruitment.dto.response.RecruitmentResponse;
 import com.boaz.backend.domain.recruitment.dto.response.SubscriptionResponse;
+import com.boaz.backend.domain.recruitment.entity.ApplicationQuestion;
+import com.boaz.backend.domain.recruitment.entity.ApplicationQuestion.Category;
+import com.boaz.backend.domain.recruitment.entity.ApplicationQuestion.Type;
+import com.boaz.backend.domain.recruitment.entity.Recruitment;
 import com.boaz.backend.domain.recruitment.entity.Subscription;
 import com.boaz.backend.domain.recruitment.service.RecruitmentService;
 import com.boaz.backend.global.exception.CustomException;
@@ -23,10 +32,17 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
+import org.springframework.http.MediaType;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -258,5 +274,478 @@ class RecruitmentAdminControllerTest {
         Subscription s = Subscription.builder().email(email).build();
         ReflectionTestUtils.setField(s, "id", id);
         return SubscriptionResponse.from(s);
+    }
+
+    private RecruitmentResponse buildRecruitmentResponse(Long id, int term) {
+        Recruitment r = Recruitment.create(term,
+                LocalDateTime.now().minusDays(1), LocalDateTime.now().plusDays(1), "[]", null);
+        ReflectionTestUtils.setField(r, "id", id);
+        return RecruitmentResponse.from(r, LocalDateTime.now());
+    }
+
+    private QuestionResponse buildQuestionResponse(Long id, int orderNum) {
+        ApplicationQuestion q = ApplicationQuestion.create(
+                null, "L" + id, Category.COMMON, Type.TEXT, "content", null, 500, null, orderNum, true);
+        ReflectionTestUtils.setField(q, "id", id);
+        return QuestionResponse.from(q);
+    }
+
+    private String recruitmentCreateJson(boolean withTerm) throws Exception {
+        Map<String, Object> body = new HashMap<>();
+        if (withTerm) body.put("term", 28);
+        body.put("start_date", "2026-08-01T00:00:00");
+        body.put("end_date", "2026-08-15T23:59:59");
+        body.put("schedule", List.of());
+        body.put("brochure_url", "https://e.com/b.pdf");
+        return objectMapper.writeValueAsString(body);
+    }
+
+    private String questionsCreateJson(boolean withQuestions) throws Exception {
+        Map<String, Object> body = new HashMap<>();
+        body.put("recruitment_id", 1);
+        if (withQuestions) {
+            Map<String, Object> item = new HashMap<>();
+            item.put("label", "공통1");
+            item.put("category", "COMMON");
+            item.put("type", "TEXT");
+            item.put("content", "질문");
+            item.put("limit_length", 500);
+            item.put("order_num", 1);
+            item.put("is_required", true);
+            body.put("questions", List.of(item));
+        } else {
+            body.put("questions", List.of());
+        }
+        return objectMapper.writeValueAsString(body);
+    }
+
+    // ──────────────────────────────────────────────
+    // REC-ADMIN-002: GET /api/v1/admin/recruitment
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("REC-ADMIN-002 GET /api/v1/admin/recruitment")
+    class GetAllRecruitments {
+
+        @Test
+        @DisplayName("TC-004 정상 조회 → 200 + 목록")
+        void success() throws Exception {
+            when(recruitmentService.getAllRecruitments())
+                    .thenReturn(List.of(buildRecruitmentResponse(12L, 27), buildRecruitmentResponse(11L, 26)));
+
+            mockMvc.perform(get("/api/v1/admin/recruitment")
+                            .with(authentication(adminAuth())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.length()").value(2))
+                    .andExpect(jsonPath("$.data[0].recruitment_id").value(12));
+        }
+
+        @Test
+        @DisplayName("TC-005 미인증 요청 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(get("/api/v1/admin/recruitment"))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.error_code").value("TOKEN_NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("TC-006 User 권한으로 접근 → 403")
+        void forbidden() throws Exception {
+            mockMvc.perform(get("/api/v1/admin/recruitment")
+                            .with(authentication(userAuth())))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.error_code").value("ACCESS_DENIED"));
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // REC-ADMIN-003: POST /api/v1/admin/recruitment
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("REC-ADMIN-003 POST /api/v1/admin/recruitment")
+    class CreateRecruitment {
+
+        @Test
+        @DisplayName("TC-006 정상 등록 → 201 + recruitment_id")
+        void success() throws Exception {
+            when(recruitmentService.createRecruitment(any())).thenReturn(RecruitmentIdResponse.of(13L));
+
+            mockMvc.perform(post("/api/v1/admin/recruitment")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(recruitmentCreateJson(true)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.status").value(201))
+                    .andExpect(jsonPath("$.data.recruitment_id").value(13));
+        }
+
+        @Test
+        @DisplayName("TC-005 필수 필드(term) 누락 → 400 INVALID_INPUT_VALUE (@Valid)")
+        void missingField() throws Exception {
+            mockMvc.perform(post("/api/v1/admin/recruitment")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(recruitmentCreateJson(false)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error_code").value("INVALID_INPUT_VALUE"));
+        }
+
+        @Test
+        @DisplayName("EX-003 중복 기수 → 409 DUPLICATE_TERM")
+        void duplicateTerm() throws Exception {
+            when(recruitmentService.createRecruitment(any()))
+                    .thenThrow(new CustomException(ErrorCode.DUPLICATE_TERM));
+
+            mockMvc.perform(post("/api/v1/admin/recruitment")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(recruitmentCreateJson(true)))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.error_code").value("DUPLICATE_TERM"));
+        }
+
+        @Test
+        @DisplayName("TC-007 미인증 요청 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(post("/api/v1/admin/recruitment")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(recruitmentCreateJson(true)))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("[Security] User 권한으로 접근 → 403")
+        void forbidden() throws Exception {
+            mockMvc.perform(post("/api/v1/admin/recruitment")
+                            .with(authentication(userAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(recruitmentCreateJson(true)))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // REC-ADMIN-004: PATCH /api/v1/admin/recruitment/{id}
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("REC-ADMIN-004 PATCH /api/v1/admin/recruitment/{id}")
+    class UpdateRecruitment {
+
+        @Test
+        @DisplayName("TC-007 정상 수정 → 200 + recruitment_id")
+        void success() throws Exception {
+            when(recruitmentService.updateRecruitment(eq(12L), any())).thenReturn(RecruitmentIdResponse.of(12L));
+
+            mockMvc.perform(patch("/api/v1/admin/recruitment/12")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"start_date\":\"2026-08-01T00:00:00\"}"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.recruitment_id").value(12));
+        }
+
+        @Test
+        @DisplayName("EX-003 존재하지 않는 공고 → 404 RECRUITMENT_NOT_FOUND")
+        void notFound() throws Exception {
+            when(recruitmentService.updateRecruitment(eq(999L), any()))
+                    .thenThrow(new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
+
+            mockMvc.perform(patch("/api/v1/admin/recruitment/999")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"term\":28}"))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.error_code").value("RECRUITMENT_NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("[Security] 미인증 요청 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(patch("/api/v1/admin/recruitment/12")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{}"))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("[Security] User 권한으로 접근 → 403")
+        void forbidden() throws Exception {
+            mockMvc.perform(patch("/api/v1/admin/recruitment/12")
+                            .with(authentication(userAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{}"))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // REC-ADMIN-005: DELETE /api/v1/admin/recruitment/{id}
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("REC-ADMIN-005 DELETE /api/v1/admin/recruitment/{id}")
+    class DeleteRecruitment {
+
+        @Test
+        @DisplayName("TC-005 정상 삭제 → 200")
+        void success() throws Exception {
+            doNothing().when(recruitmentService).deleteRecruitment(12L);
+
+            mockMvc.perform(delete("/api/v1/admin/recruitment/12")
+                            .with(authentication(adminAuth())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200));
+        }
+
+        @Test
+        @DisplayName("EX-001 연관 데이터 존재 → 400 RECRUITMENT_HAS_REFERENCES")
+        void hasReferences() throws Exception {
+            doThrow(new CustomException(ErrorCode.RECRUITMENT_HAS_REFERENCES))
+                    .when(recruitmentService).deleteRecruitment(12L);
+
+            mockMvc.perform(delete("/api/v1/admin/recruitment/12")
+                            .with(authentication(adminAuth())))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error_code").value("RECRUITMENT_HAS_REFERENCES"));
+        }
+
+        @Test
+        @DisplayName("[Security] 미인증 요청 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(delete("/api/v1/admin/recruitment/12"))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("[Security] User 권한으로 접근 → 403")
+        void forbidden() throws Exception {
+            mockMvc.perform(delete("/api/v1/admin/recruitment/12")
+                            .with(authentication(userAuth())))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // REC-ADMIN-006: POST /api/v1/admin/recruitment/questions
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("REC-ADMIN-006 POST /api/v1/admin/recruitment/questions")
+    class CreateQuestions {
+
+        @Test
+        @DisplayName("TC-001 정상 등록 → 201 + ids")
+        void success() throws Exception {
+            when(recruitmentService.createQuestions(any())).thenReturn(QuestionIdsResponse.of(List.of(1L, 2L)));
+
+            mockMvc.perform(post("/api/v1/admin/recruitment/questions")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(questionsCreateJson(true)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.data.ids.length()").value(2));
+        }
+
+        @Test
+        @DisplayName("TC-009 questions 빈 배열 → 400 INVALID_INPUT_VALUE (@NotEmpty)")
+        void emptyQuestions() throws Exception {
+            mockMvc.perform(post("/api/v1/admin/recruitment/questions")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(questionsCreateJson(false)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error_code").value("INVALID_INPUT_VALUE"));
+        }
+
+        @Test
+        @DisplayName("EX-005 존재하지 않는 공고 → 404 RECRUITMENT_NOT_FOUND")
+        void notFound() throws Exception {
+            when(recruitmentService.createQuestions(any()))
+                    .thenThrow(new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
+
+            mockMvc.perform(post("/api/v1/admin/recruitment/questions")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(questionsCreateJson(true)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.error_code").value("RECRUITMENT_NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("[Security] 미인증 요청 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(post("/api/v1/admin/recruitment/questions")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(questionsCreateJson(true)))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("[Security] User 권한으로 접근 → 403")
+        void forbidden() throws Exception {
+            mockMvc.perform(post("/api/v1/admin/recruitment/questions")
+                            .with(authentication(userAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(questionsCreateJson(true)))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // REC-ADMIN-007: GET /api/v1/admin/recruitment/{recruitmentId}/questions
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("REC-ADMIN-007 GET /api/v1/admin/recruitment/{recruitmentId}/questions")
+    class GetAdminQuestions {
+
+        @Test
+        @DisplayName("TC-006 정상 조회 → 200 + 목록")
+        void success() throws Exception {
+            when(recruitmentService.getAdminQuestions(12L))
+                    .thenReturn(List.of(buildQuestionResponse(1L, 1), buildQuestionResponse(2L, 10)));
+
+            mockMvc.perform(get("/api/v1/admin/recruitment/12/questions")
+                            .with(authentication(adminAuth())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.length()").value(2))
+                    .andExpect(jsonPath("$.data[0].order_num").value(1));
+        }
+
+        @Test
+        @DisplayName("EX-001 존재하지 않는 공고 → 404 RECRUITMENT_NOT_FOUND")
+        void notFound() throws Exception {
+            when(recruitmentService.getAdminQuestions(999L))
+                    .thenThrow(new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
+
+            mockMvc.perform(get("/api/v1/admin/recruitment/999/questions")
+                            .with(authentication(adminAuth())))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.error_code").value("RECRUITMENT_NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("[Security] 미인증 요청 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(get("/api/v1/admin/recruitment/12/questions"))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("[Security] User 권한으로 접근 → 403")
+        void forbidden() throws Exception {
+            mockMvc.perform(get("/api/v1/admin/recruitment/12/questions")
+                            .with(authentication(userAuth())))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // REC-ADMIN-008: PATCH /api/v1/admin/recruitment/questions/{questionId}
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("REC-ADMIN-008 PATCH /api/v1/admin/recruitment/questions/{questionId}")
+    class UpdateQuestion {
+
+        @Test
+        @DisplayName("TC-008 정상 수정 → 200 + question_id")
+        void success() throws Exception {
+            when(recruitmentService.updateQuestion(eq(1L), any())).thenReturn(QuestionIdResponse.of(1L));
+
+            mockMvc.perform(patch("/api/v1/admin/recruitment/questions/1")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"content\":\"수정된 내용\"}"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.question_id").value(1));
+        }
+
+        @Test
+        @DisplayName("EX-003 존재하지 않는 질문 → 404 QUESTIONS_NOT_FOUND")
+        void notFound() throws Exception {
+            when(recruitmentService.updateQuestion(eq(999L), any()))
+                    .thenThrow(new CustomException(ErrorCode.QUESTIONS_NOT_FOUND));
+
+            mockMvc.perform(patch("/api/v1/admin/recruitment/questions/999")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"content\":\"x\"}"))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.error_code").value("QUESTIONS_NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("[Security] 미인증 요청 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(patch("/api/v1/admin/recruitment/questions/1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{}"))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("[Security] User 권한으로 접근 → 403")
+        void forbidden() throws Exception {
+            mockMvc.perform(patch("/api/v1/admin/recruitment/questions/1")
+                            .with(authentication(userAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{}"))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // REC-ADMIN-009: DELETE /api/v1/admin/recruitment/questions/{questionId}
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("REC-ADMIN-009 DELETE /api/v1/admin/recruitment/questions/{questionId}")
+    class DeleteQuestion {
+
+        @Test
+        @DisplayName("TC-004 정상 삭제 → 200")
+        void success() throws Exception {
+            doNothing().when(recruitmentService).deleteQuestion(1L);
+
+            mockMvc.perform(delete("/api/v1/admin/recruitment/questions/1")
+                            .with(authentication(adminAuth())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200));
+        }
+
+        @Test
+        @DisplayName("EX-001 참조 답변 존재 → 400 QUESTION_HAS_ANSWERS")
+        void hasAnswers() throws Exception {
+            doThrow(new CustomException(ErrorCode.QUESTION_HAS_ANSWERS))
+                    .when(recruitmentService).deleteQuestion(1L);
+
+            mockMvc.perform(delete("/api/v1/admin/recruitment/questions/1")
+                            .with(authentication(adminAuth())))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error_code").value("QUESTION_HAS_ANSWERS"));
+        }
+
+        @Test
+        @DisplayName("EX-002 존재하지 않는 질문 → 404 QUESTIONS_NOT_FOUND")
+        void notFound() throws Exception {
+            doThrow(new CustomException(ErrorCode.QUESTIONS_NOT_FOUND))
+                    .when(recruitmentService).deleteQuestion(999L);
+
+            mockMvc.perform(delete("/api/v1/admin/recruitment/questions/999")
+                            .with(authentication(adminAuth())))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.error_code").value("QUESTIONS_NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("[Security] 미인증 요청 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(delete("/api/v1/admin/recruitment/questions/1"))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("[Security] User 권한으로 접근 → 403")
+        void forbidden() throws Exception {
+            mockMvc.perform(delete("/api/v1/admin/recruitment/questions/1")
+                            .with(authentication(userAuth())))
+                    .andExpect(status().isForbidden());
+        }
     }
 }

--- a/src/test/java/com/boaz/backend/domain/recruitment/integration/RecruitmentIntegrationTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/integration/RecruitmentIntegrationTest.java
@@ -2,6 +2,11 @@ package com.boaz.backend.domain.recruitment.integration;
 
 import com.boaz.backend.domain.recruitment.dto.request.ApplicationRequest;
 import com.boaz.backend.domain.recruitment.dto.request.DraftApplicationRequest;
+import com.boaz.backend.domain.recruitment.dto.request.QuestionItemRequest;
+import com.boaz.backend.domain.recruitment.dto.request.QuestionUpdateRequest;
+import com.boaz.backend.domain.recruitment.dto.request.QuestionsCreateRequest;
+import com.boaz.backend.domain.recruitment.dto.request.RecruitmentCreateRequest;
+import com.boaz.backend.domain.recruitment.dto.request.RecruitmentUpdateRequest;
 import com.boaz.backend.domain.recruitment.dto.request.SubscriptionRequest;
 import com.boaz.backend.domain.recruitment.dto.response.ApplicationResponse;
 import com.boaz.backend.domain.recruitment.dto.response.DeadlineResponse;
@@ -31,7 +36,10 @@ import com.boaz.backend.global.exception.CustomException;
 import com.boaz.backend.global.exception.ErrorCode;
 import com.boaz.backend.global.util.S3Service;
 import com.boaz.backend.support.TestcontainersBase;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.openapitools.jackson.nullable.JsonNullable;
+import org.springframework.test.util.ReflectionTestUtils;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.DisplayName;
@@ -666,6 +674,273 @@ class RecruitmentIntegrationTest extends TestcontainersBase {
             em.flush();
 
             assertThat(subscriptionRepository.count()).isZero();
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // Admin CRUD 통합 테스트 헬퍼
+    // ──────────────────────────────────────────────
+
+    private RecruitmentCreateRequest buildCreateReq(int term, LocalDateTime start, LocalDateTime end, String brochure) {
+        RecruitmentCreateRequest req = new RecruitmentCreateRequest();
+        ReflectionTestUtils.setField(req, "term", term);
+        ReflectionTestUtils.setField(req, "startDate", start);
+        ReflectionTestUtils.setField(req, "endDate", end);
+        ReflectionTestUtils.setField(req, "schedule", objectMapper.createArrayNode());
+        ReflectionTestUtils.setField(req, "brochureUrl", brochure);
+        return req;
+    }
+
+    private QuestionItemRequest buildItem(String label, Category category, Type type,
+            Integer limitLength, JsonNode metadata, int orderNum) {
+        QuestionItemRequest item = new QuestionItemRequest();
+        ReflectionTestUtils.setField(item, "label", label);
+        ReflectionTestUtils.setField(item, "category", category);
+        ReflectionTestUtils.setField(item, "type", type);
+        ReflectionTestUtils.setField(item, "content", "내용 " + label);
+        ReflectionTestUtils.setField(item, "limitLength", limitLength);
+        ReflectionTestUtils.setField(item, "metadata", metadata);
+        ReflectionTestUtils.setField(item, "orderNum", orderNum);
+        ReflectionTestUtils.setField(item, "isRequired", true);
+        return item;
+    }
+
+    private QuestionsCreateRequest buildQuestionsReq(Long recruitmentId, QuestionItemRequest... items) {
+        QuestionsCreateRequest req = new QuestionsCreateRequest();
+        ReflectionTestUtils.setField(req, "recruitmentId", recruitmentId);
+        ReflectionTestUtils.setField(req, "questions", List.of(items));
+        return req;
+    }
+
+    @Nested
+    @DisplayName("모집 공고 CRUD end-to-end (REC-ADMIN-002~005)")
+    class AdminRecruitmentCrud {
+
+        @Test
+        @DisplayName("REC-ADMIN-003 공고 등록 → 실제 DB 영속")
+        void createPersists() {
+            LocalDateTime now = LocalDateTime.now();
+            RecruitmentCreateRequest req = buildCreateReq(28, now.plusDays(1), now.plusDays(15), "https://e.com/b.pdf");
+
+            recruitmentService.createRecruitment(req);
+            em.flush();
+            em.clear();
+
+            assertThat(recruitmentRepository.findByTerm(28)).isPresent();
+        }
+
+        @Test
+        @DisplayName("REC-ADMIN-003 동일 기수 재등록 → DUPLICATE_TERM")
+        void createDuplicateTerm() {
+            saveActiveRecruitment(27);
+            em.flush();
+            LocalDateTime now = LocalDateTime.now();
+            RecruitmentCreateRequest req = buildCreateReq(27, now.plusDays(1), now.plusDays(15), null);
+
+            assertThatThrownBy(() -> recruitmentService.createRecruitment(req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.DUPLICATE_TERM);
+        }
+
+        @Test
+        @DisplayName("REC-ADMIN-004 start_date만 수정 → 해당 필드만 변경, 나머지 유지")
+        void updatePartial() {
+            Recruitment r = saveActiveRecruitment(27);
+            Long id = r.getId();
+            em.flush();
+            em.clear();
+
+            LocalDateTime newStart = LocalDateTime.now().minusDays(3).withNano(0);
+            RecruitmentUpdateRequest req = new RecruitmentUpdateRequest();
+            ReflectionTestUtils.setField(req, "startDate", newStart);
+
+            recruitmentService.updateRecruitment(id, req);
+            em.flush();
+            em.clear();
+
+            Recruitment reloaded = recruitmentRepository.findById(id).orElseThrow();
+            assertThat(reloaded.getStartDate()).isEqualToIgnoringNanos(newStart);
+            assertThat(reloaded.getTerm()).isEqualTo(27);
+        }
+
+        @Test
+        @DisplayName("REC-ADMIN-004 brochure_url null 명시 전송 → 삭제")
+        void updateDeleteBrochure() {
+            LocalDateTime now = LocalDateTime.now();
+            Recruitment r = recruitmentRepository.save(
+                    Recruitment.create(27, now.minusDays(1), now.plusDays(1), "{}", "https://e.com/b.pdf"));
+            Long id = r.getId();
+            em.flush();
+            em.clear();
+
+            RecruitmentUpdateRequest req = new RecruitmentUpdateRequest();
+            ReflectionTestUtils.setField(req, "brochureUrl", JsonNullable.of(null));
+
+            recruitmentService.updateRecruitment(id, req);
+            em.flush();
+            em.clear();
+
+            assertThat(recruitmentRepository.findById(id).orElseThrow().getBrochureUrl()).isNull();
+        }
+
+        @Test
+        @DisplayName("REC-ADMIN-005 연관 데이터 없는 공고 → 삭제됨")
+        void deleteNoRefs() {
+            Recruitment r = saveActiveRecruitment(27);
+            Long id = r.getId();
+            em.flush();
+            em.clear();
+
+            recruitmentService.deleteRecruitment(id);
+            em.flush();
+            em.clear();
+
+            assertThat(recruitmentRepository.findById(id)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("REC-ADMIN-005 연관 질문 존재 → RECRUITMENT_HAS_REFERENCES")
+        void deleteWithRefs() {
+            Recruitment r = saveActiveRecruitment(27);
+            saveQuestion(r, Category.COMMON, 1);
+            em.flush();
+            em.clear();
+
+            assertThatThrownBy(() -> recruitmentService.deleteRecruitment(r.getId()))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.RECRUITMENT_HAS_REFERENCES);
+        }
+    }
+
+    @Nested
+    @DisplayName("지원서 질문 CRUD end-to-end (REC-ADMIN-006~009)")
+    class AdminQuestionCrud {
+
+        @Test
+        @DisplayName("REC-ADMIN-006 TEXT+TABLE 다건 등록 → limit_length/metadata 분기 영속")
+        void createQuestionsPersist() throws Exception {
+            Recruitment r = saveActiveRecruitment(27);
+            em.flush();
+            em.clear();
+
+            JsonNode metadata = objectMapper.readTree("{\"rows\":[\"A\"],\"columns\":[\"B\"]}");
+            QuestionsCreateRequest req = buildQuestionsReq(r.getId(),
+                    buildItem("C1", Category.COMMON, Type.TEXT, 500, null, 1),
+                    buildItem("E1", Category.ENGINEERING, Type.TABLE, null, metadata, 1));
+
+            recruitmentService.createQuestions(req);
+            em.flush();
+            em.clear();
+
+            List<ApplicationQuestion> saved = questionRepository.findByRecruitmentIdOrderByOrderNumAsc(r.getId());
+            assertThat(saved).hasSize(2);
+            ApplicationQuestion text = saved.stream().filter(q -> q.getType() == Type.TEXT).findFirst().orElseThrow();
+            ApplicationQuestion table = saved.stream().filter(q -> q.getType() == Type.TABLE).findFirst().orElseThrow();
+            assertThat(text.getLimitLength()).isEqualTo(500);
+            assertThat(text.getMetadata()).isNull();
+            assertThat(table.getLimitLength()).isNull();
+            assertThat(table.getMetadata()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("REC-ADMIN-006 DB에 동일 label 존재 → DUPLICATE_QUESTION_LABEL")
+        void createDuplicateLabel() {
+            Recruitment r = saveActiveRecruitment(27);
+            questionRepository.save(ApplicationQuestion.create(
+                    r, "C1", Category.COMMON, Type.TEXT, "기존", null, 500, null, 1, true));
+            em.flush();
+            em.clear();
+
+            QuestionsCreateRequest req = buildQuestionsReq(r.getId(),
+                    buildItem("C1", Category.COMMON, Type.TEXT, 500, null, 2));
+
+            assertThatThrownBy(() -> recruitmentService.createQuestions(req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.DUPLICATE_QUESTION_LABEL);
+        }
+
+        @Test
+        @DisplayName("REC-ADMIN-007 order_num 오름차순 반환 (is_active 무관)")
+        void getAdminQuestionsOrder() {
+            Recruitment r = saveClosedRecruitment(26); // 마감 공고
+            saveQuestion(r, Category.COMMON, 10);
+            saveQuestion(r, Category.COMMON, 1);
+            em.flush();
+            em.clear();
+
+            List<QuestionResponse> result = recruitmentService.getAdminQuestions(r.getId());
+
+            assertThat(result).extracting(QuestionResponse::getOrderNum).containsExactly(1, 10);
+        }
+
+        @Test
+        @DisplayName("REC-ADMIN-007 질문 없음 → 빈 배열 (QUESTIONS_NOT_FOUND 아님)")
+        void getAdminQuestionsEmpty() {
+            Recruitment r = saveActiveRecruitment(27);
+            em.flush();
+            em.clear();
+
+            assertThat(recruitmentService.getAdminQuestions(r.getId())).isEmpty();
+        }
+
+        @Test
+        @DisplayName("REC-ADMIN-008 TEXT→TABLE 타입 변경 → metadata 저장, limit_length 정리")
+        void updateTypeChange() throws Exception {
+            Recruitment r = saveActiveRecruitment(27);
+            ApplicationQuestion q = saveQuestion(r, Category.COMMON, 1); // TEXT, limit 500
+            Long qid = q.getId();
+            em.flush();
+            em.clear();
+
+            QuestionUpdateRequest req = new QuestionUpdateRequest();
+            ReflectionTestUtils.setField(req, "type", Type.TABLE);
+            ReflectionTestUtils.setField(req, "metadata",
+                    JsonNullable.of(objectMapper.readTree("{\"rows\":[\"A\"],\"columns\":[\"B\"]}")));
+
+            recruitmentService.updateQuestion(qid, req);
+            em.flush();
+            em.clear();
+
+            ApplicationQuestion reloaded = questionRepository.findById(qid).orElseThrow();
+            assertThat(reloaded.getType()).isEqualTo(Type.TABLE);
+            assertThat(reloaded.getMetadata()).isNotNull();
+            assertThat(reloaded.getLimitLength()).isNull();
+        }
+
+        @Test
+        @DisplayName("REC-ADMIN-009 답변 없는 질문 → 삭제됨")
+        void deleteQuestionNoAnswers() {
+            Recruitment r = saveActiveRecruitment(27);
+            ApplicationQuestion q = saveQuestion(r, Category.COMMON, 1);
+            Long qid = q.getId();
+            em.flush();
+            em.clear();
+
+            recruitmentService.deleteQuestion(qid);
+            em.flush();
+            em.clear();
+
+            assertThat(questionRepository.findById(qid)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("REC-ADMIN-009 참조 답변 존재 → QUESTION_HAS_ANSWERS")
+        void deleteQuestionWithAnswers() {
+            Recruitment r = saveActiveRecruitment(27);
+            User u = saveUser();
+            ApplicationQuestion q = saveQuestion(r, Category.COMMON, 1);
+            Applicant a = applicantRepository.save(Applicant.builder()
+                    .recruitment(r).user(u).status(Applicant.ApplicantStatus.SUBMITTED)
+                    .track(Track.ENGINEERING).name("n").email("a@example.com").phone("01012345678")
+                    .build());
+            answerRepository.save(ApplicantAnswer.builder()
+                    .applicant(a).question(q).answerText("답").build());
+            em.flush();
+            em.clear();
+
+            assertThatThrownBy(() -> recruitmentService.deleteQuestion(q.getId()))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.QUESTION_HAS_ANSWERS);
         }
     }
 }

--- a/src/test/java/com/boaz/backend/domain/recruitment/integration/RecruitmentIntegrationTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/integration/RecruitmentIntegrationTest.java
@@ -860,6 +860,31 @@ class RecruitmentIntegrationTest extends TestcontainersBase {
         }
 
         @Test
+        @DisplayName("REC-ADMIN-006 TC-011 두 번째 항목 충돌 시 앞 항목 포함 전체 미저장 (원자성)")
+        void createPartialFailureRollsBackAll() {
+            Recruitment r = saveActiveRecruitment(27);
+            questionRepository.save(ApplicationQuestion.create(
+                    r, "EXIST", Category.COMMON, Type.TEXT, "기존", null, 500, null, 1, true));
+            em.flush();
+            em.clear();
+
+            // item1(NEW1)은 유효하지만, item2(EXIST)가 DB label 과 충돌 → 전체 실패해야 함
+            QuestionsCreateRequest req = buildQuestionsReq(r.getId(),
+                    buildItem("NEW1", Category.COMMON, Type.TEXT, 500, null, 2),
+                    buildItem("EXIST", Category.ENGINEERING, Type.TEXT, 500, null, 1));
+
+            assertThatThrownBy(() -> recruitmentService.createQuestions(req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.DUPLICATE_QUESTION_LABEL);
+            em.flush();
+            em.clear();
+
+            // 기존 EXIST 1건만 남고 NEW1 은 저장되지 않아야 함
+            List<ApplicationQuestion> saved = questionRepository.findByRecruitmentIdOrderByOrderNumAsc(r.getId());
+            assertThat(saved).extracting(ApplicationQuestion::getLabel).containsExactly("EXIST");
+        }
+
+        @Test
         @DisplayName("REC-ADMIN-007 order_num 오름차순 반환 (is_active 무관)")
         void getAdminQuestionsOrder() {
             Recruitment r = saveClosedRecruitment(26); // 마감 공고

--- a/src/test/java/com/boaz/backend/domain/recruitment/repository/ApplicationQuestionRepositoryTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/repository/ApplicationQuestionRepositoryTest.java
@@ -86,6 +86,12 @@ class ApplicationQuestionRepositoryTest extends TestcontainersBase {
         assertThat(questionRepository.existsByRecruitmentIdAndLabel(r.getId(), "공통1")).isTrue();
         assertThat(questionRepository.existsByRecruitmentIdAndLabel(r.getId(), "없는라벨")).isFalse();
 
+        // label 자기 자신 제외 (REC-ADMIN-008 질문 수정 중복 검증)
+        assertThat(questionRepository.existsByRecruitmentIdAndLabelAndIdNot(
+                r.getId(), "공통1", savedId)).isFalse();
+        assertThat(questionRepository.existsByRecruitmentIdAndLabelAndIdNot(
+                r.getId(), "공통1", savedId + 1)).isTrue();
+
         assertThat(questionRepository.existsByRecruitmentIdAndCategoryAndOrderNum(
                 r.getId(), Category.COMMON, 1)).isTrue();
         // 자기 자신(savedId) 제외 시 중복 아님
@@ -93,5 +99,18 @@ class ApplicationQuestionRepositoryTest extends TestcontainersBase {
                 r.getId(), Category.COMMON, 1, savedId)).isFalse();
         assertThat(questionRepository.existsByRecruitmentIdAndCategoryAndOrderNumAndIdNot(
                 r.getId(), Category.COMMON, 1, savedId + 1)).isTrue();
+    }
+
+    @Test
+    @DisplayName("existsByRecruitmentId: 공고 연관 질문 존재 여부 (REC-ADMIN-005 삭제 가드)")
+    void existsByRecruitmentId() {
+        Recruitment r = persistRecruitment(27);
+        Recruitment empty = persistRecruitment(26);
+        persistQuestion(r, "공통1", Category.COMMON, 1);
+        em.flush();
+        em.clear();
+
+        assertThat(questionRepository.existsByRecruitmentId(r.getId())).isTrue();
+        assertThat(questionRepository.existsByRecruitmentId(empty.getId())).isFalse();
     }
 }

--- a/src/test/java/com/boaz/backend/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/service/RecruitmentServiceTest.java
@@ -1737,6 +1737,21 @@ class RecruitmentServiceTest {
                     .isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
             verify(recruitmentRepository, never()).save(any());
         }
+
+        @Test
+        @DisplayName("TC-004b end_date < start_date → INVALID_INPUT_VALUE")
+        void endBeforeStart() {
+            LocalDateTime start = LocalDateTime.now().plusDays(15);
+            LocalDateTime end = LocalDateTime.now().plusDays(1); // end < start
+            RecruitmentCreateRequest req = buildCreateRecruitmentReq(28, start, end, null);
+            when(recruitmentRepository.existsByTerm(28)).thenReturn(false);
+
+            assertThatThrownBy(() -> recruitmentService.createRecruitment(req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
+            verify(recruitmentRepository, never()).save(any());
+        }
     }
 
     // ══════════════════════════════════════════════
@@ -1788,6 +1803,21 @@ class RecruitmentServiceTest {
             recruitmentService.updateRecruitment(1L, req);
 
             assertThat(r.getBrochureUrl()).isNull();
+        }
+
+        @Test
+        @DisplayName("TC-003b brochure_url 미전송(undefined) → 기존 값 유지")
+        void brochureUndefinedKept() {
+            Recruitment r = createActiveRecruitment(); // brochure 존재
+            String original = r.getBrochureUrl();
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(r));
+            RecruitmentUpdateRequest req = new RecruitmentUpdateRequest();
+            ReflectionTestUtils.setField(req, "startDate", LocalDateTime.now().minusDays(2));
+            // brochureUrl 은 JsonNullable.undefined() 기본값 → 전송 안 함
+
+            recruitmentService.updateRecruitment(1L, req);
+
+            assertThat(r.getBrochureUrl()).isEqualTo(original);
         }
 
         @Test
@@ -2033,6 +2063,22 @@ class RecruitmentServiceTest {
                     .extracting(e -> ((CustomException) e).getErrorCode())
                     .isEqualTo(ErrorCode.MISSING_PARAMETER);
         }
+
+        @Test
+        @DisplayName("TC-008 TABLE인데 metadata 누락 → MISSING_PARAMETER")
+        void tableMissingMetadata() {
+            Recruitment r = createActiveRecruitment();
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(r));
+            QuestionsCreateRequest req = buildQuestionsCreateReq(1L,
+                    buildQuestionItem("T1", ApplicationQuestion.Category.ENGINEERING,
+                            ApplicationQuestion.Type.TABLE, null, null, 1));
+
+            assertThatThrownBy(() -> recruitmentService.createQuestions(req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.MISSING_PARAMETER);
+            verify(applicationQuestionRepository, never()).save(any());
+        }
     }
 
     // ══════════════════════════════════════════════
@@ -2224,6 +2270,22 @@ class RecruitmentServiceTest {
             recruitmentService.updateQuestion(1L, req);
 
             assertThat(q.getMetadata()).isNull();
+        }
+
+        @Test
+        @DisplayName("TC-007b metadata 미전송(undefined) → 기존 값 유지")
+        void metadataUndefinedKept() {
+            Recruitment r = createActiveRecruitment();
+            ApplicationQuestion q = createTableQuestion(1L, r, ApplicationQuestion.Category.ENGINEERING, 1, true);
+            String original = q.getMetadata();
+            when(applicationQuestionRepository.findById(1L)).thenReturn(Optional.of(q));
+            QuestionUpdateRequest req = new QuestionUpdateRequest();
+            ReflectionTestUtils.setField(req, "content", "내용만 수정");
+            // metadata, limitLength, description 모두 JsonNullable.undefined() 기본값 → 미전송
+
+            recruitmentService.updateQuestion(1L, req);
+
+            assertThat(q.getMetadata()).isEqualTo(original);
         }
     }
 

--- a/src/test/java/com/boaz/backend/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/service/RecruitmentServiceTest.java
@@ -2050,6 +2050,25 @@ class RecruitmentServiceTest {
         }
 
         @Test
+        @DisplayName("TC-006b DB에 동일 category order_num 존재 → DUPLICATE_QUESTION_ORDER")
+        void dbDuplicateOrder() {
+            Recruitment r = createActiveRecruitment();
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(r));
+            when(applicationQuestionRepository.existsByRecruitmentIdAndLabel(1L, "C1")).thenReturn(false);
+            when(applicationQuestionRepository.existsByRecruitmentIdAndCategoryAndOrderNum(
+                    1L, ApplicationQuestion.Category.COMMON, 1)).thenReturn(true);
+            QuestionsCreateRequest req = buildQuestionsCreateReq(1L,
+                    buildQuestionItem("C1", ApplicationQuestion.Category.COMMON,
+                            ApplicationQuestion.Type.TEXT, 500, null, 1));
+
+            assertThatThrownBy(() -> recruitmentService.createQuestions(req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.DUPLICATE_QUESTION_ORDER);
+            verify(applicationQuestionRepository, never()).save(any());
+        }
+
+        @Test
         @DisplayName("TC-007 TEXT인데 limit_length 누락 → MISSING_PARAMETER")
         void textMissingLimitLength() {
             Recruitment r = createActiveRecruitment();

--- a/src/test/java/com/boaz/backend/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/service/RecruitmentServiceTest.java
@@ -2065,7 +2065,7 @@ class RecruitmentServiceTest {
         }
 
         @Test
-        @DisplayName("TC-008 TABLE인데 metadata 누락 → MISSING_PARAMETER")
+        @DisplayName("TC-007b TABLE인데 metadata 누락 → MISSING_PARAMETER")
         void tableMissingMetadata() {
             Recruitment r = createActiveRecruitment();
             when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(r));

--- a/src/test/java/com/boaz/backend/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/service/RecruitmentServiceTest.java
@@ -3,7 +3,14 @@ package com.boaz.backend.domain.recruitment.service;
 import com.boaz.backend.domain.recruitment.dto.request.AnswerRequest;
 import com.boaz.backend.domain.recruitment.dto.request.ApplicationRequest;
 import com.boaz.backend.domain.recruitment.dto.request.DraftApplicationRequest;
+import com.boaz.backend.domain.recruitment.dto.request.QuestionItemRequest;
+import com.boaz.backend.domain.recruitment.dto.request.QuestionsCreateRequest;
+import com.boaz.backend.domain.recruitment.dto.request.QuestionUpdateRequest;
+import com.boaz.backend.domain.recruitment.dto.request.RecruitmentCreateRequest;
+import com.boaz.backend.domain.recruitment.dto.request.RecruitmentUpdateRequest;
 import com.boaz.backend.domain.recruitment.dto.request.SubscriptionRequest;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.util.concurrent.atomic.AtomicLong;
 import com.boaz.backend.domain.recruitment.dto.response.*;
 import com.boaz.backend.domain.recruitment.entity.*;
 import com.boaz.backend.domain.recruitment.repository.*;
@@ -1567,6 +1574,703 @@ class RecruitmentServiceTest {
                     .isInstanceOf(CustomException.class)
                     .extracting(e -> ((CustomException) e).getErrorCode())
                     .isEqualTo(ErrorCode.RECRUITMENT_CLOSED);
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // Admin CRUD 테스트 헬퍼
+    // ──────────────────────────────────────────────
+
+    private RecruitmentCreateRequest buildCreateRecruitmentReq(
+            Integer term, LocalDateTime start, LocalDateTime end, String brochure) {
+        RecruitmentCreateRequest req = new RecruitmentCreateRequest();
+        ReflectionTestUtils.setField(req, "term", term);
+        ReflectionTestUtils.setField(req, "startDate", start);
+        ReflectionTestUtils.setField(req, "endDate", end);
+        ReflectionTestUtils.setField(req, "schedule", objectMapper.createArrayNode());
+        ReflectionTestUtils.setField(req, "brochureUrl", brochure);
+        return req;
+    }
+
+    private QuestionItemRequest buildQuestionItem(String label, ApplicationQuestion.Category category,
+            ApplicationQuestion.Type type, Integer limitLength, JsonNode metadata, int orderNum) {
+        QuestionItemRequest item = new QuestionItemRequest();
+        ReflectionTestUtils.setField(item, "label", label);
+        ReflectionTestUtils.setField(item, "category", category);
+        ReflectionTestUtils.setField(item, "type", type);
+        ReflectionTestUtils.setField(item, "content", "질문 " + label);
+        ReflectionTestUtils.setField(item, "limitLength", limitLength);
+        ReflectionTestUtils.setField(item, "metadata", metadata);
+        ReflectionTestUtils.setField(item, "orderNum", orderNum);
+        ReflectionTestUtils.setField(item, "isRequired", true);
+        return item;
+    }
+
+    private QuestionsCreateRequest buildQuestionsCreateReq(Long recruitmentId, QuestionItemRequest... items) {
+        QuestionsCreateRequest req = new QuestionsCreateRequest();
+        ReflectionTestUtils.setField(req, "recruitmentId", recruitmentId);
+        ReflectionTestUtils.setField(req, "questions", List.of(items));
+        return req;
+    }
+
+    // ══════════════════════════════════════════════
+    // REC-ADMIN-002: 모든 모집 공고 조회
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("REC-ADMIN-002 모든 모집 공고 조회")
+    class GetAllRecruitments {
+
+        @Test
+        @DisplayName("TC-001 공고 여러 건 → term 내림차순 목록 반환")
+        void termDescList() {
+            Recruitment r27 = createActiveRecruitment();   // term 27
+            Recruitment r26 = createExpiredRecruitment();  // term 26
+            when(recruitmentRepository.findAllByOrderByTermDesc()).thenReturn(List.of(r27, r26));
+
+            List<RecruitmentResponse> result = recruitmentService.getAllRecruitments();
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).getTerm()).isEqualTo(27);
+        }
+
+        @Test
+        @DisplayName("TC-002 마감/예정 공고 포함 → is_active 무관 전체 필드 반환")
+        void inactiveStillFullFields() {
+            Recruitment upcoming = createUpcomingRecruitment(); // term 28, start 미래
+            Recruitment expired = createExpiredRecruitment();   // term 26, end 과거
+            when(recruitmentRepository.findAllByOrderByTermDesc()).thenReturn(List.of(upcoming, expired));
+
+            List<RecruitmentResponse> result = recruitmentService.getAllRecruitments();
+
+            RecruitmentResponse expiredRes = result.stream()
+                    .filter(r -> r.getTerm() == 26).findFirst().orElseThrow();
+            assertThat(expiredRes.getIsActive()).isFalse();
+            assertThat(expiredRes.getStartDate()).isNotNull();
+            assertThat(expiredRes.getEndDate()).isNotNull();
+
+            RecruitmentResponse upcomingRes = result.stream()
+                    .filter(r -> r.getTerm() == 28).findFirst().orElseThrow();
+            assertThat(upcomingRes.getIsActive()).isFalse();
+            assertThat(upcomingRes.getStartDate()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("TC-003 공고 없음 → 빈 배열 (404 아님)")
+        void empty() {
+            when(recruitmentRepository.findAllByOrderByTermDesc()).thenReturn(Collections.emptyList());
+
+            assertThat(recruitmentService.getAllRecruitments()).isEmpty();
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // REC-ADMIN-003: 모집 공고 등록
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("REC-ADMIN-003 모집 공고 등록")
+    class CreateRecruitment {
+
+        @Test
+        @DisplayName("TC-001 신규 기수 등록 → recruitment_id 반환")
+        void createSuccess() {
+            LocalDateTime start = LocalDateTime.now().plusDays(1);
+            LocalDateTime end = LocalDateTime.now().plusDays(15);
+            RecruitmentCreateRequest req = buildCreateRecruitmentReq(28, start, end, "https://e.com/b.pdf");
+            when(recruitmentRepository.existsByTerm(28)).thenReturn(false);
+            when(recruitmentRepository.save(any())).thenAnswer(inv -> {
+                Recruitment r = inv.getArgument(0);
+                ReflectionTestUtils.setField(r, "id", 13L);
+                return r;
+            });
+
+            RecruitmentIdResponse res = recruitmentService.createRecruitment(req);
+
+            assertThat(res.getRecruitmentId()).isEqualTo(13L);
+            verify(recruitmentRepository).save(any(Recruitment.class));
+        }
+
+        @Test
+        @DisplayName("TC-002 brochure_url 미입력 → null 저장")
+        void nullBrochure() {
+            LocalDateTime start = LocalDateTime.now().plusDays(1);
+            LocalDateTime end = LocalDateTime.now().plusDays(15);
+            RecruitmentCreateRequest req = buildCreateRecruitmentReq(28, start, end, null);
+            when(recruitmentRepository.existsByTerm(28)).thenReturn(false);
+            when(recruitmentRepository.save(any())).thenAnswer(inv -> {
+                Recruitment r = inv.getArgument(0);
+                ReflectionTestUtils.setField(r, "id", 13L);
+                return r;
+            });
+
+            recruitmentService.createRecruitment(req);
+
+            org.mockito.ArgumentCaptor<Recruitment> captor =
+                    org.mockito.ArgumentCaptor.forClass(Recruitment.class);
+            verify(recruitmentRepository).save(captor.capture());
+            assertThat(captor.getValue().getBrochureUrl()).isNull();
+        }
+
+        @Test
+        @DisplayName("TC-003 이미 존재하는 기수 → DUPLICATE_TERM")
+        void duplicateTerm() {
+            RecruitmentCreateRequest req = buildCreateRecruitmentReq(
+                    27, LocalDateTime.now().plusDays(1), LocalDateTime.now().plusDays(15), null);
+            when(recruitmentRepository.existsByTerm(27)).thenReturn(true);
+
+            assertThatThrownBy(() -> recruitmentService.createRecruitment(req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.DUPLICATE_TERM);
+            verify(recruitmentRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("TC-004 end_date == start_date → INVALID_INPUT_VALUE")
+        void endNotAfterStart() {
+            LocalDateTime same = LocalDateTime.now().plusDays(1);
+            RecruitmentCreateRequest req = buildCreateRecruitmentReq(28, same, same, null);
+            when(recruitmentRepository.existsByTerm(28)).thenReturn(false);
+
+            assertThatThrownBy(() -> recruitmentService.createRecruitment(req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
+            verify(recruitmentRepository, never()).save(any());
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // REC-ADMIN-004: 모집 공고 수정
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("REC-ADMIN-004 모집 공고 수정")
+    class UpdateRecruitment {
+
+        @Test
+        @DisplayName("TC-001 start_date만 수정 → 해당 필드만 변경")
+        void updateStartOnly() {
+            Recruitment r = createActiveRecruitment(); // term 27, id 1
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(r));
+            LocalDateTime newStart = LocalDateTime.now().minusDays(2);
+            RecruitmentUpdateRequest req = new RecruitmentUpdateRequest();
+            ReflectionTestUtils.setField(req, "startDate", newStart);
+
+            RecruitmentIdResponse res = recruitmentService.updateRecruitment(1L, req);
+
+            assertThat(res.getRecruitmentId()).isEqualTo(1L);
+            assertThat(r.getStartDate()).isEqualTo(newStart);
+            assertThat(r.getTerm()).isEqualTo(27); // 미포함 필드 유지
+        }
+
+        @Test
+        @DisplayName("TC-002 schedule 수정 → 배열 전체 교체")
+        void replaceSchedule() throws Exception {
+            Recruitment r = createActiveRecruitment();
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(r));
+            var schedule = objectMapper.createArrayNode();
+            schedule.add(objectMapper.createObjectNode().put("step", "서류"));
+            RecruitmentUpdateRequest req = new RecruitmentUpdateRequest();
+            ReflectionTestUtils.setField(req, "schedule", schedule);
+
+            recruitmentService.updateRecruitment(1L, req);
+
+            assertThat(r.getSchedule()).isEqualTo(objectMapper.writeValueAsString(schedule));
+        }
+
+        @Test
+        @DisplayName("TC-003 brochure_url null 명시 전송 → 삭제")
+        void deleteBrochure() {
+            Recruitment r = createActiveRecruitment(); // brochure 존재
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(r));
+            RecruitmentUpdateRequest req = new RecruitmentUpdateRequest();
+            ReflectionTestUtils.setField(req, "brochureUrl", JsonNullable.of(null));
+
+            recruitmentService.updateRecruitment(1L, req);
+
+            assertThat(r.getBrochureUrl()).isNull();
+        }
+
+        @Test
+        @DisplayName("TC-004 존재하지 않는 공고 → RECRUITMENT_NOT_FOUND")
+        void notFound() {
+            when(recruitmentRepository.findById(999L)).thenReturn(Optional.empty());
+            RecruitmentUpdateRequest req = new RecruitmentUpdateRequest();
+
+            assertThatThrownBy(() -> recruitmentService.updateRecruitment(999L, req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.RECRUITMENT_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("TC-005 다른 공고와 term 중복 → DUPLICATE_TERM")
+        void duplicateTerm() {
+            Recruitment r = createActiveRecruitment(); // id 1
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(r));
+            when(recruitmentRepository.existsByTermAndIdNot(26, 1L)).thenReturn(true);
+            RecruitmentUpdateRequest req = new RecruitmentUpdateRequest();
+            ReflectionTestUtils.setField(req, "term", 26);
+
+            assertThatThrownBy(() -> recruitmentService.updateRecruitment(1L, req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.DUPLICATE_TERM);
+        }
+
+        @Test
+        @DisplayName("TC-006 end_date만 수정했는데 기존 start_date보다 이전 → INVALID_INPUT_VALUE")
+        void endBeforeExistingStart() {
+            Recruitment r = createActiveRecruitment(); // start = now-1d
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(r));
+            RecruitmentUpdateRequest req = new RecruitmentUpdateRequest();
+            ReflectionTestUtils.setField(req, "endDate", LocalDateTime.now().minusDays(2));
+
+            assertThatThrownBy(() -> recruitmentService.updateRecruitment(1L, req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // REC-ADMIN-005: 모집 공고 삭제
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("REC-ADMIN-005 모집 공고 삭제")
+    class DeleteRecruitment {
+
+        @Test
+        @DisplayName("TC-001 연관 데이터 없는 공고 → 삭제")
+        void deleteSuccess() {
+            Recruitment r = createActiveRecruitment();
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(r));
+            when(applicantRepository.existsByRecruitmentId(1L)).thenReturn(false);
+            when(applicationQuestionRepository.existsByRecruitmentId(1L)).thenReturn(false);
+
+            recruitmentService.deleteRecruitment(1L);
+
+            verify(recruitmentRepository).delete(r);
+        }
+
+        @Test
+        @DisplayName("TC-002 존재하지 않는 공고 → RECRUITMENT_NOT_FOUND")
+        void notFound() {
+            when(recruitmentRepository.findById(999L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> recruitmentService.deleteRecruitment(999L))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.RECRUITMENT_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("TC-003 연관 지원자 존재 → RECRUITMENT_HAS_REFERENCES")
+        void hasApplicants() {
+            Recruitment r = createActiveRecruitment();
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(r));
+            when(applicantRepository.existsByRecruitmentId(1L)).thenReturn(true);
+
+            assertThatThrownBy(() -> recruitmentService.deleteRecruitment(1L))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.RECRUITMENT_HAS_REFERENCES);
+            verify(recruitmentRepository, never()).delete(any());
+        }
+
+        @Test
+        @DisplayName("TC-004 연관 질문 존재 → RECRUITMENT_HAS_REFERENCES")
+        void hasQuestions() {
+            Recruitment r = createActiveRecruitment();
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(r));
+            when(applicantRepository.existsByRecruitmentId(1L)).thenReturn(false);
+            when(applicationQuestionRepository.existsByRecruitmentId(1L)).thenReturn(true);
+
+            assertThatThrownBy(() -> recruitmentService.deleteRecruitment(1L))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.RECRUITMENT_HAS_REFERENCES);
+            verify(recruitmentRepository, never()).delete(any());
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // REC-ADMIN-006: 지원서 질문 등록
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("REC-ADMIN-006 지원서 질문 등록")
+    class CreateQuestions {
+
+        @Test
+        @DisplayName("TC-001 TEXT+TABLE 다건 등록 → ids 반환")
+        void createMixedSuccess() throws Exception {
+            Recruitment r = createActiveRecruitment();
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(r));
+            when(applicationQuestionRepository.existsByRecruitmentIdAndLabel(eq(1L), any())).thenReturn(false);
+            when(applicationQuestionRepository.existsByRecruitmentIdAndCategoryAndOrderNum(eq(1L), any(), any()))
+                    .thenReturn(false);
+            AtomicLong seq = new AtomicLong(100);
+            when(applicationQuestionRepository.save(any())).thenAnswer(inv -> {
+                ApplicationQuestion q = inv.getArgument(0);
+                ReflectionTestUtils.setField(q, "id", seq.getAndIncrement());
+                return q;
+            });
+
+            JsonNode metadata = objectMapper.readTree("{\"rows\":[\"A\"],\"columns\":[\"B\"]}");
+            QuestionsCreateRequest req = buildQuestionsCreateReq(1L,
+                    buildQuestionItem("C1", ApplicationQuestion.Category.COMMON,
+                            ApplicationQuestion.Type.TEXT, 500, null, 1),
+                    buildQuestionItem("E1", ApplicationQuestion.Category.ENGINEERING,
+                            ApplicationQuestion.Type.TABLE, null, metadata, 1));
+
+            QuestionIdsResponse res = recruitmentService.createQuestions(req);
+
+            assertThat(res.getIds()).hasSize(2);
+            verify(applicationQuestionRepository, times(2)).save(any());
+        }
+
+        @Test
+        @DisplayName("TC-002 다른 category면 동일 order_num 허용")
+        void sameOrderDifferentCategory() {
+            Recruitment r = createActiveRecruitment();
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(r));
+            when(applicationQuestionRepository.existsByRecruitmentIdAndLabel(eq(1L), any())).thenReturn(false);
+            when(applicationQuestionRepository.existsByRecruitmentIdAndCategoryAndOrderNum(eq(1L), any(), any()))
+                    .thenReturn(false);
+            when(applicationQuestionRepository.save(any())).thenAnswer(inv -> {
+                ApplicationQuestion q = inv.getArgument(0);
+                ReflectionTestUtils.setField(q, "id", 1L);
+                return q;
+            });
+
+            QuestionsCreateRequest req = buildQuestionsCreateReq(1L,
+                    buildQuestionItem("C1", ApplicationQuestion.Category.COMMON,
+                            ApplicationQuestion.Type.TEXT, 500, null, 1),
+                    buildQuestionItem("E1", ApplicationQuestion.Category.ENGINEERING,
+                            ApplicationQuestion.Type.TEXT, 500, null, 1));
+
+            QuestionIdsResponse res = recruitmentService.createQuestions(req);
+
+            assertThat(res.getIds()).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("TC-003 존재하지 않는 공고 → RECRUITMENT_NOT_FOUND")
+        void notFound() {
+            when(recruitmentRepository.findById(999L)).thenReturn(Optional.empty());
+            QuestionsCreateRequest req = buildQuestionsCreateReq(999L,
+                    buildQuestionItem("C1", ApplicationQuestion.Category.COMMON,
+                            ApplicationQuestion.Type.TEXT, 500, null, 1));
+
+            assertThatThrownBy(() -> recruitmentService.createQuestions(req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.RECRUITMENT_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("TC-004 요청 내 label 중복 → DUPLICATE_QUESTION_LABEL")
+        void inRequestDuplicateLabel() {
+            Recruitment r = createActiveRecruitment();
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(r));
+            QuestionsCreateRequest req = buildQuestionsCreateReq(1L,
+                    buildQuestionItem("C1", ApplicationQuestion.Category.COMMON,
+                            ApplicationQuestion.Type.TEXT, 500, null, 1),
+                    buildQuestionItem("C1", ApplicationQuestion.Category.COMMON,
+                            ApplicationQuestion.Type.TEXT, 500, null, 2));
+
+            assertThatThrownBy(() -> recruitmentService.createQuestions(req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.DUPLICATE_QUESTION_LABEL);
+            verify(applicationQuestionRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("TC-005 요청 내 동일 category order_num 중복 → DUPLICATE_QUESTION_ORDER")
+        void inRequestDuplicateOrder() {
+            Recruitment r = createActiveRecruitment();
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(r));
+            QuestionsCreateRequest req = buildQuestionsCreateReq(1L,
+                    buildQuestionItem("C1", ApplicationQuestion.Category.COMMON,
+                            ApplicationQuestion.Type.TEXT, 500, null, 1),
+                    buildQuestionItem("C2", ApplicationQuestion.Category.COMMON,
+                            ApplicationQuestion.Type.TEXT, 500, null, 1));
+
+            assertThatThrownBy(() -> recruitmentService.createQuestions(req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.DUPLICATE_QUESTION_ORDER);
+        }
+
+        @Test
+        @DisplayName("TC-006 DB에 동일 label 존재 → DUPLICATE_QUESTION_LABEL")
+        void dbDuplicateLabel() {
+            Recruitment r = createActiveRecruitment();
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(r));
+            when(applicationQuestionRepository.existsByRecruitmentIdAndLabel(1L, "C1")).thenReturn(true);
+            QuestionsCreateRequest req = buildQuestionsCreateReq(1L,
+                    buildQuestionItem("C1", ApplicationQuestion.Category.COMMON,
+                            ApplicationQuestion.Type.TEXT, 500, null, 1));
+
+            assertThatThrownBy(() -> recruitmentService.createQuestions(req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.DUPLICATE_QUESTION_LABEL);
+            verify(applicationQuestionRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("TC-007 TEXT인데 limit_length 누락 → MISSING_PARAMETER")
+        void textMissingLimitLength() {
+            Recruitment r = createActiveRecruitment();
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(r));
+            QuestionsCreateRequest req = buildQuestionsCreateReq(1L,
+                    buildQuestionItem("C1", ApplicationQuestion.Category.COMMON,
+                            ApplicationQuestion.Type.TEXT, null, null, 1));
+
+            assertThatThrownBy(() -> recruitmentService.createQuestions(req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.MISSING_PARAMETER);
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // REC-ADMIN-007: 지원서 질문 목록 조회 (어드민)
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("REC-ADMIN-007 지원서 질문 목록 조회 (어드민)")
+    class GetAdminQuestions {
+
+        @Test
+        @DisplayName("TC-001 질문 존재 → order_num 오름차순 반환")
+        void orderAscList() {
+            Recruitment r = createActiveRecruitment();
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(r));
+            when(applicationQuestionRepository.findByRecruitmentIdOrderByOrderNumAsc(1L))
+                    .thenReturn(List.of(
+                            createTextQuestion(1L, r, ApplicationQuestion.Category.COMMON, 1, true),
+                            createTextQuestion(2L, r, ApplicationQuestion.Category.ENGINEERING, 10, true)));
+
+            List<QuestionResponse> result = recruitmentService.getAdminQuestions(1L);
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).getOrderNum()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("TC-002 마감/예정 공고도 조회 가능 (is_active 무관)")
+        void inactiveStillReturns() {
+            Recruitment r = createExpiredRecruitment(); // id 2
+            when(recruitmentRepository.findById(2L)).thenReturn(Optional.of(r));
+            when(applicationQuestionRepository.findByRecruitmentIdOrderByOrderNumAsc(2L))
+                    .thenReturn(List.of(createTextQuestion(1L, r, ApplicationQuestion.Category.COMMON, 1, true)));
+
+            List<QuestionResponse> result = recruitmentService.getAdminQuestions(2L);
+
+            assertThat(result).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("TC-003 {Track} 플레이스홀더 미치환 확인")
+        void trackPlaceholderNotReplaced() {
+            Recruitment r = createActiveRecruitment();
+            ApplicationQuestion q = ApplicationQuestion.create(r, "E1",
+                    ApplicationQuestion.Category.ENGINEERING, ApplicationQuestion.Type.TEXT,
+                    "{Track} 관련 경험", null, 500, null, 1, true);
+            ReflectionTestUtils.setField(q, "id", 5L);
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(r));
+            when(applicationQuestionRepository.findByRecruitmentIdOrderByOrderNumAsc(1L))
+                    .thenReturn(List.of(q));
+
+            List<QuestionResponse> result = recruitmentService.getAdminQuestions(1L);
+
+            assertThat(result.get(0).getContent()).isEqualTo("{Track} 관련 경험");
+        }
+
+        @Test
+        @DisplayName("TC-004 질문 없음 → 빈 배열 (QUESTIONS_NOT_FOUND 아님)")
+        void emptyList() {
+            Recruitment r = createActiveRecruitment();
+            when(recruitmentRepository.findById(1L)).thenReturn(Optional.of(r));
+            when(applicationQuestionRepository.findByRecruitmentIdOrderByOrderNumAsc(1L))
+                    .thenReturn(Collections.emptyList());
+
+            assertThat(recruitmentService.getAdminQuestions(1L)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("TC-005 존재하지 않는 공고 → RECRUITMENT_NOT_FOUND")
+        void notFound() {
+            when(recruitmentRepository.findById(999L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> recruitmentService.getAdminQuestions(999L))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.RECRUITMENT_NOT_FOUND);
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // REC-ADMIN-008: 지원서 질문 수정
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("REC-ADMIN-008 지원서 질문 수정")
+    class UpdateQuestion {
+
+        @Test
+        @DisplayName("TC-001 content만 수정 → 해당 필드만 변경")
+        void updateContentOnly() {
+            Recruitment r = createActiveRecruitment();
+            ApplicationQuestion q = createTextQuestion(1L, r, ApplicationQuestion.Category.COMMON, 1, true);
+            when(applicationQuestionRepository.findById(1L)).thenReturn(Optional.of(q));
+            QuestionUpdateRequest req = new QuestionUpdateRequest();
+            ReflectionTestUtils.setField(req, "content", "수정된 질문 내용");
+
+            QuestionIdResponse res = recruitmentService.updateQuestion(1L, req);
+
+            assertThat(res.getQuestionId()).isEqualTo(1L);
+            assertThat(q.getContent()).isEqualTo("수정된 질문 내용");
+        }
+
+        @Test
+        @DisplayName("TC-002 TEXT→TABLE 타입 변경 (metadata 동반, limit_length 정리)")
+        void changeTypeToTable() throws Exception {
+            Recruitment r = createActiveRecruitment();
+            ApplicationQuestion q = createTextQuestion(1L, r, ApplicationQuestion.Category.COMMON, 1, true);
+            when(applicationQuestionRepository.findById(1L)).thenReturn(Optional.of(q));
+            JsonNode metadata = objectMapper.readTree("{\"rows\":[\"A\"],\"columns\":[\"B\"]}");
+            QuestionUpdateRequest req = new QuestionUpdateRequest();
+            ReflectionTestUtils.setField(req, "type", ApplicationQuestion.Type.TABLE);
+            ReflectionTestUtils.setField(req, "metadata", JsonNullable.of(metadata));
+
+            recruitmentService.updateQuestion(1L, req);
+
+            assertThat(q.getType()).isEqualTo(ApplicationQuestion.Type.TABLE);
+            assertThat(q.getMetadata()).isNotNull();
+            assertThat(q.getLimitLength()).isNull();
+        }
+
+        @Test
+        @DisplayName("TC-003 TABLE→TEXT 변경인데 limit_length 누락 → MISSING_PARAMETER")
+        void changeTypeToTextMissingLimit() {
+            Recruitment r = createActiveRecruitment();
+            ApplicationQuestion q = createTableQuestion(1L, r, ApplicationQuestion.Category.ENGINEERING, 1, true);
+            when(applicationQuestionRepository.findById(1L)).thenReturn(Optional.of(q));
+            QuestionUpdateRequest req = new QuestionUpdateRequest();
+            ReflectionTestUtils.setField(req, "type", ApplicationQuestion.Type.TEXT);
+
+            assertThatThrownBy(() -> recruitmentService.updateQuestion(1L, req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.MISSING_PARAMETER);
+        }
+
+        @Test
+        @DisplayName("TC-004 존재하지 않는 질문 → QUESTIONS_NOT_FOUND")
+        void notFound() {
+            when(applicationQuestionRepository.findById(999L)).thenReturn(Optional.empty());
+            QuestionUpdateRequest req = new QuestionUpdateRequest();
+
+            assertThatThrownBy(() -> recruitmentService.updateQuestion(999L, req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.QUESTIONS_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("TC-005 같은 공고 내 label 중복 → DUPLICATE_QUESTION_LABEL")
+        void duplicateLabel() {
+            Recruitment r = createActiveRecruitment(); // id 1
+            ApplicationQuestion q = createTextQuestion(1L, r, ApplicationQuestion.Category.COMMON, 1, true);
+            when(applicationQuestionRepository.findById(1L)).thenReturn(Optional.of(q));
+            when(applicationQuestionRepository.existsByRecruitmentIdAndLabelAndIdNot(1L, "공통1", 1L))
+                    .thenReturn(true);
+            QuestionUpdateRequest req = new QuestionUpdateRequest();
+            ReflectionTestUtils.setField(req, "label", "공통1");
+
+            assertThatThrownBy(() -> recruitmentService.updateQuestion(1L, req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.DUPLICATE_QUESTION_LABEL);
+        }
+
+        @Test
+        @DisplayName("TC-006 order_num 중복 (resolvedCategory 기준) → DUPLICATE_QUESTION_ORDER")
+        void duplicateOrder() {
+            Recruitment r = createActiveRecruitment();
+            ApplicationQuestion q = createTextQuestion(1L, r, ApplicationQuestion.Category.COMMON, 1, true);
+            when(applicationQuestionRepository.findById(1L)).thenReturn(Optional.of(q));
+            when(applicationQuestionRepository.existsByRecruitmentIdAndCategoryAndOrderNumAndIdNot(
+                    1L, ApplicationQuestion.Category.COMMON, 1, 1L)).thenReturn(true);
+            QuestionUpdateRequest req = new QuestionUpdateRequest();
+            ReflectionTestUtils.setField(req, "orderNum", 1);
+
+            assertThatThrownBy(() -> recruitmentService.updateQuestion(1L, req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.DUPLICATE_QUESTION_ORDER);
+        }
+
+        @Test
+        @DisplayName("TC-007 metadata null 명시 전송 → 삭제")
+        void deleteMetadata() {
+            Recruitment r = createActiveRecruitment();
+            ApplicationQuestion q = createTableQuestion(1L, r, ApplicationQuestion.Category.ENGINEERING, 1, true);
+            when(applicationQuestionRepository.findById(1L)).thenReturn(Optional.of(q));
+            QuestionUpdateRequest req = new QuestionUpdateRequest();
+            ReflectionTestUtils.setField(req, "metadata", JsonNullable.of(null));
+
+            recruitmentService.updateQuestion(1L, req);
+
+            assertThat(q.getMetadata()).isNull();
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    // REC-ADMIN-009: 지원서 질문 삭제
+    // ══════════════════════════════════════════════
+    @Nested
+    @DisplayName("REC-ADMIN-009 지원서 질문 삭제")
+    class DeleteQuestion {
+
+        @Test
+        @DisplayName("TC-001 답변 없는 질문 → 삭제")
+        void deleteSuccess() {
+            Recruitment r = createActiveRecruitment();
+            ApplicationQuestion q = createTextQuestion(1L, r, ApplicationQuestion.Category.COMMON, 1, true);
+            when(applicationQuestionRepository.findById(1L)).thenReturn(Optional.of(q));
+            when(applicantAnswerRepository.existsByQuestionId(1L)).thenReturn(false);
+
+            recruitmentService.deleteQuestion(1L);
+
+            verify(applicationQuestionRepository).delete(q);
+        }
+
+        @Test
+        @DisplayName("TC-002 존재하지 않는 질문 → QUESTIONS_NOT_FOUND")
+        void notFound() {
+            when(applicationQuestionRepository.findById(999L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> recruitmentService.deleteQuestion(999L))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.QUESTIONS_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("TC-003 참조 답변 존재 → QUESTION_HAS_ANSWERS")
+        void hasAnswers() {
+            Recruitment r = createActiveRecruitment();
+            ApplicationQuestion q = createTextQuestion(1L, r, ApplicationQuestion.Category.COMMON, 1, true);
+            when(applicationQuestionRepository.findById(1L)).thenReturn(Optional.of(q));
+            when(applicantAnswerRepository.existsByQuestionId(1L)).thenReturn(true);
+
+            assertThatThrownBy(() -> recruitmentService.deleteQuestion(1L))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.QUESTION_HAS_ANSWERS);
+            verify(applicationQuestionRepository, never()).delete(any());
         }
     }
 }


### PR DESCRIPTION
## 💡 개요

* Issue Number: #136

Recruitment 도메인 테스트 중 **Admin 모집 공고/질문 CRUD (REC-ADMIN-002~009)** 테스트를 추가합니다. dev 최신(#170 평가 도메인 포함)을 머지한 상태라, 추가 테스트가 현재 코드 기준으로 컴파일·통과함을 확인했습니다.

## 🪐 주요 변경 사항

- REC-ADMIN-002~009 (모집 공고 목록/등록/수정/삭제 + 질문 등록/조회/수정/삭제) 4계층 테스트 추가
- `createQuestions` DB order_num 중복 케이스 보강 (TC-006b → DUPLICATE_QUESTION_ORDER)
- dev 머지로 #170 평가 도메인 반영

## ✅ 상세 내용

- **Service(Unit)**: 각 기능 정상/예외(중복·검증·NOT_FOUND) + JsonNullable null(삭제)/undefined(유지) 분기
- **Controller(@WebMvcTest)**: 정상 응답 + @Valid/@NotEmpty/@Positive + 401/403
- **Integration(Testcontainers)**: 등록·삭제 end-to-end, 질문 다건 등록 **부분 실패 전체 롤백(원자성)**
- **Repository(@DataJpaTest)**: `findAllByOrderByTermDesc`, label/order_num 중복 쿼리 등
- recruitment 도메인 전 기능(공개 8 + 어드민 12) 테스트 누락 0건 확인

## 🔔 참고 사항

- `@coderabbitai ignore` — 본 PR은 CodeRabbit 리뷰 제외
- dev는 CD 미트리거(배포 영향 없음). 머지 후 CI로 통합 검증
- 테스트 명세서(`docs/test/TC-REC-ADMIN-006.md`)에 TC-006b 동기화 (docs는 gitignore라 PR 미포함)
