### PR TITLE
[Test] Admin 도메인 테스트 코드 작성 (#174)

### DIFF
--- a/src/test/java/com/boaz/backend/domain/admin/controller/AdminControllerTest.java
+++ b/src/test/java/com/boaz/backend/domain/admin/controller/AdminControllerTest.java
@@ -1,0 +1,424 @@
+package com.boaz.backend.domain.admin.controller;
+
+import com.boaz.backend.domain.admin.dto.response.AdminAccountResponse;
+import com.boaz.backend.domain.admin.dto.response.AdminIdResponse;
+import com.boaz.backend.domain.admin.dto.response.AdminMeResponse;
+import com.boaz.backend.domain.admin.entity.Admin;
+import com.boaz.backend.domain.admin.service.AdminService;
+import com.boaz.backend.global.common.enums.Track;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import com.boaz.backend.global.config.JacksonConfig;
+import com.boaz.backend.global.security.AdminUserDetails;
+import com.boaz.backend.global.security.UserPrincipal;
+import com.boaz.backend.support.TestSecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@WebMvcTest(
+    value = AdminController.class,
+    excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class}
+)
+@Import({TestSecurityConfig.class, JacksonConfig.class})
+class AdminControllerTest {
+
+    @Autowired MockMvc mockMvc;
+
+    @MockitoBean AdminService adminService;
+
+    private static final String CREATE_BODY =
+            "{\"username\":\"boaz_team2\",\"password\":\"Boaz1234!\",\"role\":\"TEAM\","
+            + "\"name\":\"김보아즈\",\"track\":\"ANALYSIS\",\"term\":25,\"team_name\":\"기획팀\"}";
+
+    private Admin admin(Long id, Admin.Role role) {
+        Admin a = Admin.builder()
+                .username("user" + id).password("ENC").role(role).name("name" + id)
+                .track(Track.ANALYSIS).term(25).teamName(Admin.TeamName.기획팀).createdBy(null)
+                .build();
+        ReflectionTestUtils.setField(a, "id", id);
+        return a;
+    }
+
+    private UsernamePasswordAuthenticationToken adminAuth(Admin.Role role) {
+        AdminUserDetails principal = new AdminUserDetails(admin(1L, role));
+        return new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+    }
+
+    private UsernamePasswordAuthenticationToken adminAuth() {
+        return adminAuth(Admin.Role.SUPER);
+    }
+
+    private UsernamePasswordAuthenticationToken userAuth() {
+        return new UsernamePasswordAuthenticationToken(
+                new UserPrincipal(1L), null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+    }
+
+    // ──────────────────────────────────────────────
+    // ADMIN-001: GET /api/v1/admin/accounts
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("ADMIN-001 GET /api/v1/admin/accounts")
+    class GetAccounts {
+
+        @Test
+        @DisplayName("TC-004 SUPER 정상 조회 → 200 + 목록")
+        void success() throws Exception {
+            when(adminService.getAccounts(any()))
+                    .thenReturn(List.of(AdminAccountResponse.from(admin(1L, Admin.Role.SUPER)),
+                            AdminAccountResponse.from(admin(2L, Admin.Role.TEAM))));
+
+            mockMvc.perform(get("/api/v1/admin/accounts").with(authentication(adminAuth())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.length()").value(2));
+        }
+
+        @Test
+        @DisplayName("EX-002 TEAM 호출 → 서비스 UNAUTHORIZED → 401")
+        void teamForbidden() throws Exception {
+            when(adminService.getAccounts(any())).thenThrow(new CustomException(ErrorCode.UNAUTHORIZED));
+
+            mockMvc.perform(get("/api/v1/admin/accounts").with(authentication(adminAuth(Admin.Role.TEAM))))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.error_code").value("UNAUTHORIZED"));
+        }
+
+        @Test
+        @DisplayName("TC-005 미인증 → 401 TOKEN_NOT_FOUND")
+        void unauthorized() throws Exception {
+            mockMvc.perform(get("/api/v1/admin/accounts"))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.error_code").value("TOKEN_NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("[Security] User 권한으로 접근 → 403 ACCESS_DENIED")
+        void forbidden() throws Exception {
+            mockMvc.perform(get("/api/v1/admin/accounts").with(authentication(userAuth())))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.error_code").value("ACCESS_DENIED"));
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // ADMIN-002: POST /api/v1/admin/accounts
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("ADMIN-002 POST /api/v1/admin/accounts")
+    class CreateAccount {
+
+        @Test
+        @DisplayName("TC-005 정상 생성 → 201 + id")
+        void success() throws Exception {
+            when(adminService.createAccount(any(), any())).thenReturn(new AdminIdResponse(13L));
+
+            mockMvc.perform(post("/api/v1/admin/accounts")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(CREATE_BODY))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.status").value(201))
+                    .andExpect(jsonPath("$.data.id").value(13));
+        }
+
+        @Test
+        @DisplayName("TC-006 비밀번호 규칙 위반(@Pattern) → 400 INVALID_INPUT_VALUE")
+        void invalidPassword() throws Exception {
+            String body = CREATE_BODY.replace("Boaz1234!", "1234");
+
+            mockMvc.perform(post("/api/v1/admin/accounts")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error_code").value("INVALID_INPUT_VALUE"));
+        }
+
+        @Test
+        @DisplayName("EX-003 username 중복 → 409 DUPLICATE_USERNAME")
+        void duplicateUsername() throws Exception {
+            when(adminService.createAccount(any(), any()))
+                    .thenThrow(new CustomException(ErrorCode.DUPLICATE_USERNAME));
+
+            mockMvc.perform(post("/api/v1/admin/accounts")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(CREATE_BODY))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.error_code").value("DUPLICATE_USERNAME"));
+        }
+
+        @Test
+        @DisplayName("TC-007 미인증 → 401 TOKEN_NOT_FOUND")
+        void unauthorized() throws Exception {
+            mockMvc.perform(post("/api/v1/admin/accounts")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(CREATE_BODY))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.error_code").value("TOKEN_NOT_FOUND"));
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // ADMIN-007: GET /api/v1/admin/accounts/me
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("ADMIN-007 GET /api/v1/admin/accounts/me")
+    class GetMe {
+
+        @Test
+        @DisplayName("TC-003 인증 주체 → 200 + {id, team_name, name}")
+        void success() throws Exception {
+            when(adminService.getMe(any()))
+                    .thenReturn(AdminMeResponse.builder().id(1L).teamName("대표진").name("문혁준").build());
+
+            mockMvc.perform(get("/api/v1/admin/accounts/me").with(authentication(adminAuth())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.id").value(1))
+                    .andExpect(jsonPath("$.data.team_name").value("대표진"))
+                    .andExpect(jsonPath("$.data.name").value("문혁준"))
+                    .andExpect(jsonPath("$.data.password").doesNotExist())
+                    .andExpect(jsonPath("$.data.role").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("TEAM 도 호출 가능 → 200")
+        void teamAllowed() throws Exception {
+            when(adminService.getMe(any()))
+                    .thenReturn(AdminMeResponse.builder().id(5L).teamName("기획팀").name("홍길동").build());
+
+            mockMvc.perform(get("/api/v1/admin/accounts/me").with(authentication(adminAuth(Admin.Role.TEAM))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.id").value(5));
+        }
+
+        @Test
+        @DisplayName("TC-004 미인증 → 401 TOKEN_NOT_FOUND")
+        void unauthorized() throws Exception {
+            mockMvc.perform(get("/api/v1/admin/accounts/me"))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.error_code").value("TOKEN_NOT_FOUND"));
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // ADMIN-003: GET /api/v1/admin/accounts/{id}
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("ADMIN-003 GET /api/v1/admin/accounts/{id}")
+    class GetAccount {
+
+        @Test
+        @DisplayName("정상 조회 → 200")
+        void success() throws Exception {
+            when(adminService.getAccount(eq(2L), any()))
+                    .thenReturn(AdminAccountResponse.from(admin(2L, Admin.Role.TEAM)));
+
+            mockMvc.perform(get("/api/v1/admin/accounts/2").with(authentication(adminAuth())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.id").value(2));
+        }
+
+        @Test
+        @DisplayName("TC-005 id 타입 불일치 → 400 INVALID_PARAMETER_TYPE")
+        void typeMismatch() throws Exception {
+            mockMvc.perform(get("/api/v1/admin/accounts/abc").with(authentication(adminAuth())))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error_code").value("INVALID_PARAMETER_TYPE"));
+        }
+
+        @Test
+        @DisplayName("EX-004 존재하지 않는 계정 → 404 ADMIN_NOT_FOUND")
+        void notFound() throws Exception {
+            when(adminService.getAccount(eq(999L), any()))
+                    .thenThrow(new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+
+            mockMvc.perform(get("/api/v1/admin/accounts/999").with(authentication(adminAuth())))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.error_code").value("ADMIN_NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("EX-002 TEAM 타 계정 → 서비스 UNAUTHORIZED → 401")
+        void teamOther() throws Exception {
+            when(adminService.getAccount(eq(2L), any()))
+                    .thenThrow(new CustomException(ErrorCode.UNAUTHORIZED));
+
+            mockMvc.perform(get("/api/v1/admin/accounts/2").with(authentication(adminAuth(Admin.Role.TEAM))))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.error_code").value("UNAUTHORIZED"));
+        }
+
+        @Test
+        @DisplayName("EX-001 미인증 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(get("/api/v1/admin/accounts/2"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // ADMIN-004: PATCH /api/v1/admin/accounts/{id}
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("ADMIN-004 PATCH /api/v1/admin/accounts/{id}")
+    class UpdateAccount {
+
+        @Test
+        @DisplayName("TC-009 정상 수정 → 200 + id")
+        void success() throws Exception {
+            when(adminService.updateAccount(eq(2L), any(), any())).thenReturn(new AdminIdResponse(2L));
+
+            mockMvc.perform(patch("/api/v1/admin/accounts/2")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"name\":\"새이름\"}"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.id").value(2));
+        }
+
+        @Test
+        @DisplayName("EX-002 본인 role 변경 → 403 CANNOT_MODIFY_OWN_ROLE")
+        void cannotModifyOwnRole() throws Exception {
+            when(adminService.updateAccount(eq(1L), any(), any()))
+                    .thenThrow(new CustomException(ErrorCode.CANNOT_MODIFY_OWN_ROLE));
+
+            mockMvc.perform(patch("/api/v1/admin/accounts/1")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"role\":\"TEAM\"}"))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.error_code").value("CANNOT_MODIFY_OWN_ROLE"));
+        }
+
+        @Test
+        @DisplayName("EX-008 미인증 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(patch("/api/v1/admin/accounts/2")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{}"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // ADMIN-005: DELETE /api/v1/admin/accounts/{id}
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("ADMIN-005 DELETE /api/v1/admin/accounts/{id}")
+    class DeleteAccount {
+
+        @Test
+        @DisplayName("TC-006 정상 삭제 → 200 + data null")
+        void success() throws Exception {
+            doNothing().when(adminService).deleteAccount(eq(2L), any());
+
+            mockMvc.perform(delete("/api/v1/admin/accounts/2").with(authentication(adminAuth())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("EX-002 마지막 SUPER 삭제 → 400 LAST_SUPER_ACCOUNT")
+        void lastSuper() throws Exception {
+            doThrow(new CustomException(ErrorCode.LAST_SUPER_ACCOUNT))
+                    .when(adminService).deleteAccount(eq(1L), any());
+
+            mockMvc.perform(delete("/api/v1/admin/accounts/1").with(authentication(adminAuth())))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error_code").value("LAST_SUPER_ACCOUNT"));
+        }
+
+        @Test
+        @DisplayName("EX-005 미인증 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(delete("/api/v1/admin/accounts/2"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // ADMIN-006: PATCH /api/v1/admin/accounts/{id}/password
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("ADMIN-006 PATCH /api/v1/admin/accounts/{id}/password")
+    class ResetPassword {
+
+        @Test
+        @DisplayName("TC-008 정상 변경 → 200 + data null")
+        void success() throws Exception {
+            doNothing().when(adminService).resetPassword(eq(2L), any(), any());
+
+            mockMvc.perform(patch("/api/v1/admin/accounts/2/password")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"new_password\":\"NewBoaz1234!\"}"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200));
+        }
+
+        @Test
+        @DisplayName("TC-007 newPassword 규칙 위반(@Pattern) → 400 INVALID_INPUT_VALUE")
+        void invalidNewPassword() throws Exception {
+            mockMvc.perform(patch("/api/v1/admin/accounts/2/password")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"new_password\":\"1234\"}"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error_code").value("INVALID_INPUT_VALUE"));
+        }
+
+        @Test
+        @DisplayName("EX-003 본인 변경 currentPassword 불일치 → 401 INVALID_CURRENT_PASSWORD")
+        void invalidCurrentPassword() throws Exception {
+            doThrow(new CustomException(ErrorCode.INVALID_CURRENT_PASSWORD))
+                    .when(adminService).resetPassword(eq(1L), any(), any());
+
+            mockMvc.perform(patch("/api/v1/admin/accounts/1/password")
+                            .with(authentication(adminAuth()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"current_password\":\"wrong\",\"new_password\":\"NewBoaz1234!\"}"))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.error_code").value("INVALID_CURRENT_PASSWORD"));
+        }
+
+        @Test
+        @DisplayName("EX-007 미인증 → 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(patch("/api/v1/admin/accounts/2/password")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"new_password\":\"NewBoaz1234!\"}"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/admin/integration/AdminIntegrationTest.java
+++ b/src/test/java/com/boaz/backend/domain/admin/integration/AdminIntegrationTest.java
@@ -1,0 +1,267 @@
+package com.boaz.backend.domain.admin.integration;
+
+import com.boaz.backend.domain.admin.dto.request.AdminCreateRequest;
+import com.boaz.backend.domain.admin.dto.request.AdminPasswordResetRequest;
+import com.boaz.backend.domain.admin.dto.request.AdminUpdateRequest;
+import com.boaz.backend.domain.admin.entity.Admin;
+import com.boaz.backend.domain.admin.repository.AdminRepository;
+import com.boaz.backend.domain.admin.service.AdminService;
+import com.boaz.backend.domain.auth.entity.RefreshToken;
+import com.boaz.backend.domain.auth.repository.RefreshTokenRepository;
+import com.boaz.backend.global.common.enums.AccountType;
+import com.boaz.backend.global.common.enums.Track;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import com.boaz.backend.support.TestcontainersBase;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openapitools.jackson.nullable.JsonNullable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class AdminIntegrationTest extends TestcontainersBase {
+
+    @Autowired AdminService adminService;
+    @Autowired AdminRepository adminRepository;
+    @Autowired RefreshTokenRepository refreshTokenRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+
+    @PersistenceContext EntityManager em;
+
+    private int seq = 0;
+
+    private Admin saveAdmin(Admin.Role role, String rawPassword) {
+        Admin a = Admin.builder()
+                .username("user" + (++seq)).password(passwordEncoder.encode(rawPassword)).role(role)
+                .name("name" + seq).track(Track.ANALYSIS).term(25).teamName(Admin.TeamName.기획팀).createdBy(null)
+                .build();
+        return adminRepository.save(a);
+    }
+
+    private void saveRefreshToken(Long adminId) {
+        refreshTokenRepository.save(RefreshToken.builder()
+                .accountId(adminId).accountType(AccountType.ADMIN)
+                .token("token-" + adminId).expiresAt(LocalDateTime.now().plusDays(1))
+                .build());
+    }
+
+    private AdminCreateRequest createReq(String username) {
+        AdminCreateRequest req = new AdminCreateRequest();
+        ReflectionTestUtils.setField(req, "username", username);
+        ReflectionTestUtils.setField(req, "password", "Boaz1234!");
+        ReflectionTestUtils.setField(req, "role", Admin.Role.TEAM);
+        ReflectionTestUtils.setField(req, "name", "김보아즈");
+        ReflectionTestUtils.setField(req, "track", Track.ANALYSIS);
+        ReflectionTestUtils.setField(req, "term", 25);
+        ReflectionTestUtils.setField(req, "teamName", Admin.TeamName.기획팀);
+        return req;
+    }
+
+    @Nested
+    @DisplayName("계정 생성 end-to-end (ADMIN-002)")
+    class CreateAccount {
+
+        @Test
+        @DisplayName("생성 → DB 영속, password BCrypt 해시, createdBy = 생성자 id")
+        void persistsWithHashedPassword() {
+            Admin superAdmin = saveAdmin(Admin.Role.SUPER, "Super1234!");
+            em.flush();
+            em.clear();
+
+            var res = adminService.createAccount(createReq("new_team"), superAdmin);
+            em.flush();
+            em.clear();
+
+            Admin saved = adminRepository.findById(res.getId()).orElseThrow();
+            assertThat(saved.getPassword()).isNotEqualTo("Boaz1234!");
+            assertThat(passwordEncoder.matches("Boaz1234!", saved.getPassword())).isTrue();
+            assertThat(saved.getCreatedBy()).isEqualTo(superAdmin.getId());
+        }
+
+        @Test
+        @DisplayName("동일 username 재생성 → DUPLICATE_USERNAME")
+        void duplicateUsername() {
+            Admin superAdmin = saveAdmin(Admin.Role.SUPER, "Super1234!");
+            adminService.createAccount(createReq("dup_team"), superAdmin);
+            em.flush();
+            em.clear();
+
+            assertThatThrownBy(() -> adminService.createAccount(createReq("dup_team"), superAdmin))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.DUPLICATE_USERNAME);
+        }
+    }
+
+    @Nested
+    @DisplayName("계정 수정 end-to-end (ADMIN-004)")
+    class UpdateAccount {
+
+        @Test
+        @DisplayName("role 변경 → 영속 반영 + 대상 RefreshToken 삭제")
+        void roleChangeDeletesToken() {
+            Admin superAdmin = saveAdmin(Admin.Role.SUPER, "Super1234!");
+            Admin target = saveAdmin(Admin.Role.TEAM, "Team1234!");
+            saveRefreshToken(target.getId());
+            em.flush();
+            em.clear();
+
+            AdminUpdateRequest req = new AdminUpdateRequest();
+            ReflectionTestUtils.setField(req, "role", JsonNullable.of(Admin.Role.SUPER));
+            adminService.updateAccount(target.getId(), req, superAdmin);
+            em.flush();
+            em.clear();
+
+            assertThat(adminRepository.findById(target.getId()).orElseThrow().getRole())
+                    .isEqualTo(Admin.Role.SUPER);
+            assertThat(refreshTokenRepository.findByAccountTypeAndAccountId(AccountType.ADMIN, target.getId()))
+                    .isEmpty();
+        }
+
+        @Test
+        @DisplayName("프로필 필드만 수정 → 대상 RefreshToken 유지")
+        void profileOnlyKeepsToken() {
+            Admin superAdmin = saveAdmin(Admin.Role.SUPER, "Super1234!");
+            Admin target = saveAdmin(Admin.Role.TEAM, "Team1234!");
+            saveRefreshToken(target.getId());
+            em.flush();
+            em.clear();
+
+            AdminUpdateRequest req = new AdminUpdateRequest();
+            ReflectionTestUtils.setField(req, "name", JsonNullable.of("변경된이름"));
+            adminService.updateAccount(target.getId(), req, superAdmin);
+            em.flush();
+            em.clear();
+
+            assertThat(adminRepository.findById(target.getId()).orElseThrow().getName())
+                    .isEqualTo("변경된이름");
+            assertThat(refreshTokenRepository.findByAccountTypeAndAccountId(AccountType.ADMIN, target.getId()))
+                    .isPresent();
+        }
+    }
+
+    @Nested
+    @DisplayName("계정 삭제 end-to-end (ADMIN-005)")
+    class DeleteAccount {
+
+        @Test
+        @DisplayName("soft delete → deletedAt 세팅, 목록 제외, RefreshToken 삭제")
+        void softDeleteExcludesAndDeletesToken() {
+            Admin superAdmin = saveAdmin(Admin.Role.SUPER, "Super1234!");
+            Admin target = saveAdmin(Admin.Role.TEAM, "Team1234!");
+            saveRefreshToken(target.getId());
+            em.flush();
+            em.clear();
+
+            adminService.deleteAccount(target.getId(), superAdmin);
+            em.flush();
+            em.clear();
+
+            // 레코드는 물리 존재하지만 deletedAt 세팅됨
+            Admin reloaded = adminRepository.findById(target.getId()).orElseThrow();
+            assertThat(reloaded.isDeleted()).isTrue();
+            // 활성 목록(findAll...DeletedAtIsNull)에서 제외
+            assertThat(adminRepository.findByIdAndDeletedAtIsNull(target.getId())).isEmpty();
+            assertThat(adminRepository.findAllByDeletedAtIsNullOrderByCreatedAtAsc())
+                    .extracting(Admin::getId).doesNotContain(target.getId());
+            // RefreshToken 삭제
+            assertThat(refreshTokenRepository.findByAccountTypeAndAccountId(AccountType.ADMIN, target.getId()))
+                    .isEmpty();
+        }
+
+        @Test
+        @DisplayName("마지막 SUPER 삭제 → LAST_SUPER_ACCOUNT (삭제 안 됨)")
+        void lastSuperBlocked() {
+            Admin superAdmin = saveAdmin(Admin.Role.SUPER, "Super1234!");
+            em.flush();
+            em.clear();
+
+            assertThatThrownBy(() -> adminService.deleteAccount(superAdmin.getId(), superAdmin))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.LAST_SUPER_ACCOUNT);
+            assertThat(adminRepository.findByIdAndDeletedAtIsNull(superAdmin.getId())).isPresent();
+        }
+    }
+
+    @Nested
+    @DisplayName("비밀번호 변경 end-to-end (ADMIN-006)")
+    class ResetPassword {
+
+        @Test
+        @DisplayName("SUPER 타인 초기화 → 해시 변경(matches new) + RefreshToken 삭제")
+        void superResetsOther() {
+            Admin superAdmin = saveAdmin(Admin.Role.SUPER, "Super1234!");
+            Admin target = saveAdmin(Admin.Role.TEAM, "Team1234!");
+            saveRefreshToken(target.getId());
+            em.flush();
+            em.clear();
+
+            AdminPasswordResetRequest req = new AdminPasswordResetRequest();
+            ReflectionTestUtils.setField(req, "newPassword", "NewBoaz1234!");
+            adminService.resetPassword(target.getId(), req, superAdmin);
+            em.flush();
+            em.clear();
+
+            Admin reloaded = adminRepository.findById(target.getId()).orElseThrow();
+            assertThat(passwordEncoder.matches("NewBoaz1234!", reloaded.getPassword())).isTrue();
+            assertThat(refreshTokenRepository.findByAccountTypeAndAccountId(AccountType.ADMIN, target.getId()))
+                    .isEmpty();
+        }
+
+        @Test
+        @DisplayName("본인 변경 (currentPassword 일치) → 해시 변경")
+        void selfChange() {
+            Admin self = saveAdmin(Admin.Role.TEAM, "Team1234!");
+            saveRefreshToken(self.getId());
+            em.flush();
+            em.clear();
+
+            Admin currentAdmin = adminRepository.findById(self.getId()).orElseThrow();
+            AdminPasswordResetRequest req = new AdminPasswordResetRequest();
+            ReflectionTestUtils.setField(req, "currentPassword", "Team1234!");
+            ReflectionTestUtils.setField(req, "newPassword", "NewBoaz1234!");
+            adminService.resetPassword(self.getId(), req, currentAdmin);
+            em.flush();
+            em.clear();
+
+            assertThat(passwordEncoder.matches("NewBoaz1234!",
+                    adminRepository.findById(self.getId()).orElseThrow().getPassword())).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("모든 계정 조회 end-to-end (ADMIN-001)")
+    class GetAccounts {
+
+        @Test
+        @DisplayName("soft delete 제외하고 활성 계정만 반환")
+        void excludesDeleted() {
+            Admin superAdmin = saveAdmin(Admin.Role.SUPER, "Super1234!");
+            Admin active = saveAdmin(Admin.Role.TEAM, "Team1234!");
+            Admin deleted = saveAdmin(Admin.Role.TEAM, "Team1234!");
+            deleted.softDelete();
+            em.flush();
+            em.clear();
+
+            var result = adminService.getAccounts(superAdmin);
+
+            assertThat(result).extracting("id")
+                    .contains(superAdmin.getId(), active.getId())
+                    .doesNotContain(deleted.getId());
+        }
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/admin/repository/AdminRepositoryTest.java
+++ b/src/test/java/com/boaz/backend/domain/admin/repository/AdminRepositoryTest.java
@@ -1,0 +1,198 @@
+package com.boaz.backend.domain.admin.repository;
+
+import com.boaz.backend.domain.admin.entity.Admin;
+import com.boaz.backend.global.common.enums.Track;
+import com.boaz.backend.global.config.JpaConfig;
+import com.boaz.backend.support.TestcontainersBase;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(JpaConfig.class)
+@ActiveProfiles("test")
+class AdminRepositoryTest extends TestcontainersBase {
+
+    @Autowired AdminRepository adminRepository;
+    @Autowired TestEntityManager em;
+
+    private Admin persistAdmin(String username, Admin.Role role, Track track,
+                               String name, Admin.TeamName team) {
+        Admin a = Admin.builder()
+                .username(username).password("ENC").role(role).name(name)
+                .track(track).term(25).teamName(team).createdBy(null)
+                .build();
+        return em.persistFlushFind(a);
+    }
+
+    private Admin persistDeletedAdmin(String username, Admin.Role role, Track track,
+                                      String name, Admin.TeamName team) {
+        Admin a = persistAdmin(username, role, track, name, team);
+        a.softDelete();
+        em.flush();
+        return a;
+    }
+
+    private void setCreatedAt(Long id, String createdAt) {
+        EntityManager entityManager = em.getEntityManager();
+        entityManager.createNativeQuery("UPDATE admin SET created_at = ?1 WHERE id = ?2")
+                .setParameter(1, createdAt)
+                .setParameter(2, id)
+                .executeUpdate();
+    }
+
+    @Nested
+    @DisplayName("findByUsernameAndDeletedAtIsNull")
+    class FindByUsername {
+
+        @Test
+        @DisplayName("활성 계정만 username 으로 조회, soft delete 된 username 은 empty")
+        void onlyActive() {
+            persistAdmin("active", Admin.Role.TEAM, Track.ANALYSIS, "활성", Admin.TeamName.기획팀);
+            persistDeletedAdmin("deleted", Admin.Role.TEAM, Track.ANALYSIS, "삭제됨", Admin.TeamName.기획팀);
+            em.clear();
+
+            assertThat(adminRepository.findByUsernameAndDeletedAtIsNull("active")).isPresent();
+            assertThat(adminRepository.findByUsernameAndDeletedAtIsNull("deleted")).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("existsByUsernameAndDeletedAtIsNull")
+    class ExistsByUsername {
+
+        @Test
+        @DisplayName("활성 username 은 true, soft delete 된 username 은 false (재사용 가능)")
+        void softDeleteReusable() {
+            persistAdmin("active", Admin.Role.TEAM, Track.ANALYSIS, "활성", Admin.TeamName.기획팀);
+            persistDeletedAdmin("recycled", Admin.Role.TEAM, Track.ANALYSIS, "삭제됨", Admin.TeamName.기획팀);
+            em.clear();
+
+            assertThat(adminRepository.existsByUsernameAndDeletedAtIsNull("active")).isTrue();
+            assertThat(adminRepository.existsByUsernameAndDeletedAtIsNull("recycled")).isFalse();
+            assertThat(adminRepository.existsByUsernameAndDeletedAtIsNull("none")).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllByDeletedAtIsNullOrderByCreatedAtAsc")
+    class FindAllOrdered {
+
+        @Test
+        @DisplayName("created_at 오름차순 + soft delete 제외")
+        void orderedExcludingDeleted() {
+            Admin a1 = persistAdmin("a1", Admin.Role.SUPER, Track.ANALYSIS, "first", Admin.TeamName.대표진);
+            Admin a2 = persistAdmin("a2", Admin.Role.TEAM, Track.ANALYSIS, "second", Admin.TeamName.기획팀);
+            Admin a3 = persistAdmin("a3", Admin.Role.TEAM, Track.ENGINEERING, "third", Admin.TeamName.기획팀);
+            Admin deleted = persistAdmin("a4", Admin.Role.TEAM, Track.VISUALIZATION, "deleted", Admin.TeamName.기획팀);
+
+            // @CreatedDate 가 동일 트랜잭션에서 같은 값일 수 있어 created_at 을 네이티브로 명시
+            setCreatedAt(a1.getId(), "2026-03-01 10:00:00");
+            setCreatedAt(a2.getId(), "2026-03-05 10:00:00");
+            setCreatedAt(a3.getId(), "2026-03-10 10:00:00");
+            setCreatedAt(deleted.getId(), "2026-03-07 10:00:00");
+            deleted.softDelete();
+            em.flush();
+            em.clear();
+
+            List<Admin> result = adminRepository.findAllByDeletedAtIsNullOrderByCreatedAtAsc();
+
+            assertThat(result).extracting(Admin::getName).containsExactly("first", "second", "third");
+        }
+
+        @Test
+        @DisplayName("활성 계정 없음 → 빈 리스트")
+        void empty() {
+            assertThat(adminRepository.findAllByDeletedAtIsNullOrderByCreatedAtAsc()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByIdAndDeletedAtIsNull")
+    class FindById {
+
+        @Test
+        @DisplayName("활성 계정은 반환, soft delete 된 계정은 empty")
+        void onlyActive() {
+            Admin active = persistAdmin("active", Admin.Role.TEAM, Track.ANALYSIS, "활성", Admin.TeamName.기획팀);
+            Admin deleted = persistDeletedAdmin("deleted", Admin.Role.TEAM, Track.ANALYSIS, "삭제됨", Admin.TeamName.기획팀);
+            em.clear();
+
+            assertThat(adminRepository.findByIdAndDeletedAtIsNull(active.getId())).isPresent();
+            assertThat(adminRepository.findByIdAndDeletedAtIsNull(deleted.getId())).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("countByRoleAndDeletedAtIsNull")
+    class CountByRole {
+
+        @Test
+        @DisplayName("역할별 활성 계정 수 (soft delete 제외)")
+        void countExcludingDeleted() {
+            persistAdmin("s1", Admin.Role.SUPER, Track.ANALYSIS, "super1", Admin.TeamName.대표진);
+            persistAdmin("s2", Admin.Role.SUPER, Track.ANALYSIS, "super2", Admin.TeamName.대표진);
+            persistDeletedAdmin("s3", Admin.Role.SUPER, Track.ANALYSIS, "super-deleted", Admin.TeamName.대표진);
+            persistAdmin("t1", Admin.Role.TEAM, Track.ANALYSIS, "team1", Admin.TeamName.기획팀);
+            em.clear();
+
+            assertThat(adminRepository.countByRoleAndDeletedAtIsNull(Admin.Role.SUPER)).isEqualTo(2);
+            assertThat(adminRepository.countByRoleAndDeletedAtIsNull(Admin.Role.TEAM)).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("findByTrackAndDeletedAtIsNullOrderByNameAsc")
+    class FindByTrack {
+
+        @Test
+        @DisplayName("해당 부문 활성 평가자만 이름 오름차순")
+        void byTrackOrdered() {
+            persistAdmin("e1", Admin.Role.TEAM, Track.ENGINEERING, "나", Admin.TeamName.기획팀);
+            persistAdmin("e2", Admin.Role.TEAM, Track.ENGINEERING, "가", Admin.TeamName.기획팀);
+            persistAdmin("a1", Admin.Role.TEAM, Track.ANALYSIS, "다", Admin.TeamName.기획팀);
+            persistDeletedAdmin("e3", Admin.Role.TEAM, Track.ENGINEERING, "라", Admin.TeamName.기획팀);
+            em.clear();
+
+            List<Admin> result = adminRepository.findByTrackAndDeletedAtIsNullOrderByNameAsc(Track.ENGINEERING);
+
+            assertThat(result).extracting(Admin::getName).containsExactly("가", "나");
+        }
+    }
+
+    @Nested
+    @DisplayName("findEvaluatorPool")
+    class FindEvaluatorPool {
+
+        @Test
+        @DisplayName("해당 부문 OR (전부문 권한 role+team) 평가자 풀, 이름순, soft delete 제외")
+        void pool() {
+            // 해당 부문(ENGINEERING)
+            persistAdmin("e1", Admin.Role.TEAM, Track.ENGINEERING, "가", Admin.TeamName.기획팀);
+            // 전부문 권한자 (role=SUPER AND team=차기대표진) — 본인 track 무관 포함
+            persistAdmin("all", Admin.Role.SUPER, Track.ANALYSIS, "나", Admin.TeamName.차기대표진);
+            // 제외 대상: 다른 부문 + 전부문 권한 아님
+            persistAdmin("a1", Admin.Role.TEAM, Track.ANALYSIS, "다", Admin.TeamName.기획팀);
+            // 제외 대상: ENGINEERING 이지만 soft delete
+            persistDeletedAdmin("e2", Admin.Role.TEAM, Track.ENGINEERING, "라", Admin.TeamName.기획팀);
+            em.clear();
+
+            List<Admin> result = adminRepository.findEvaluatorPool(
+                    Track.ENGINEERING, Admin.Role.SUPER, Admin.TeamName.차기대표진);
+
+            assertThat(result).extracting(Admin::getName).containsExactly("가", "나");
+        }
+    }
+}

--- a/src/test/java/com/boaz/backend/domain/admin/service/AdminServiceTest.java
+++ b/src/test/java/com/boaz/backend/domain/admin/service/AdminServiceTest.java
@@ -1,0 +1,547 @@
+package com.boaz.backend.domain.admin.service;
+
+import com.boaz.backend.domain.admin.dto.request.AdminCreateRequest;
+import com.boaz.backend.domain.admin.dto.request.AdminPasswordResetRequest;
+import com.boaz.backend.domain.admin.dto.request.AdminUpdateRequest;
+import com.boaz.backend.domain.admin.dto.response.AdminAccountResponse;
+import com.boaz.backend.domain.admin.dto.response.AdminIdResponse;
+import com.boaz.backend.domain.admin.dto.response.AdminMeResponse;
+import com.boaz.backend.domain.admin.entity.Admin;
+import com.boaz.backend.domain.admin.repository.AdminRepository;
+import com.boaz.backend.domain.auth.repository.RefreshTokenRepository;
+import com.boaz.backend.global.common.enums.AccountType;
+import com.boaz.backend.global.common.enums.Track;
+import com.boaz.backend.global.exception.CustomException;
+import com.boaz.backend.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openapitools.jackson.nullable.JsonNullable;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminServiceTest {
+
+    @InjectMocks AdminService adminService;
+
+    @Mock AdminRepository adminRepository;
+    @Mock PasswordEncoder passwordEncoder;
+    @Mock RefreshTokenRepository refreshTokenRepository;
+
+    // ──────────────────────────────────────────────
+    // 헬퍼
+    // ──────────────────────────────────────────────
+
+    private Admin admin(Long id, Admin.Role role) {
+        return adminWith(id, role, Track.ANALYSIS, "name" + id, Admin.TeamName.기획팀);
+    }
+
+    private Admin adminWith(Long id, Admin.Role role, Track track, String name, Admin.TeamName team) {
+        Admin a = Admin.builder()
+                .username("user" + id).password("OLD_HASH").role(role).name(name)
+                .track(track).term(25).teamName(team).createdBy(null)
+                .build();
+        ReflectionTestUtils.setField(a, "id", id);
+        return a;
+    }
+
+    private AdminCreateRequest createRequest(String username, Track track) {
+        AdminCreateRequest req = new AdminCreateRequest();
+        ReflectionTestUtils.setField(req, "username", username);
+        ReflectionTestUtils.setField(req, "password", "Boaz1234!");
+        ReflectionTestUtils.setField(req, "role", Admin.Role.TEAM);
+        ReflectionTestUtils.setField(req, "name", "김보아즈");
+        ReflectionTestUtils.setField(req, "track", track);
+        ReflectionTestUtils.setField(req, "term", 25);
+        ReflectionTestUtils.setField(req, "teamName", Admin.TeamName.기획팀);
+        return req;
+    }
+
+    private AdminPasswordResetRequest pwRequest(String current, String newPw) {
+        AdminPasswordResetRequest req = new AdminPasswordResetRequest();
+        ReflectionTestUtils.setField(req, "currentPassword", current);
+        ReflectionTestUtils.setField(req, "newPassword", newPw);
+        return req;
+    }
+
+    // ──────────────────────────────────────────────
+    // ADMIN-001: getAccounts (모든 계정 조회, SUPER only)
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("ADMIN-001 getAccounts")
+    class GetAccounts {
+
+        @Test
+        @DisplayName("TC-001 SUPER 조회 → created_at 오름차순 목록 매핑")
+        void superList() {
+            Admin currentAdmin = admin(1L, Admin.Role.SUPER);
+            when(adminRepository.findAllByDeletedAtIsNullOrderByCreatedAtAsc())
+                    .thenReturn(List.of(admin(1L, Admin.Role.SUPER), admin(2L, Admin.Role.TEAM)));
+
+            List<AdminAccountResponse> result = adminService.getAccounts(currentAdmin);
+
+            assertThat(result).hasSize(2);
+            assertThat(result).extracting(AdminAccountResponse::getId).containsExactly(1L, 2L);
+        }
+
+        @Test
+        @DisplayName("TC-002 계정 없음 → 빈 배열 (예외 없음)")
+        void empty() {
+            Admin currentAdmin = admin(1L, Admin.Role.SUPER);
+            when(adminRepository.findAllByDeletedAtIsNullOrderByCreatedAtAsc()).thenReturn(List.of());
+
+            assertThat(adminService.getAccounts(currentAdmin)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("TC-003 TEAM 호출 → UNAUTHORIZED (DB 조회 안 함)")
+        void teamForbidden() {
+            Admin currentAdmin = admin(5L, Admin.Role.TEAM);
+
+            assertThatThrownBy(() -> adminService.getAccounts(currentAdmin))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.UNAUTHORIZED);
+            verify(adminRepository, never()).findAllByDeletedAtIsNullOrderByCreatedAtAsc();
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // ADMIN-002: createAccount (계정 생성, SUPER only)
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("ADMIN-002 createAccount")
+    class CreateAccount {
+
+        @Test
+        @DisplayName("TC-001 SUPER 생성 → 201, password 인코딩 + createdBy 기록")
+        void success() {
+            Admin currentAdmin = admin(1L, Admin.Role.SUPER);
+            AdminCreateRequest req = createRequest("boaz_team2", Track.ANALYSIS);
+            when(adminRepository.existsByUsernameAndDeletedAtIsNull("boaz_team2")).thenReturn(false);
+            when(passwordEncoder.encode("Boaz1234!")).thenReturn("ENCODED");
+            when(adminRepository.save(any(Admin.class))).thenAnswer(inv -> {
+                Admin a = inv.getArgument(0);
+                ReflectionTestUtils.setField(a, "id", 13L);
+                return a;
+            });
+
+            AdminIdResponse res = adminService.createAccount(req, currentAdmin);
+
+            assertThat(res.getId()).isEqualTo(13L);
+            ArgumentCaptor<Admin> captor = ArgumentCaptor.forClass(Admin.class);
+            verify(adminRepository).save(captor.capture());
+            assertThat(captor.getValue().getPassword()).isEqualTo("ENCODED");
+            assertThat(captor.getValue().getCreatedBy()).isEqualTo(1L);
+        }
+
+        @Test
+        @DisplayName("TC-002 TEAM 호출 → UNAUTHORIZED, save 안 함")
+        void teamForbidden() {
+            Admin currentAdmin = admin(5L, Admin.Role.TEAM);
+            AdminCreateRequest req = createRequest("boaz_team2", Track.ANALYSIS);
+
+            assertThatThrownBy(() -> adminService.createAccount(req, currentAdmin))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.UNAUTHORIZED);
+            verify(adminRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("TC-003 track=ALL → INVALID_TRACK_SELECTION, save 안 함")
+        void trackAll() {
+            Admin currentAdmin = admin(1L, Admin.Role.SUPER);
+            AdminCreateRequest req = createRequest("boaz_team2", Track.ALL);
+
+            assertThatThrownBy(() -> adminService.createAccount(req, currentAdmin))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.INVALID_TRACK_SELECTION);
+            verify(adminRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("TC-004 username 중복 → DUPLICATE_USERNAME, save 안 함")
+        void duplicateUsername() {
+            Admin currentAdmin = admin(1L, Admin.Role.SUPER);
+            AdminCreateRequest req = createRequest("boaz_team2", Track.ANALYSIS);
+            when(adminRepository.existsByUsernameAndDeletedAtIsNull("boaz_team2")).thenReturn(true);
+
+            assertThatThrownBy(() -> adminService.createAccount(req, currentAdmin))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.DUPLICATE_USERNAME);
+            verify(adminRepository, never()).save(any());
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // ADMIN-007: getMe (내 계정 정보 조회)
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("ADMIN-007 getMe")
+    class GetMe {
+
+        @Test
+        @DisplayName("TC-001 SUPER 본인 정보 → id/team_name/name 매핑, repository 미상호작용")
+        void superSelf() {
+            Admin currentAdmin = adminWith(1L, Admin.Role.SUPER, Track.ANALYSIS, "문혁준", Admin.TeamName.대표진);
+
+            AdminMeResponse res = adminService.getMe(currentAdmin);
+
+            assertThat(res.getId()).isEqualTo(1L);
+            assertThat(res.getName()).isEqualTo("문혁준");
+            assertThat(res.getTeamName()).isEqualTo("대표진");
+            verifyNoInteractions(adminRepository, refreshTokenRepository, passwordEncoder);
+        }
+
+        @Test
+        @DisplayName("TC-002 TEAM 도 호출 가능 → 본인 정보 반환 (권한 거부 없음)")
+        void teamAllowed() {
+            Admin currentAdmin = adminWith(5L, Admin.Role.TEAM, Track.ENGINEERING, "홍길동", Admin.TeamName.기획팀);
+
+            AdminMeResponse res = adminService.getMe(currentAdmin);
+
+            assertThat(res.getId()).isEqualTo(5L);
+            assertThat(res.getName()).isEqualTo("홍길동");
+            assertThat(res.getTeamName()).isEqualTo("기획팀");
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // ADMIN-003: getAccount (id별 계정 조회)
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("ADMIN-003 getAccount")
+    class GetAccount {
+
+        @Test
+        @DisplayName("TC-001 SUPER 가 타 계정 조회 → 반환")
+        void superOther() {
+            Admin currentAdmin = admin(1L, Admin.Role.SUPER);
+            when(adminRepository.findByIdAndDeletedAtIsNull(2L)).thenReturn(Optional.of(admin(2L, Admin.Role.TEAM)));
+
+            AdminAccountResponse res = adminService.getAccount(2L, currentAdmin);
+
+            assertThat(res.getId()).isEqualTo(2L);
+        }
+
+        @Test
+        @DisplayName("TC-002 TEAM 이 본인 계정 조회 → 반환")
+        void teamSelf() {
+            Admin currentAdmin = admin(5L, Admin.Role.TEAM);
+            when(adminRepository.findByIdAndDeletedAtIsNull(5L)).thenReturn(Optional.of(currentAdmin));
+
+            AdminAccountResponse res = adminService.getAccount(5L, currentAdmin);
+
+            assertThat(res.getId()).isEqualTo(5L);
+        }
+
+        @Test
+        @DisplayName("TC-003 TEAM 이 타 계정 조회 → UNAUTHORIZED (DB 조회 안 함)")
+        void teamOther() {
+            Admin currentAdmin = admin(5L, Admin.Role.TEAM);
+
+            assertThatThrownBy(() -> adminService.getAccount(2L, currentAdmin))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.UNAUTHORIZED);
+            verify(adminRepository, never()).findByIdAndDeletedAtIsNull(anyLong());
+        }
+
+        @Test
+        @DisplayName("TC-004 존재하지 않는 계정 → ADMIN_NOT_FOUND")
+        void notFound() {
+            Admin currentAdmin = admin(1L, Admin.Role.SUPER);
+            when(adminRepository.findByIdAndDeletedAtIsNull(999L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> adminService.getAccount(999L, currentAdmin))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.ADMIN_NOT_FOUND);
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // ADMIN-004: updateAccount (id별 계정 수정)
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("ADMIN-004 updateAccount")
+    class UpdateAccount {
+
+        @Test
+        @DisplayName("TC-001 SUPER 프로필 필드만 수정 → 변경, role 미전송 시 토큰 삭제 안 함")
+        void profileOnly() {
+            Admin currentAdmin = admin(1L, Admin.Role.SUPER);
+            Admin target = admin(2L, Admin.Role.TEAM);
+            when(adminRepository.findByIdAndDeletedAtIsNull(2L)).thenReturn(Optional.of(target));
+            AdminUpdateRequest req = new AdminUpdateRequest();
+            ReflectionTestUtils.setField(req, "name", JsonNullable.of("새이름"));
+
+            AdminIdResponse res = adminService.updateAccount(2L, req, currentAdmin);
+
+            assertThat(res.getId()).isEqualTo(2L);
+            assertThat(target.getName()).isEqualTo("새이름");
+            verify(refreshTokenRepository, never()).deleteByAccountTypeAndAccountId(any(), anyLong());
+        }
+
+        @Test
+        @DisplayName("TC-002 SUPER 가 타 계정 role 변경 → 변경 + RefreshToken 삭제")
+        void roleChange() {
+            Admin currentAdmin = admin(1L, Admin.Role.SUPER);
+            Admin target = admin(2L, Admin.Role.TEAM);
+            when(adminRepository.findByIdAndDeletedAtIsNull(2L)).thenReturn(Optional.of(target));
+            AdminUpdateRequest req = new AdminUpdateRequest();
+            ReflectionTestUtils.setField(req, "role", JsonNullable.of(Admin.Role.SUPER));
+
+            adminService.updateAccount(2L, req, currentAdmin);
+
+            assertThat(target.getRole()).isEqualTo(Admin.Role.SUPER);
+            verify(refreshTokenRepository).deleteByAccountTypeAndAccountId(AccountType.ADMIN, 2L);
+        }
+
+        @Test
+        @DisplayName("TC-003 TEAM 이 타 계정 수정 → UNAUTHORIZED (DB 조회 안 함)")
+        void teamOther() {
+            Admin currentAdmin = admin(5L, Admin.Role.TEAM);
+            AdminUpdateRequest req = new AdminUpdateRequest();
+
+            assertThatThrownBy(() -> adminService.updateAccount(2L, req, currentAdmin))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.UNAUTHORIZED);
+            verify(adminRepository, never()).findByIdAndDeletedAtIsNull(anyLong());
+        }
+
+        @Test
+        @DisplayName("TC-004 TEAM 이 본인에 role 전송 → UNAUTHORIZED (CANNOT_MODIFY_OWN_ROLE 아님, 순서 2>3)")
+        void teamSelfRole() {
+            Admin currentAdmin = admin(5L, Admin.Role.TEAM);
+            AdminUpdateRequest req = new AdminUpdateRequest();
+            ReflectionTestUtils.setField(req, "role", JsonNullable.of(Admin.Role.SUPER));
+
+            assertThatThrownBy(() -> adminService.updateAccount(5L, req, currentAdmin))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.UNAUTHORIZED);
+        }
+
+        @Test
+        @DisplayName("TC-005 SUPER 가 본인 role 변경 → CANNOT_MODIFY_OWN_ROLE (DB 조회 안 함)")
+        void superSelfRole() {
+            Admin currentAdmin = admin(1L, Admin.Role.SUPER);
+            AdminUpdateRequest req = new AdminUpdateRequest();
+            ReflectionTestUtils.setField(req, "role", JsonNullable.of(Admin.Role.TEAM));
+
+            assertThatThrownBy(() -> adminService.updateAccount(1L, req, currentAdmin))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.CANNOT_MODIFY_OWN_ROLE);
+            verify(adminRepository, never()).findByIdAndDeletedAtIsNull(anyLong());
+        }
+
+        @Test
+        @DisplayName("TC-006 존재하지 않는 계정 → ADMIN_NOT_FOUND")
+        void notFound() {
+            Admin currentAdmin = admin(1L, Admin.Role.SUPER);
+            when(adminRepository.findByIdAndDeletedAtIsNull(999L)).thenReturn(Optional.empty());
+            AdminUpdateRequest req = new AdminUpdateRequest();
+
+            assertThatThrownBy(() -> adminService.updateAccount(999L, req, currentAdmin))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.ADMIN_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("TC-007 track=ALL → INVALID_TRACK_SELECTION")
+        void trackAll() {
+            Admin currentAdmin = admin(1L, Admin.Role.SUPER);
+            when(adminRepository.findByIdAndDeletedAtIsNull(2L)).thenReturn(Optional.of(admin(2L, Admin.Role.TEAM)));
+            AdminUpdateRequest req = new AdminUpdateRequest();
+            ReflectionTestUtils.setField(req, "track", JsonNullable.of(Track.ALL));
+
+            assertThatThrownBy(() -> adminService.updateAccount(2L, req, currentAdmin))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.INVALID_TRACK_SELECTION);
+        }
+
+        @Test
+        @DisplayName("TC-008 term < 0 → INVALID_INPUT_VALUE")
+        void negativeTerm() {
+            Admin currentAdmin = admin(1L, Admin.Role.SUPER);
+            when(adminRepository.findByIdAndDeletedAtIsNull(2L)).thenReturn(Optional.of(admin(2L, Admin.Role.TEAM)));
+            AdminUpdateRequest req = new AdminUpdateRequest();
+            ReflectionTestUtils.setField(req, "term", JsonNullable.of(-1));
+
+            assertThatThrownBy(() -> adminService.updateAccount(2L, req, currentAdmin))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // ADMIN-005: deleteAccount (id별 계정 삭제, soft delete)
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("ADMIN-005 deleteAccount")
+    class DeleteAccount {
+
+        @Test
+        @DisplayName("TC-001 SUPER 가 타 계정(TEAM) 삭제 → soft delete + RefreshToken 삭제")
+        void superDeletesOther() {
+            Admin currentAdmin = admin(1L, Admin.Role.SUPER);
+            Admin target = admin(2L, Admin.Role.TEAM);
+            when(adminRepository.findByIdAndDeletedAtIsNull(2L)).thenReturn(Optional.of(target));
+
+            adminService.deleteAccount(2L, currentAdmin);
+
+            assertThat(target.isDeleted()).isTrue();
+            verify(refreshTokenRepository).deleteByAccountTypeAndAccountId(AccountType.ADMIN, 2L);
+            // 대상이 TEAM 이므로 SUPER 카운트 조회 안 함
+            verify(adminRepository, never()).countByRoleAndDeletedAtIsNull(any());
+        }
+
+        @Test
+        @DisplayName("TC-002 SUPER 본인 삭제 (다른 SUPER 존재) → 허용")
+        void superSelfDeleteAllowed() {
+            Admin currentAdmin = admin(1L, Admin.Role.SUPER);
+            when(adminRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(currentAdmin));
+            when(adminRepository.countByRoleAndDeletedAtIsNull(Admin.Role.SUPER)).thenReturn(2L);
+
+            adminService.deleteAccount(1L, currentAdmin);
+
+            assertThat(currentAdmin.isDeleted()).isTrue();
+            verify(refreshTokenRepository).deleteByAccountTypeAndAccountId(AccountType.ADMIN, 1L);
+        }
+
+        @Test
+        @DisplayName("TC-003 마지막 SUPER 삭제 시도 → LAST_SUPER_ACCOUNT")
+        void lastSuper() {
+            Admin currentAdmin = admin(1L, Admin.Role.SUPER);
+            when(adminRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(currentAdmin));
+            when(adminRepository.countByRoleAndDeletedAtIsNull(Admin.Role.SUPER)).thenReturn(1L);
+
+            assertThatThrownBy(() -> adminService.deleteAccount(1L, currentAdmin))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.LAST_SUPER_ACCOUNT);
+            assertThat(currentAdmin.isDeleted()).isFalse();
+            verify(refreshTokenRepository, never()).deleteByAccountTypeAndAccountId(any(), anyLong());
+        }
+
+        @Test
+        @DisplayName("TC-004 TEAM 이 타 계정 삭제 → UNAUTHORIZED (DB 조회 안 함)")
+        void teamOther() {
+            Admin currentAdmin = admin(5L, Admin.Role.TEAM);
+
+            assertThatThrownBy(() -> adminService.deleteAccount(2L, currentAdmin))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.UNAUTHORIZED);
+            verify(adminRepository, never()).findByIdAndDeletedAtIsNull(anyLong());
+        }
+
+        @Test
+        @DisplayName("TC-005 존재하지 않는 계정 → ADMIN_NOT_FOUND")
+        void notFound() {
+            Admin currentAdmin = admin(1L, Admin.Role.SUPER);
+            when(adminRepository.findByIdAndDeletedAtIsNull(999L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> adminService.deleteAccount(999L, currentAdmin))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.ADMIN_NOT_FOUND);
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // ADMIN-006: resetPassword (비밀번호 초기화/변경)
+    // ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("ADMIN-006 resetPassword")
+    class ResetPassword {
+
+        @Test
+        @DisplayName("TC-001 SUPER 타인 초기화 (currentPassword 불필요) → 변경 + 토큰 삭제, matches 미호출")
+        void superResetsOther() {
+            Admin currentAdmin = admin(1L, Admin.Role.SUPER);
+            Admin target = admin(2L, Admin.Role.TEAM);
+            when(adminRepository.findByIdAndDeletedAtIsNull(2L)).thenReturn(Optional.of(target));
+            when(passwordEncoder.encode("NewBoaz1234!")).thenReturn("ENC2");
+
+            adminService.resetPassword(2L, pwRequest(null, "NewBoaz1234!"), currentAdmin);
+
+            assertThat(target.getPassword()).isEqualTo("ENC2");
+            verify(refreshTokenRepository).deleteByAccountTypeAndAccountId(AccountType.ADMIN, 2L);
+            verify(passwordEncoder, never()).matches(any(), any());
+        }
+
+        @Test
+        @DisplayName("TC-002 본인 변경 (currentPassword 일치) → 변경 + 토큰 삭제")
+        void selfChangeMatches() {
+            Admin currentAdmin = admin(5L, Admin.Role.TEAM);
+            when(adminRepository.findByIdAndDeletedAtIsNull(5L)).thenReturn(Optional.of(currentAdmin));
+            when(passwordEncoder.matches("old", "OLD_HASH")).thenReturn(true);
+            when(passwordEncoder.encode("NewBoaz1234!")).thenReturn("ENC2");
+
+            adminService.resetPassword(5L, pwRequest("old", "NewBoaz1234!"), currentAdmin);
+
+            assertThat(currentAdmin.getPassword()).isEqualTo("ENC2");
+            verify(refreshTokenRepository).deleteByAccountTypeAndAccountId(AccountType.ADMIN, 5L);
+        }
+
+        @Test
+        @DisplayName("TC-003 본인 변경인데 currentPassword 누락 → INVALID_INPUT_VALUE")
+        void selfCurrentPasswordBlank() {
+            Admin currentAdmin = admin(1L, Admin.Role.SUPER);
+            when(adminRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(currentAdmin));
+
+            assertThatThrownBy(() -> adminService.resetPassword(1L, pwRequest(null, "NewBoaz1234!"), currentAdmin))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
+            verify(refreshTokenRepository, never()).deleteByAccountTypeAndAccountId(any(), anyLong());
+        }
+
+        @Test
+        @DisplayName("TC-004 본인 변경인데 currentPassword 불일치 → INVALID_CURRENT_PASSWORD")
+        void selfCurrentPasswordMismatch() {
+            Admin currentAdmin = admin(1L, Admin.Role.SUPER);
+            when(adminRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(currentAdmin));
+            when(passwordEncoder.matches("wrong", "OLD_HASH")).thenReturn(false);
+
+            assertThatThrownBy(() -> adminService.resetPassword(1L, pwRequest("wrong", "NewBoaz1234!"), currentAdmin))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.INVALID_CURRENT_PASSWORD);
+            verify(refreshTokenRepository, never()).deleteByAccountTypeAndAccountId(any(), anyLong());
+        }
+
+        @Test
+        @DisplayName("TC-005 TEAM 이 타 계정 변경 → UNAUTHORIZED (DB 조회 안 함)")
+        void teamOther() {
+            Admin currentAdmin = admin(5L, Admin.Role.TEAM);
+
+            assertThatThrownBy(() -> adminService.resetPassword(2L, pwRequest(null, "NewBoaz1234!"), currentAdmin))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.UNAUTHORIZED);
+            verify(adminRepository, never()).findByIdAndDeletedAtIsNull(anyLong());
+        }
+
+        @Test
+        @DisplayName("TC-006 존재하지 않는 계정 → ADMIN_NOT_FOUND")
+        void notFound() {
+            Admin currentAdmin = admin(1L, Admin.Role.SUPER);
+            when(adminRepository.findByIdAndDeletedAtIsNull(999L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> adminService.resetPassword(999L, pwRequest(null, "NewBoaz1234!"), currentAdmin))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.ADMIN_NOT_FOUND);
+        }
+    }
+}


### PR DESCRIPTION
## 💡 개요

* Issue Number: #174

Admin(관리자 계정) 도메인 테스트 코드를 4계층으로 작성합니다. admin 은 테스트 코드가 전혀 없던 유일한 도메인이었고, 코드 기준 명세서(`docs/test/TC-ADMIN-001~007`)를 바탕으로 작성했습니다.

## 🪐 주요 변경 사항
- `AdminServiceTest` (Mockito): 계정 CRUD·비밀번호·권한 분기 단위 테스트 (32)
- `AdminControllerTest` (`@WebMvcTest`): HTTP 계약·@Valid·Security 슬라이스 (26)
- `AdminRepositoryTest` (`@DataJpaTest` + Testcontainers): 커스텀 쿼리 검증 (8)
- `AdminIntegrationTest` (`@SpringBootTest` + Testcontainers): end-to-end 흐름 (9)
- 합계 **75 tests, 전부 통과**

## ✅ 상세 내용
- ADMIN-001~007: 모든 계정 조회 / 계정 생성 / 내 계정 조회(getMe) / id별 조회·수정·삭제 / 비밀번호 초기화·변경
- 권한 분기(SUPER·TEAM·본인), soft delete 제외·정렬, RefreshToken 삭제(role 변경·삭제·비번 변경), JsonNullable 부분 수정, 마지막 SUPER 삭제 가드, password BCrypt 해시 검증 등
- Repository: `findAll…OrderByCreatedAtAsc`, `existsByUsername…`, `findById…`, `countByRole…`, 평가자 풀 쿼리 등 soft delete 조건/정렬 검증

## 🔔 참고 사항
- 권한 거부 상태코드는 **코드 기준 401**(`ErrorCode.UNAUTHORIZED`)로 단언 (노션 명세 403 표기와 불일치 — 팀 정렬 필요)
- ADMIN-007(getMe)은 DB 접근이 없어 Repository 계층 테스트 없음
- `@WebMvcTest` 슬라이스에 `JacksonConfig` 미로딩으로 JsonNullable PATCH 본문이 깨지던 것 → `@Import` 에 추가해 해결
- 테스트 명세서(`docs/test/TC-ADMIN-*`)는 gitignore 대상이라 본 PR 에 미포함
