### PR TITLE
[Feat] #180 User 엔티티 ERD 정합 - 승격 시 지원서 개인정보 필드 추가

### DIFF
--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/request/ApplicationRequest.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/request/ApplicationRequest.java
@@ -1,6 +1,6 @@
 package com.boaz.backend.domain.recruitment.dto.request;
 
-import com.boaz.backend.domain.recruitment.entity.Applicant;
+import com.boaz.backend.global.common.enums.MilitaryStatus;
 import com.boaz.backend.global.common.enums.Track;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -51,7 +51,7 @@ public class ApplicationRequest {
     @Schema(description = "병역 상태", example = "COMPLETED_OR_EXEMPT", allowableValues = {"COMPLETED_OR_EXEMPT", "NOT_COMPLETED"})
     @NotNull(message = "병역 상태를 선택해주세요.")
     @JsonProperty("military_status")
-    private Applicant.MilitaryStatus militaryStatus;
+    private MilitaryStatus militaryStatus;
 
     @Schema(description = "생년월일", example = "2000-01-01")
     @NotBlank(message = "생년월일을 입력해주세요.")

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/request/DraftApplicationRequest.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/request/DraftApplicationRequest.java
@@ -1,6 +1,6 @@
 package com.boaz.backend.domain.recruitment.dto.request;
 
-import com.boaz.backend.domain.recruitment.entity.Applicant;
+import com.boaz.backend.global.common.enums.MilitaryStatus;
 import com.boaz.backend.global.common.enums.Track;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -40,7 +40,7 @@ public class DraftApplicationRequest {
 
     @Schema(description = "병역 상태", allowableValues = {"COMPLETED_OR_EXEMPT", "NOT_COMPLETED"})
     @JsonProperty("military_status")
-    private Applicant.MilitaryStatus militaryStatus;
+    private MilitaryStatus militaryStatus;
 
     @Schema(description = "생년월일 (YYYY-MM-DD)", example = "2000-01-01")
     @JsonProperty("birth_date")

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/response/ApplicantEvaluationResponse.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/response/ApplicantEvaluationResponse.java
@@ -2,6 +2,7 @@ package com.boaz.backend.domain.recruitment.dto.response;
 
 import com.boaz.backend.domain.recruitment.entity.Applicant;
 import com.boaz.backend.domain.recruitment.entity.EvaluationDecision;
+import com.boaz.backend.global.common.enums.MilitaryStatus;
 import com.boaz.backend.global.common.enums.Track;
 import lombok.Builder;
 import lombok.Getter;
@@ -35,7 +36,7 @@ public class ApplicantEvaluationResponse {
 
     private final Integer lastSemester;
 
-    private final Applicant.MilitaryStatus militaryStatus;
+    private final MilitaryStatus militaryStatus;
 
     private final LocalDate birthDate;
 

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/response/ApplicantSummaryResponse.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/response/ApplicantSummaryResponse.java
@@ -1,6 +1,7 @@
 package com.boaz.backend.domain.recruitment.dto.response;
 
 import com.boaz.backend.domain.recruitment.entity.Applicant;
+import com.boaz.backend.global.common.enums.MilitaryStatus;
 import com.boaz.backend.global.common.enums.Track;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,7 +37,7 @@ public class ApplicantSummaryResponse {
 
     private final Integer lastSemester;
 
-    private final Applicant.MilitaryStatus militaryStatus;
+    private final MilitaryStatus militaryStatus;
 
     private final LocalDate birthDate;
 

--- a/src/main/java/com/boaz/backend/domain/recruitment/dto/response/MyApplicationResponse.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/dto/response/MyApplicationResponse.java
@@ -1,6 +1,7 @@
 package com.boaz.backend.domain.recruitment.dto.response;
 
 import com.boaz.backend.domain.recruitment.entity.Applicant;
+import com.boaz.backend.global.common.enums.MilitaryStatus;
 import com.boaz.backend.global.common.enums.Track;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -49,7 +50,7 @@ public class MyApplicationResponse {
 
     @Schema(description = "병역 상태", example = "COMPLETED_OR_EXEMPT")
     @JsonProperty("military_status")
-    private final Applicant.MilitaryStatus militaryStatus;
+    private final MilitaryStatus militaryStatus;
 
     @Schema(description = "생년월일", example = "2000-01-01")
     @JsonProperty("birth_date")
@@ -77,7 +78,7 @@ public class MyApplicationResponse {
     private MyApplicationResponse(Long applicantId, Applicant.ApplicantStatus status, Track track,
                                    String name, String email, String phone, String university, String major,
                                    List<String> minorDoubleMajor, Integer lastSemester,
-                                   Applicant.MilitaryStatus militaryStatus, LocalDate birthDate,
+                                   MilitaryStatus militaryStatus, LocalDate birthDate,
                                    String graduationDate, Boolean gradSchoolPlan,
                                    List<AnswerItemResponse> answers,
                                    LocalDateTime createdAt, LocalDateTime updatedAt) {

--- a/src/main/java/com/boaz/backend/domain/recruitment/entity/Applicant.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/entity/Applicant.java
@@ -1,6 +1,5 @@
 package com.boaz.backend.domain.recruitment.entity;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -11,6 +10,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.boaz.backend.domain.user.entity.User;
 import com.boaz.backend.global.common.BaseEntity;
+import com.boaz.backend.global.common.enums.MilitaryStatus;
 import com.boaz.backend.global.common.enums.Track;
 
 import java.time.LocalDate;
@@ -22,13 +22,6 @@ import java.time.LocalDateTime;
 @Table(name = "applicants")
 @EntityListeners(AuditingEntityListener.class)
 public class Applicant extends BaseEntity {
-
-    public enum MilitaryStatus {
-        @Schema(description = "필 또는 면제")
-        COMPLETED_OR_EXEMPT,
-        @Schema(description = "미필")
-        NOT_COMPLETED
-    }
 
     public enum ApplicantStatus {
         DRAFT,

--- a/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantEvalRepository.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/repository/ApplicantEvalRepository.java
@@ -40,4 +40,9 @@ public interface ApplicantEvalRepository extends JpaRepository<ApplicantEval, Lo
     // 평가 대시보드 집계용 — 공고 내 모든 평가 (Java에서 applicant 단위 집계)
     @Query("SELECT e FROM ApplicantEval e WHERE e.applicant.recruitment.id = :recruitmentId")
     List<ApplicantEval> findByRecruitmentId(@Param("recruitmentId") Long recruitmentId);
+
+    // recruitment 내 전체 평가 삭제 (지원서 전체 삭제 시 FK 자식부터 정리, 서브쿼리 벌크 삭제)
+    @Modifying
+    @Query("DELETE FROM ApplicantEval e WHERE e.applicant.id IN (SELECT a.id FROM Applicant a WHERE a.recruitment.id = :recruitmentId)")
+    void deleteByRecruitmentId(@Param("recruitmentId") Long recruitmentId);
 }

--- a/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/boaz/backend/domain/recruitment/service/RecruitmentService.java
@@ -761,6 +761,9 @@ public class RecruitmentService {
             throw new CustomException(ErrorCode.RECRUITMENT_NOT_CLOSED);
         }
 
+        // FK 자식부터 순서대로 삭제: applicant_eval → applicant_answer → applicant
+        // (applicant_eval.applicant_id는 NOT NULL FK, ON DELETE CASCADE 없음)
+        applicantEvalRepository.deleteByRecruitmentId(recruitmentId);
         applicantAnswerRepository.deleteByRecruitmentId(recruitmentId);
         applicantRepository.deleteByRecruitmentId(recruitmentId);
     }

--- a/src/main/java/com/boaz/backend/domain/user/entity/User.java
+++ b/src/main/java/com/boaz/backend/domain/user/entity/User.java
@@ -2,12 +2,15 @@ package com.boaz.backend.domain.user.entity;
 
 import com.boaz.backend.global.common.BaseEntity;
 import com.boaz.backend.global.common.enums.MemberType;
+import com.boaz.backend.global.common.enums.MilitaryStatus;
 import com.boaz.backend.global.common.enums.Track;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -36,9 +39,34 @@ public class User extends BaseEntity {
 
     // 승격 시 Applicant에서 복사되는 필드 (기본 null)
     private String name;
+
+    @Column(length = 255)
+    private String email;
+
+    @Column(length = 20)
     private String phone;
+
+    @Column(length = 100)
     private String university;
+
+    @Column(length = 100)
     private String major;
+
+    @Column(columnDefinition = "JSON")
+    private String minorDoubleMajor;
+
+    private Integer lastSemester;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 50)
+    private MilitaryStatus militaryStatus;
+
+    private LocalDate birthDate;
+
+    @Column(length = 7)
+    private String graduationDate;
+
+    private Boolean gradSchoolPlan;
 
     @Enumerated(EnumType.STRING)
     @Column(length = 20)
@@ -55,12 +83,22 @@ public class User extends BaseEntity {
     }
 
     // 합격자 승격: memberType → MEMBER, 지원서 개인정보 복사
-    public void promote(String name, String phone, String university, String major, Track track, Integer term) {
+    public void promote(String name, String email, String phone, String university, String major,
+                        String minorDoubleMajor, Integer lastSemester, MilitaryStatus militaryStatus,
+                        LocalDate birthDate, String graduationDate, Boolean gradSchoolPlan,
+                        Track track, Integer term) {
         this.memberType = MemberType.MEMBER;
         this.name = name;
+        this.email = email;
         this.phone = phone;
         this.university = university;
         this.major = major;
+        this.minorDoubleMajor = minorDoubleMajor;
+        this.lastSemester = lastSemester;
+        this.militaryStatus = militaryStatus;
+        this.birthDate = birthDate;
+        this.graduationDate = graduationDate;
+        this.gradSchoolPlan = gradSchoolPlan;
         this.track = track;
         this.term = term;
     }

--- a/src/main/java/com/boaz/backend/domain/user/service/UserAdminService.java
+++ b/src/main/java/com/boaz/backend/domain/user/service/UserAdminService.java
@@ -60,9 +60,16 @@ public class UserAdminService {
         // 승격: 지원서 개인정보 → User 복사 + memberType → MEMBER
         user.promote(
                 applicant.getName(),
+                applicant.getEmail(),
                 applicant.getPhone(),
                 applicant.getUniversity(),
                 applicant.getMajor(),
+                applicant.getMinorDoubleMajor(),
+                applicant.getLastSemester(),
+                applicant.getMilitaryStatus(),
+                applicant.getBirthDate(),
+                applicant.getGraduationDate(),
+                applicant.getGradSchoolPlan(),
                 applicant.getTrack(),
                 applicant.getRecruitment().getTerm()
         );

--- a/src/main/java/com/boaz/backend/global/common/enums/MilitaryStatus.java
+++ b/src/main/java/com/boaz/backend/global/common/enums/MilitaryStatus.java
@@ -1,0 +1,10 @@
+package com.boaz.backend.global.common.enums;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public enum MilitaryStatus {
+    @Schema(description = "필 또는 면제")
+    COMPLETED_OR_EXEMPT,
+    @Schema(description = "미필")
+    NOT_COMPLETED
+}

--- a/src/test/java/com/boaz/backend/domain/recruitment/integration/RecruitmentIntegrationTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/integration/RecruitmentIntegrationTest.java
@@ -17,7 +17,9 @@ import com.boaz.backend.domain.recruitment.dto.response.RecruitmentResponse;
 import com.boaz.backend.domain.recruitment.dto.response.RecruitmentStatusResponse;
 import com.boaz.backend.domain.recruitment.dto.response.SubscriptionResponse;
 import com.boaz.backend.domain.recruitment.entity.Applicant;
+import com.boaz.backend.domain.admin.repository.AdminRepository;
 import com.boaz.backend.domain.recruitment.entity.ApplicantAnswer;
+import com.boaz.backend.domain.recruitment.entity.ApplicantEval;
 import com.boaz.backend.domain.recruitment.entity.ApplicationQuestion;
 import com.boaz.backend.domain.recruitment.entity.ApplicationQuestion.Category;
 import com.boaz.backend.domain.recruitment.entity.ApplicationQuestion.Type;
@@ -25,6 +27,7 @@ import com.boaz.backend.domain.recruitment.entity.DecisionFilter;
 import com.boaz.backend.domain.recruitment.entity.EvaluationDecision;
 import com.boaz.backend.domain.recruitment.entity.Recruitment;
 import com.boaz.backend.domain.recruitment.repository.ApplicantAnswerRepository;
+import com.boaz.backend.domain.recruitment.repository.ApplicantEvalRepository;
 import com.boaz.backend.domain.recruitment.repository.ApplicantRepository;
 import com.boaz.backend.domain.recruitment.repository.ApplicationQuestionRepository;
 import com.boaz.backend.domain.recruitment.repository.RecruitmentRepository;
@@ -74,6 +77,8 @@ class RecruitmentIntegrationTest extends TestcontainersBase {
     @Autowired ApplicationQuestionRepository questionRepository;
     @Autowired ApplicantRepository applicantRepository;
     @Autowired ApplicantAnswerRepository answerRepository;
+    @Autowired ApplicantEvalRepository evalRepository;
+    @Autowired AdminRepository adminRepository;
     @Autowired SubscriptionRepository subscriptionRepository;
     @Autowired UserRepository userRepository;
     @Autowired ObjectMapper objectMapper;
@@ -665,7 +670,7 @@ class RecruitmentIntegrationTest extends TestcontainersBase {
     class Admin {
 
         @Test
-        @DisplayName("마감된 공고의 지원서 전체 삭제 → answer/applicant 모두 제거")
+        @DisplayName("마감된 공고의 지원서 전체 삭제 → eval/answer/applicant 모두 제거 (평가 존재 시 FK 위반 없음, #178)")
         void deleteApplicants() {
             Recruitment r = saveClosedRecruitment(26);
             User u = saveUser();
@@ -674,8 +679,18 @@ class RecruitmentIntegrationTest extends TestcontainersBase {
                     .recruitment(r).user(u).status(Applicant.ApplicantStatus.SUBMITTED)
                     .track(Track.ENGINEERING).name("n").email("a@example.com").phone("01012345678")
                     .build());
-            answerRepository.save(com.boaz.backend.domain.recruitment.entity.ApplicantAnswer.builder()
+            answerRepository.save(ApplicantAnswer.builder()
                     .applicant(a).question(q).answerText("답").build());
+            // 평가 데이터: applicant_eval.applicant_id FK → 삭제 순서 누락 시 여기서 FK 위반 발생
+            com.boaz.backend.domain.admin.entity.Admin evaluator = adminRepository.save(
+                    com.boaz.backend.domain.admin.entity.Admin.builder()
+                    .username("evaluator-178").password("p")
+                    .role(com.boaz.backend.domain.admin.entity.Admin.Role.TEAM).name("평가자")
+                    .track(Track.ENGINEERING).term(26)
+                    .teamName(com.boaz.backend.domain.admin.entity.Admin.TeamName.서비스운영팀)
+                    .createdBy(null).build());
+            evalRepository.save(ApplicantEval.builder()
+                    .applicant(a).admin(evaluator).decision(EvaluationDecision.PASS).score(9).build());
             em.flush();
             em.clear();
 
@@ -685,6 +700,7 @@ class RecruitmentIntegrationTest extends TestcontainersBase {
 
             assertThat(applicantRepository.existsByRecruitmentId(r.getId())).isFalse();
             assertThat(answerRepository.findByApplicantIds(List.of(a.getId()))).isEmpty();
+            assertThat(evalRepository.findByRecruitmentId(r.getId())).isEmpty();
         }
 
         @Test

--- a/src/test/java/com/boaz/backend/domain/recruitment/repository/ApplicantEvalRepositoryTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/repository/ApplicantEvalRepositoryTest.java
@@ -166,5 +166,24 @@ class ApplicantEvalRepositoryTest extends TestcontainersBase {
 
             assertThat(result).hasSize(2);
         }
+
+        @Test
+        @DisplayName("deleteByRecruitmentId — 공고 내 평가만 벌크 삭제 (다른 공고 평가는 유지)")
+        void deleteByRecruitmentId() {
+            Recruitment target = persistRecruitment(27);
+            Recruitment other = persistRecruitment(28);
+            Applicant a1 = persistApplicant(target, persistUser("p1"), Track.ENGINEERING);
+            Applicant a2 = persistApplicant(other, persistUser("p2"), Track.ENGINEERING);
+            Admin ev1 = persistAdmin("ev1", Track.ENGINEERING);
+            em.persistFlushFind(ApplicantEval.builder().applicant(a1).admin(ev1).decision(EvaluationDecision.PASS).score(9).build());
+            em.persistFlushFind(ApplicantEval.builder().applicant(a2).admin(ev1).decision(EvaluationDecision.HOLD).score(5).build());
+            em.clear();
+
+            applicantEvalRepository.deleteByRecruitmentId(target.getId());
+            em.clear(); // 벌크 삭제 후 영속성 컨텍스트 정리
+
+            assertThat(applicantEvalRepository.findByRecruitmentId(target.getId())).isEmpty();
+            assertThat(applicantEvalRepository.findByRecruitmentId(other.getId())).hasSize(1);
+        }
     }
 }

--- a/src/test/java/com/boaz/backend/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/service/RecruitmentServiceTest.java
@@ -60,6 +60,7 @@ class RecruitmentServiceTest {
     @Mock ApplicationQuestionRepository applicationQuestionRepository;
     @Mock ApplicantRepository applicantRepository;
     @Mock ApplicantAnswerRepository applicantAnswerRepository;
+    @Mock ApplicantEvalRepository applicantEvalRepository;
     @Mock UserRepository userRepository;
     @Mock SubscriptionRepository subscriptionRepository;
     @Mock S3Service s3Service;
@@ -1438,14 +1439,16 @@ class RecruitmentServiceTest {
     class DeleteApplicants {
 
         @Test
-        @DisplayName("TC-001 모집 마감 후 삭제 → answer 먼저, applicant 나중 삭제")
+        @DisplayName("TC-001 모집 마감 후 삭제 → eval → answer → applicant 순 삭제")
         void deleteInOrder() {
             Recruitment r = createExpiredRecruitment();
             when(recruitmentRepository.findById(2L)).thenReturn(Optional.of(r));
 
             recruitmentService.deleteApplicants(2L);
 
-            var inOrder = inOrder(applicantAnswerRepository, applicantRepository);
+            // FK 자식부터: applicant_eval → applicant_answer → applicant
+            var inOrder = inOrder(applicantEvalRepository, applicantAnswerRepository, applicantRepository);
+            inOrder.verify(applicantEvalRepository).deleteByRecruitmentId(2L);
             inOrder.verify(applicantAnswerRepository).deleteByRecruitmentId(2L);
             inOrder.verify(applicantRepository).deleteByRecruitmentId(2L);
         }
@@ -1458,6 +1461,7 @@ class RecruitmentServiceTest {
 
             recruitmentService.deleteApplicants(2L);
 
+            verify(applicantEvalRepository).deleteByRecruitmentId(2L);
             verify(applicantAnswerRepository).deleteByRecruitmentId(2L);
         }
 

--- a/src/test/java/com/boaz/backend/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/boaz/backend/domain/recruitment/service/RecruitmentServiceTest.java
@@ -17,6 +17,7 @@ import com.boaz.backend.domain.recruitment.repository.*;
 import com.boaz.backend.domain.user.entity.User;
 import com.boaz.backend.domain.user.repository.UserRepository;
 import com.boaz.backend.global.common.enums.MemberType;
+import com.boaz.backend.global.common.enums.MilitaryStatus;
 import com.boaz.backend.global.common.enums.Track;
 import com.boaz.backend.global.exception.CustomException;
 import com.boaz.backend.global.exception.ErrorCode;
@@ -175,7 +176,7 @@ class RecruitmentServiceTest {
         ReflectionTestUtils.setField(req, "university", "한국대학교");
         ReflectionTestUtils.setField(req, "major", "컴퓨터공학");
         ReflectionTestUtils.setField(req, "lastSemester", 6);
-        ReflectionTestUtils.setField(req, "militaryStatus", Applicant.MilitaryStatus.COMPLETED_OR_EXEMPT);
+        ReflectionTestUtils.setField(req, "militaryStatus", MilitaryStatus.COMPLETED_OR_EXEMPT);
         ReflectionTestUtils.setField(req, "birthDate", "2000-01-01");
         ReflectionTestUtils.setField(req, "graduationDate", "2026-02");
         ReflectionTestUtils.setField(req, "gradSchoolPlan", false);

--- a/src/test/java/com/boaz/backend/domain/user/integration/UserIntegrationTest.java
+++ b/src/test/java/com/boaz/backend/domain/user/integration/UserIntegrationTest.java
@@ -11,6 +11,7 @@ import com.boaz.backend.domain.user.repository.UserRepository;
 import com.boaz.backend.domain.user.service.UserAdminService;
 import com.boaz.backend.domain.user.service.UserService;
 import com.boaz.backend.global.common.enums.MemberType;
+import com.boaz.backend.global.common.enums.MilitaryStatus;
 import com.boaz.backend.global.common.enums.Track;
 import com.boaz.backend.global.exception.CustomException;
 import com.boaz.backend.global.exception.ErrorCode;
@@ -25,6 +26,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -57,6 +59,10 @@ class UserIntegrationTest extends TestcontainersBase {
                 .recruitment(r).user(u).status(Applicant.ApplicantStatus.SUBMITTED)
                 .track(Track.ENGINEERING).name("홍길동").email("hong@example.com")
                 .phone("01012345678").university("한국대").major("컴공")
+                .minorDoubleMajor("[\"경영학\"]").lastSemester(6)
+                .militaryStatus(MilitaryStatus.COMPLETED_OR_EXEMPT)
+                .birthDate(LocalDate.of(2000, 3, 15))
+                .graduationDate("2026-02").gradSchoolPlan(false)
                 .build());
     }
 
@@ -107,9 +113,16 @@ class UserIntegrationTest extends TestcontainersBase {
             User promoted = userRepository.findById(u.getId()).orElseThrow();
             assertThat(promoted.getMemberType()).isEqualTo(MemberType.MEMBER);
             assertThat(promoted.getName()).isEqualTo("홍길동");
+            assertThat(promoted.getEmail()).isEqualTo("hong@example.com");
             assertThat(promoted.getPhone()).isEqualTo("01012345678");
             assertThat(promoted.getUniversity()).isEqualTo("한국대");
             assertThat(promoted.getMajor()).isEqualTo("컴공");
+            assertThat(promoted.getMinorDoubleMajor()).isEqualTo("[\"경영학\"]");
+            assertThat(promoted.getLastSemester()).isEqualTo(6);
+            assertThat(promoted.getMilitaryStatus()).isEqualTo(MilitaryStatus.COMPLETED_OR_EXEMPT);
+            assertThat(promoted.getBirthDate()).isEqualTo(LocalDate.of(2000, 3, 15));
+            assertThat(promoted.getGraduationDate()).isEqualTo("2026-02");
+            assertThat(promoted.getGradSchoolPlan()).isFalse();
             assertThat(promoted.getTrack()).isEqualTo(Track.ENGINEERING);
             assertThat(promoted.getTerm()).isEqualTo(27);
         }

--- a/src/test/java/com/boaz/backend/domain/user/service/UserAdminServiceTest.java
+++ b/src/test/java/com/boaz/backend/domain/user/service/UserAdminServiceTest.java
@@ -7,6 +7,7 @@ import com.boaz.backend.domain.user.dto.response.PromoteUsersResponse;
 import com.boaz.backend.domain.user.entity.User;
 import com.boaz.backend.domain.user.repository.UserRepository;
 import com.boaz.backend.global.common.enums.MemberType;
+import com.boaz.backend.global.common.enums.MilitaryStatus;
 import com.boaz.backend.global.common.enums.Track;
 import com.boaz.backend.global.exception.CustomException;
 import com.boaz.backend.global.exception.ErrorCode;
@@ -22,6 +23,7 @@ import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -83,6 +85,10 @@ class UserAdminServiceTest {
                 .track(Track.ENGINEERING)
                 .name("홍길동").email("hong@example.com").phone("01012345678")
                 .university("한국대").major("컴공")
+                .minorDoubleMajor("[\"경영학\"]").lastSemester(6)
+                .militaryStatus(MilitaryStatus.COMPLETED_OR_EXEMPT)
+                .birthDate(LocalDate.of(2000, 3, 15))
+                .graduationDate("2026-02").gradSchoolPlan(false)
                 .build();
     }
 
@@ -156,9 +162,16 @@ class UserAdminServiceTest {
 
         assertThat(user.getMemberType()).isEqualTo(MemberType.MEMBER);
         assertThat(user.getName()).isEqualTo("홍길동");
+        assertThat(user.getEmail()).isEqualTo("hong@example.com");
         assertThat(user.getPhone()).isEqualTo("01012345678");
         assertThat(user.getUniversity()).isEqualTo("한국대");
         assertThat(user.getMajor()).isEqualTo("컴공");
+        assertThat(user.getMinorDoubleMajor()).isEqualTo("[\"경영학\"]");
+        assertThat(user.getLastSemester()).isEqualTo(6);
+        assertThat(user.getMilitaryStatus()).isEqualTo(MilitaryStatus.COMPLETED_OR_EXEMPT);
+        assertThat(user.getBirthDate()).isEqualTo(LocalDate.of(2000, 3, 15));
+        assertThat(user.getGraduationDate()).isEqualTo("2026-02");
+        assertThat(user.getGradSchoolPlan()).isFalse();
         assertThat(user.getTrack()).isEqualTo(Track.ENGINEERING);
         assertThat(user.getTerm()).isEqualTo(27);
     }


### PR DESCRIPTION
## 💡 개요

* Issue Number: #180

## 🪐 주요 변경 사항
- `users` 테이블 스키마를 ERD와 정합화 (승격 시 지원서 개인정보 전체 복사)
- `MilitaryStatus` enum을 `Applicant` 내부 → `global.common.enums`로 이동 (Applicant/User 공용)

## ✅ 상세 내용
- `User` 엔티티에 ERD 누락 필드 7종 추가: `email`, `minor_double_major`(JSON), `last_semester`, `military_status`, `birth_date`, `graduation_date`, `grad_school_plan`
- `User.promote()` 및 `UserAdminService` 승격 로직이 `Applicant`에서 7필드 전부 복사하도록 수정
- `MilitaryStatus` 공용 이동에 따른 참조 6개 파일(요청/응답 DTO, 테스트) 갱신
- `UserAdminServiceTest`(TC-005) / `UserIntegrationTest` 필드 복사 검증 확장, 전체 테스트 그린

## 🔔 참고 사항
- **prod는 `ddl-auto: validate`** → 배포 전 RDS `users`에 신규 컬럼 7종 `ALTER TABLE` 필수 (완료). 이미 승격된 MEMBER→OUTSIDER 원복 완료.
- 브랜치가 dev 기준이라 이 PR에는 #178(applicant_eval FK 수정, #179 머지)이 함께 포함됨.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **변경 목적**: `User` 엔티티를 ERD와 정합화하고, 지원서 승격 시 개인정보를 사용자 정보에 모두 반영합니다. 또한 지원서 삭제 시 평가 데이터의 외래 키 오류를 방지합니다.

- **주요 변경 내용**:
  - `User` 엔티티에 이메일, 부전공, 마지막 학기, 군복무 상태, 생년월일, 졸업일, 대학원 진학 계획 필드 추가
  - `User.promote()` 및 승격 서비스에서 `Applicant`의 개인정보 전체 복사
  - `MilitaryStatus`를 공용 enum으로 이동하고 관련 DTO·엔티티·테스트 참조 변경
  - 지원서 삭제 전 `ApplicantEval`을 먼저 삭제하도록 로직 및 리포지토리 추가
  - 승격 필드 복사와 평가 데이터 삭제에 대한 단위·통합 테스트 보강

- **영향 범위**:
  - **API 변경**: `militaryStatus` 타입이 `Applicant.MilitaryStatus`에서 공용 `MilitaryStatus`로 변경
  - **DB 스키마 변경**: `users` 테이블에 신규 컬럼 7종 추가 필요
  - **설정 변경**: 없음

<!-- end of auto-generated comment: release notes by coderabbit.ai -->