### PR TITLE
[Fix] 지원서 전체 삭제 시 평가(applicant_eval) 미삭제로 인한 FK 위반 수정

### DIFF
--- a/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantEvalRepository.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantEvalRepository.java
@@ -40,4 +40,9 @@ public interface ApplicantEvalRepository extends JpaRepository<ApplicantEval, Lo
     // 평가 대시보드 집계용 — 공고 내 모든 평가 (Java에서 applicant 단위 집계)
     @Query("SELECT e FROM ApplicantEval e WHERE e.applicant.recruitment.id = :recruitmentId")
     List<ApplicantEval> findByRecruitmentId(@Param("recruitmentId") Long recruitmentId);
+
+    // recruitment 내 전체 평가 삭제 (지원서 전체 삭제 시 FK 자식부터 정리, 서브쿼리 벌크 삭제)
+    @Modifying
+    @Query("DELETE FROM ApplicantEval e WHERE e.applicant.id IN (SELECT a.id FROM Applicant a WHERE a.recruitment.id = :recruitmentId)")
+    void deleteByRecruitmentId(@Param("recruitmentId") Long recruitmentId);
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -761,6 +761,9 @@ public class RecruitmentService {
             throw new CustomException(ErrorCode.RECRUITMENT_NOT_CLOSED);
         }
 
+        // FK 자식부터 순서대로 삭제: applicant_eval → applicant_answer → applicant
+        // (applicant_eval.applicant_id는 NOT NULL FK, ON DELETE CASCADE 없음)
+        applicantEvalRepository.deleteByRecruitmentId(recruitmentId);
         applicantAnswerRepository.deleteByRecruitmentId(recruitmentId);
         applicantRepository.deleteByRecruitmentId(recruitmentId);
     }

--- a/src/test/java/com/boaz/backend/domain/recruitment/integration/RecruitmentIntegrationTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/integration/RecruitmentIntegrationTest.java
@@ -17,7 +17,9 @@ import com.boaz.backend.domain.recruitment.dto.response.RecruitmentResponse;
 import com.boaz.backend.domain.recruitment.dto.response.RecruitmentStatusResponse;
 import com.boaz.backend.domain.recruitment.dto.response.SubscriptionResponse;
 import com.boaz.backend.domain.recruitment.entity.Applicant;
+import com.boaz.backend.domain.admin.repository.AdminRepository;
 import com.boaz.backend.domain.recruitment.entity.ApplicantAnswer;
+import com.boaz.backend.domain.recruitment.entity.ApplicantEval;
 import com.boaz.backend.domain.recruitment.entity.ApplicationQuestion;
 import com.boaz.backend.domain.recruitment.entity.ApplicationQuestion.Category;
 import com.boaz.backend.domain.recruitment.entity.ApplicationQuestion.Type;
@@ -25,6 +27,7 @@ import com.boaz.backend.domain.recruitment.entity.DecisionFilter;
 import com.boaz.backend.domain.recruitment.entity.EvaluationDecision;
 import com.boaz.backend.domain.recruitment.entity.Recruitment;
 import com.boaz.backend.domain.recruitment.repository.ApplicantAnswerRepository;
+import com.boaz.backend.domain.recruitment.repository.ApplicantEvalRepository;
 import com.boaz.backend.domain.recruitment.repository.ApplicantRepository;
 import com.boaz.backend.domain.recruitment.repository.ApplicationQuestionRepository;
 import com.boaz.backend.domain.recruitment.repository.RecruitmentRepository;
@@ -74,6 +77,8 @@ class RecruitmentIntegrationTest extends TestcontainersBase {
     @Autowired ApplicationQuestionRepository questionRepository;
     @Autowired ApplicantRepository applicantRepository;
     @Autowired ApplicantAnswerRepository answerRepository;
+    @Autowired ApplicantEvalRepository evalRepository;
+    @Autowired AdminRepository adminRepository;
     @Autowired SubscriptionRepository subscriptionRepository;
     @Autowired UserRepository userRepository;
     @Autowired ObjectMapper objectMapper;
@@ -665,7 +670,7 @@ class RecruitmentIntegrationTest extends TestcontainersBase {
     class Admin {
 
         @Test
-        @DisplayName("마감된 공고의 지원서 전체 삭제 → answer/applicant 모두 제거")
+        @DisplayName("마감된 공고의 지원서 전체 삭제 → eval/answer/applicant 모두 제거 (평가 존재 시 FK 위반 없음, #178)")
         void deleteApplicants() {
             Recruitment r = saveClosedRecruitment(26);
             User u = saveUser();
@@ -674,8 +679,18 @@ class RecruitmentIntegrationTest extends TestcontainersBase {
                     .recruitment(r).user(u).status(Applicant.ApplicantStatus.SUBMITTED)
                     .track(Track.ENGINEERING).name("n").email("a@example.com").phone("01012345678")
                     .build());
-            answerRepository.save(com.boaz.backend.domain.recruitment.entity.ApplicantAnswer.builder()
+            answerRepository.save(ApplicantAnswer.builder()
                     .applicant(a).question(q).answerText("답").build());
+            // 평가 데이터: applicant_eval.applicant_id FK → 삭제 순서 누락 시 여기서 FK 위반 발생
+            com.boaz.backend.domain.admin.entity.Admin evaluator = adminRepository.save(
+                    com.boaz.backend.domain.admin.entity.Admin.builder()
+                    .username("evaluator-178").password("p")
+                    .role(com.boaz.backend.domain.admin.entity.Admin.Role.TEAM).name("평가자")
+                    .track(Track.ENGINEERING).term(26)
+                    .teamName(com.boaz.backend.domain.admin.entity.Admin.TeamName.서비스운영팀)
+                    .createdBy(null).build());
+            evalRepository.save(ApplicantEval.builder()
+                    .applicant(a).admin(evaluator).decision(EvaluationDecision.PASS).score(9).build());
             em.flush();
             em.clear();
 
@@ -685,6 +700,7 @@ class RecruitmentIntegrationTest extends TestcontainersBase {
 
             assertThat(applicantRepository.existsByRecruitmentId(r.getId())).isFalse();
             assertThat(answerRepository.findByApplicantIds(List.of(a.getId()))).isEmpty();
+            assertThat(evalRepository.findByRecruitmentId(r.getId())).isEmpty();
         }
 
         @Test

--- a/src/test/java/com/boaz/backend/domain/recruitment/repository/ApplicantEvalRepositoryTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/repository/ApplicantEvalRepositoryTest.java
@@ -166,5 +166,24 @@ class ApplicantEvalRepositoryTest extends TestcontainersBase {
 
             assertThat(result).hasSize(2);
         }
+
+        @Test
+        @DisplayName("deleteByRecruitmentId — 공고 내 평가만 벌크 삭제 (다른 공고 평가는 유지)")
+        void deleteByRecruitmentId() {
+            Recruitment target = persistRecruitment(27);
+            Recruitment other = persistRecruitment(28);
+            Applicant a1 = persistApplicant(target, persistUser("p1"), Track.ENGINEERING);
+            Applicant a2 = persistApplicant(other, persistUser("p2"), Track.ENGINEERING);
+            Admin ev1 = persistAdmin("ev1", Track.ENGINEERING);
+            em.persistFlushFind(ApplicantEval.builder().applicant(a1).admin(ev1).decision(EvaluationDecision.PASS).score(9).build());
+            em.persistFlushFind(ApplicantEval.builder().applicant(a2).admin(ev1).decision(EvaluationDecision.HOLD).score(5).build());
+            em.clear();
+
+            applicantEvalRepository.deleteByRecruitmentId(target.getId());
+            em.clear(); // 벌크 삭제 후 영속성 컨텍스트 정리
+
+            assertThat(applicantEvalRepository.findByRecruitmentId(target.getId())).isEmpty();
+            assertThat(applicantEvalRepository.findByRecruitmentId(other.getId())).hasSize(1);
+        }
     }
 }

--- a/src/test/java/com/boaz/backend/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/service/RecruitmentServiceTest.java
@@ -60,6 +60,7 @@ class RecruitmentServiceTest {
     @Mock ApplicationQuestionRepository applicationQuestionRepository;
     @Mock ApplicantRepository applicantRepository;
     @Mock ApplicantAnswerRepository applicantAnswerRepository;
+    @Mock ApplicantEvalRepository applicantEvalRepository;
     @Mock UserRepository userRepository;
     @Mock SubscriptionRepository subscriptionRepository;
     @Mock S3Service s3Service;
@@ -1438,14 +1439,16 @@ class RecruitmentServiceTest {
     class DeleteApplicants {
 
         @Test
-        @DisplayName("TC-001 모집 마감 후 삭제 → answer 먼저, applicant 나중 삭제")
+        @DisplayName("TC-001 모집 마감 후 삭제 → eval → answer → applicant 순 삭제")
         void deleteInOrder() {
             Recruitment r = createExpiredRecruitment();
             when(recruitmentRepository.findById(2L)).thenReturn(Optional.of(r));
 
             recruitmentService.deleteApplicants(2L);
 
-            var inOrder = inOrder(applicantAnswerRepository, applicantRepository);
+            // FK 자식부터: applicant_eval → applicant_answer → applicant
+            var inOrder = inOrder(applicantEvalRepository, applicantAnswerRepository, applicantRepository);
+            inOrder.verify(applicantEvalRepository).deleteByRecruitmentId(2L);
             inOrder.verify(applicantAnswerRepository).deleteByRecruitmentId(2L);
             inOrder.verify(applicantRepository).deleteByRecruitmentId(2L);
         }
@@ -1458,6 +1461,7 @@ class RecruitmentServiceTest {
 
             recruitmentService.deleteApplicants(2L);
 
+            verify(applicantEvalRepository).deleteByRecruitmentId(2L);
             verify(applicantAnswerRepository).deleteByRecruitmentId(2L);
         }
 


### PR DESCRIPTION
## 💡 개요

* Issue Number: #178

## 🪐 주요 변경 사항
- 리크루팅 어드민 **지원서 전체 삭제**(`deleteApplicants`)가 `applicant_eval`을 정리하지 않아, 평가가 존재하는 공고 삭제 시 FK 제약 위반으로 실패하던 버그 수정
- 삭제 순서를 FK 자식부터(`applicant_eval → applicant_answer → applicant`)로 정정

## ✅ 상세 내용
- `ApplicantEvalRepository`: `deleteByRecruitmentId` 서브쿼리 벌크 삭제 메서드 추가 (기존 `ApplicantAnswerRepository`와 동일 패턴, 메모리 적재 없이 삭제)
- `RecruitmentService.deleteApplicants`: 기존 `answer → applicant` 순서 앞에 `applicant_eval` 삭제를 추가하여 `eval → answer → applicant` 순서로 정정
- **배경**: 평가 어드민 기능(#170) 추가로 `applicant_eval.applicant_id`(NOT NULL FK, `ON DELETE CASCADE` 없음)가 생겼으나 삭제 로직이 미반영된 상태였음
- **테스트 보강**
  - `RecruitmentServiceTest`: `ApplicantEvalRepository` mock 추가, 삭제 순서 검증을 `eval → answer → applicant` 로 갱신
  - `ApplicantEvalRepositoryTest`: `deleteByRecruitmentId` — 대상 공고 평가만 삭제하고 타 공고 평가는 유지하는지 검증
  - `RecruitmentIntegrationTest`: end-to-end 삭제 테스트에 평가 데이터를 추가하여 **평가 존재 공고도 FK 위반 없이 삭제**되는지 실제 DB로 검증 (회귀 방지)

## 🔔 참고 사항
- 전체 테스트 스위트 통과 확인 (`./gradlew test`, Testcontainers/Docker 기동 상태)
- 다른 삭제 경로는 동일 이슈 없음: 공고/질문 삭제는 자식 존재 시 guard로 거부, 관리자 삭제는 soft delete
- 테스트 명세서(`docs/test/TC-REC-ADMIN-010.md`)도 함께 갱신 (해당 경로는 gitignore 대상이라 커밋에는 미포함)